### PR TITLE
Update user import script, error template, README, and TODOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Java 8 (OpenJDK OK)
 MongoDB 2.4+ (https://www.mongodb.com/)  
 Jetty 9.3+ (http://www.eclipse.org/jetty/download.html)
     (see jetty-config.md for version used for testing)  
-This repo (git clone https://github.com/kbaseIncubator/auth2proto)  
+This repo (git clone https://github.com/kbase/auth2)  
 The jars repo (git clone https://github.com/kbase/jars)  
 The two repos above need to be in the same parent folder.
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,8 @@ accounts and tests if any, allow setting auth service url
 * Narrative Method Store
 * Data Import Export
 * Search
+* Solar auth
+* Bulk IO
 
 Auth service work
 -----------------
@@ -43,6 +45,8 @@ Auth service work
   * Force pwd reset for local accounts (per user and all)
   * Reset local account pwd
 * API
+  * Token name in config
+  * Configure redirect urls for login and link intermediate steps
   * Introspect token (e.g. not the legacy apis, provide complete info)
   * /user/<name> - get user details
   * /me
@@ -64,7 +68,7 @@ Auth service work
 
 External dependencies
 ---------------------
-* JGI updates kbase<->JGI account linking
+* JGI updates kbase<->JGI account linking (on dev server as of 16/11/18)
 * JGI stops using uid/pwd to login for jgidm account
 
 Future work

--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,9 @@ Auth service work
 * User import
   * Need list of every username that exists in any KBase data source
     * Needs a new script
-  * Need solution for KBase users not appearing in Globus v2 API
+  * May need to add a call to the v2 Globus API if looking up the user in the
+    Nexus API fails (occurs when user is set to private and not in kbase_users
+    group)
 * Deploy
   * Dockerization
 

--- a/src/us/kbase/auth2/cli/AuthCLI.java
+++ b/src/us/kbase/auth2/cli/AuthCLI.java
@@ -1,21 +1,33 @@
 package us.kbase.auth2.cli;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 
 import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -23,14 +35,15 @@ import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
-import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
 import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+import us.kbase.auth2.lib.identity.RemoteIdentity;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
 import us.kbase.auth2.lib.identity.GlobusIdentityProvider.GlobusIdentityProviderConfigurator;
 import us.kbase.auth2.lib.identity.GoogleIdentityProvider.GoogleIdentityProviderConfigurator;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.storage.exceptions.StorageInitException;
-import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.service.AuthBuilder;
 import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthStartupConfig;
@@ -41,9 +54,12 @@ public class AuthCLI {
 	
 	//TODO TEST
 	//TODO JAVADOC
-
+	//TODO TEST Move as much code as possible into a class to make things easier to test
+	
 	private static final String NAME = "manageauth";
 	private static final String GLOBUS = "Globus";
+	
+	private static final ObjectMapper MAPPER = new ObjectMapper();
 	
 	public static void main(String[] args) {
 		quietLogger();
@@ -91,6 +107,7 @@ public class AuthCLI {
 		
 		if (a.globus_users != null && !a.globus_users.trim().isEmpty()) {
 			importUsers(a, auth);
+			System.exit(0);
 		}
 		
 		jc.usage();
@@ -104,31 +121,112 @@ public class AuthCLI {
 					"if importing users");
 			System.exit(1);
 		}
+		final LocalDateTime now = LocalDateTime.now();
 		final Path p = Paths.get(a.globus_users);
 		final List<String> users = getUserList(a, p);
+		final Client cli = ClientBuilder.newClient();
 		int success = 0;
 		for (final String user: users) {
 			if (user.isEmpty()) {
 				continue;
 			}
 			System.out.println("Importing user " + user);
+			final RemoteIdentity ri;
 			try {
-				auth.importUser(new IncomingToken(a.token), GLOBUS, user);
+				ri = getGlobusNexusIdentity(cli, a.token, user);
+			} catch (IdentityRetrievalException | IOException e) {
+				//TODO IMPORT if this happens, make an account from the v2 API. Write the user finding script first though.
+				error("\tError in identity retrieval for user " + user,
+						e, a, true);
+				continue;
+			}
+			System.out.println("\tID       : " + ri.getRemoteID().getId());
+			System.out.println("\tUsername : " +
+					ri.getDetails().getUsername());
+			System.out.println("\tFull name: " + ri.getDetails().getFullname());
+			System.out.println("\tEmail    : " + ri.getDetails().getEmail());
+			try {
+				auth.importUser(ri);
 				success++;
-			} catch (NoSuchIdentityProviderException e) {
-				System.out.println(GLOBUS +
-						" identity provider is not configured");
-				System.exit(1);
 			} catch (UserExistsException | IllegalParameterException |
-					AuthStorageException | IdentityRetrievalException e) {
-				error("\tError", e, a, true);
+					AuthStorageException e) {
+				error("\tError for user " + user, e, a, true);
 			}
 		}
+		final Duration d = Duration.between(now, LocalDateTime.now());
 		System.out.println(String.format(
-				"Imported %s out of %s users from file %s",
-				success, users.size(), p));
-		System.exit(0);
+				"Imported %s out of %s users from file %s in %s",
+				success, users.size(), p, getDurationString(d)));
 	}
+
+	private static Object getDurationString(Duration d) {
+		final long days = d.toDays();
+		d = d.minusDays(days);
+		final long hours = d.toHours();
+		d = d.minusHours(hours);
+		final long min = d.toMinutes();
+		final long sec = d.minusMinutes(min).getSeconds();
+		return String.format("%sD %sH %sM %sS", days, hours, min, sec);
+	}
+
+
+
+	private static RemoteIdentity getGlobusNexusIdentity(
+			final Client cli,
+			final String token,
+			final String user)
+			throws IdentityRetrievalException, IOException {
+		
+		//TODO NOW make the url a class var
+		final URI idtarget = UriBuilder.fromPath(
+				"https://nexus.api.globusonline.org/users/" + user)
+				.build();
+		
+		final Map<String, Object> ret = globusGetRequest(cli, token, idtarget);
+		final String username = ((String) ret.get("username"))
+				+ "@globusid.org";
+		final String fullname = (String) ret.get("full_name");
+		final String email = (String) ret.get("email");
+		final String id = (String) ret.get("identity_id");
+		return new RemoteIdentity(
+				new RemoteIdentityID(GLOBUS, id),
+				new RemoteIdentityDetails(username, fullname, email));
+	}
+	
+	private static Map<String, Object> globusGetRequest(
+			final Client cli,
+			final String accessToken,
+			final URI idtarget)
+			throws IdentityRetrievalException, IOException {
+		final WebTarget wt = cli.target(idtarget);
+		Response r = null;
+		try {
+			r = wt.request(MediaType.APPLICATION_JSON_TYPE)
+					//TODO NOW class var
+					.header("X-Globus-Goauthtoken", accessToken)
+					.header("Accept", MediaType.APPLICATION_JSON)
+					.get();
+			//TODO TEST with 500s with HTML
+			// on error globus returns JSON with content-type = text/html
+			// and jersey pukes if you directly try to read a Map
+			@SuppressWarnings("unchecked")
+			final Map<String, Object> mtemp = MAPPER.readValue(
+					r.readEntity(String.class), Map.class);
+			if (mtemp.containsKey("message")) {
+				throw new IdentityRetrievalException(String.format(
+						"Identity provider returned an error: %s: %s; id: %s",
+						mtemp.get("code"), mtemp.get("message"),
+						mtemp.get("request_id")));
+			}
+			return mtemp;
+		} finally {
+			if (r != null) {
+				r.close();
+			}
+		}
+	}
+
+
 
 	private static List<String> getUserList(final Args a, final Path p) {
 		final String userstr;
@@ -207,8 +305,9 @@ public class AuthCLI {
 		@Parameter(names = {"--import-globus-users"}, description = 
 				"A UTF-8 encoded file of whitespace, comma, or semicolon " +
 				"separated Globus user names in the user@provider format " +
-				"(for example. foo@globusid.org). A Globus token from " +
-				"https://tokens.globus.org must be provided in the -t option.")
+				"(for example. foo@globusid.org). A Nexus Globus token for " +
+				"an admin of the kbase_users group must be provided in the " +
+				"-t option.")
 		private String globus_users;
 	}
 }

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -894,6 +894,16 @@ public class Authentication {
 		}
 		final IdentityProvider idp = idFactory.getProvider(provider);
 		final RemoteIdentity ri = idp.getIdentity(providerToken, user);
+		importUser(ri);
+	}
+
+	// do not expose this method in the public API
+	public void importUser(final RemoteIdentity ri)
+			throws IllegalParameterException, UserExistsException,
+			AuthStorageException {
+		if (ri == null) {
+			throw new NullPointerException("ri");
+		}
 		String username = ri.getDetails().getUsername();
 		/* Do NOT otherwise change the username here - this is importing
 		 * existing users, and so changing the username will mean erroneous
@@ -920,4 +930,5 @@ public class Authentication {
 				new HashSet<>(Arrays.asList(ri.withID())),
 				null, null, now, now));
 	}
+
 }

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityID.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityID.java
@@ -11,11 +11,11 @@ public class RemoteIdentityID {
 	public RemoteIdentityID(final String provider, final String id) {
 		if (provider == null || provider.trim().isEmpty()) {
 			throw new IllegalArgumentException(
-					"provider cannot be null or emtpy");
+					"provider cannot be null or empty");
 		}
 		if (id == null || id.trim().isEmpty()) {
 			throw new IllegalArgumentException(
-					"id cannot be null or emtpy");
+					"id cannot be null or empty");
 		}
 		this.provider = provider.trim();
 		this.id = id.trim();

--- a/templates/error.mustache
+++ b/templates/error.mustache
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
-    <title>{{code}} {{status}}</title>
+    <title>{{httpCode}} {{httpStatus}}</title>
   </head>
   <body>
     <p>


### PR DESCRIPTION
now uses old Nexus API to import users. Some users may not be active in
the v2 OAuth API.

May need to add a call to the v2 API to get user IDs for users that are
set to private and not in the kbase_users group.