### PR TITLE
WIP Refactor getting custom roles to avoid race conditions

### DIFF
--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -7,19 +7,19 @@ import java.util.Set;
 
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
-public class AuthUser {
+public abstract class AuthUser {
 
 	//TODO TEST unit test
 	//TODO JAVADOC
 	
-	//an local auth user can never have identities, a regular auth user must
+	//a local auth user can never have identities, a regular auth user must
 	// have at least one
 	private final String fullName;
 	private final String email;
 	private final UserName userName;
 	private final Set<Role> roles;
-	private final Set<String> customRoles;
 	private final Set<RemoteIdentityWithID> identities;
 	private final Date created;
 	private final Date lastLogin;
@@ -30,7 +30,6 @@ public class AuthUser {
 			final String fullName,
 			Set<RemoteIdentityWithID> identities,
 			Set<Role> roles,
-			Set<String> customRoles,
 			final Date created,
 			final Date lastLogin) {
 		super();
@@ -46,10 +45,6 @@ public class AuthUser {
 			roles = new HashSet<>();
 		}
 		this.roles = Collections.unmodifiableSet(roles);
-		if (customRoles == null) {
-			customRoles = new HashSet<>();
-		}
-		this.customRoles = Collections.unmodifiableSet(customRoles);
 		this.created = created;
 		this.lastLogin = lastLogin;
 	}
@@ -78,9 +73,7 @@ public class AuthUser {
 		return roles;
 	}
 
-	public Set<String> getCustomRoles() {
-		return customRoles;
-	}
+	public abstract Set<String> getCustomRoles() throws AuthStorageException;
 	
 	public Set<RemoteIdentityWithID> getIdentities() {
 		return identities;
@@ -102,92 +95,4 @@ public class AuthUser {
 		}
 		return null;
 	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((created == null) ? 0 : created.hashCode());
-		result = prime * result + ((customRoles == null) ? 0 : customRoles.hashCode());
-		result = prime * result + ((email == null) ? 0 : email.hashCode());
-		result = prime * result + ((fullName == null) ? 0 : fullName.hashCode());
-		result = prime * result + ((identities == null) ? 0 : identities.hashCode());
-		result = prime * result + ((lastLogin == null) ? 0 : lastLogin.hashCode());
-		result = prime * result + ((roles == null) ? 0 : roles.hashCode());
-		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		AuthUser other = (AuthUser) obj;
-		if (created == null) {
-			if (other.created != null) {
-				return false;
-			}
-		} else if (!created.equals(other.created)) {
-			return false;
-		}
-		if (customRoles == null) {
-			if (other.customRoles != null) {
-				return false;
-			}
-		} else if (!customRoles.equals(other.customRoles)) {
-			return false;
-		}
-		if (email == null) {
-			if (other.email != null) {
-				return false;
-			}
-		} else if (!email.equals(other.email)) {
-			return false;
-		}
-		if (fullName == null) {
-			if (other.fullName != null) {
-				return false;
-			}
-		} else if (!fullName.equals(other.fullName)) {
-			return false;
-		}
-		if (identities == null) {
-			if (other.identities != null) {
-				return false;
-			}
-		} else if (!identities.equals(other.identities)) {
-			return false;
-		}
-		if (lastLogin == null) {
-			if (other.lastLogin != null) {
-				return false;
-			}
-		} else if (!lastLogin.equals(other.lastLogin)) {
-			return false;
-		}
-		if (roles == null) {
-			if (other.roles != null) {
-				return false;
-			}
-		} else if (!roles.equals(other.roles)) {
-			return false;
-		}
-		if (userName == null) {
-			if (other.userName != null) {
-				return false;
-			}
-		} else if (!userName.equals(other.userName)) {
-			return false;
-		}
-		return true;
-	}
-	
-	
 }

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -355,7 +355,6 @@ public class Authentication {
 		}
 	}
 	
-	//TODO ROLES PERFORMANCE only get custom roles on request. Always check custom roles exist and delete from user if they don't.
 	// gets user for token
 	private AuthUser getUser(
 			final IncomingToken token,
@@ -364,8 +363,7 @@ public class Authentication {
 		final HashedToken ht = getToken(token);
 		final AuthUser u = getUser(ht);
 		if (required.length > 0) {
-			final Set<Role> has = u.getRoles().stream()
-					.flatMap(r -> r.included().stream())
+			final Set<Role> has = u.getRoles().stream().flatMap(r -> r.included().stream())
 					.collect(Collectors.toSet());
 			has.retainAll(Arrays.asList(required)); // intersection
 			if (has.isEmpty()) {

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -76,26 +76,9 @@ public class Authentication {
 	//TODO PWD last pwd reset field for local users
 	
 	/* TODO ROLES feature: delete custom roles (see below)
-	 * Should use role IDs and keep role IDs in the user record. On delete, delete the ID. This prevents semantic changes being a problem.
 	 * 1) delete role from system
 	 * 2) delete role from all users
-	 * Current code in the Mongo user classes will ensure that any race conditions result in the eventual removal of the role, although semantic changes are an issue
-	 * Delete role from all users
-	 * Delete role from system:
-	 * 1) Remove role from all users
-	 * 2) delete role from system
-	 * 3) Remove role from all users again
-	 * 4) On getting a user, any roles that aren't in the system should be
-	 * removed
-	 * 
-	 * Still a possibility of a race condition allowing adding a deleted role to
-	 * a user after step 3, and then the role being re-added with different
-	 * semantics, which would mean that users that erroneously have the role
-	 * would be granted the new semantics, which is wrong
-	 * Might not be worth worrying about
-	 * 
-	 * Maybe just disable instead? Still possible for race conditions to add to a user after
-	 * disable.
+	 * Current code in the Mongo user classes will ensure that any race conditions result in the eventual removal of the role 
 	 */
 	
 	private final AuthStorage storage;

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -532,15 +532,7 @@ public class Authentication {
 			throws AuthStorageException, NoSuchUserException,
 			NoSuchRoleException, InvalidTokenException, UnauthorizedException {
 		getUser(adminToken, Role.ADMIN);
-		final Set<CustomRole> roles = storage.getCustomRoles(roleIds);
-		final Set<String> rstr = roles.stream().map(r -> r.getID())
-				.collect(Collectors.toSet());
-		for (final String r: roleIds) {
-			if (!rstr.contains(r)) {
-				throw new NoSuchRoleException(r);
-			}
-		}
-		storage.setCustomRoles(userName, rstr);
+		storage.setCustomRoles(userName, roleIds);
 	}
 
 

--- a/src/us/kbase/auth2/lib/LocalUser.java
+++ b/src/us/kbase/auth2/lib/LocalUser.java
@@ -3,7 +3,7 @@ package us.kbase.auth2.lib;
 import java.util.Date;
 import java.util.Set;
 
-public class LocalUser extends AuthUser {
+public abstract class LocalUser extends AuthUser {
 	
 	//TODO TEST unit test
 	//TODO JAVADOC
@@ -17,14 +17,12 @@ public class LocalUser extends AuthUser {
 			final String email,
 			final String fullName,
 			final Set<Role> roles,
-			final Set<String> customRoles,
 			final Date created,
 			final Date lastLogin,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset) {
-		super(userName, email, fullName, null, roles, customRoles, created,
-				lastLogin);
+		super(userName, email, fullName, null, roles, created, lastLogin);
 		// what's the right # here? Have to rely on user to some extent
 		if (passwordHash == null || passwordHash.length < 10) {
 			throw new IllegalArgumentException(

--- a/src/us/kbase/auth2/lib/NewLocalUser.java
+++ b/src/us/kbase/auth2/lib/NewLocalUser.java
@@ -1,0 +1,30 @@
+package us.kbase.auth2.lib;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+public class NewLocalUser extends LocalUser {
+
+	//TODO JAVADOC
+	//TODO TESTS
+	
+	public NewLocalUser(
+			final UserName userName,
+			final String email,
+			final String fullName,
+			final Date created,
+			final Date lastLogin,
+			final byte[] passwordHash,
+			final byte[] salt,
+			final boolean forceReset) {
+		super(userName, email, fullName, Collections.emptySet(), created, lastLogin,
+				passwordHash, salt, forceReset);
+	}
+
+	@Override
+	public Set<String> getCustomRoles() {
+		return Collections.emptySet();
+	}
+
+}

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -1,0 +1,29 @@
+package us.kbase.auth2.lib;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+
+public class NewUser extends AuthUser {
+	
+	//TODO JAVADOC
+	//TODO TESTS
+
+	public NewUser(
+			final UserName userName,
+			final String email,
+			final String fullName,
+			final Set<RemoteIdentityWithID> identities,
+			final Date created,
+			final Date lastLogin) {
+		super(userName, email, fullName, identities, Collections.emptySet(), created, lastLogin);
+	}
+
+	@Override
+	public Set<String> getCustomRoles() {
+		return Collections.emptySet();
+	}
+
+}

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -15,6 +15,7 @@ import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserUpdate;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
+import us.kbase.auth2.lib.exceptions.NoSuchRoleException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.exceptions.UnLinkFailedException;
@@ -105,11 +106,16 @@ public interface AuthStorage {
 
 	Set<CustomRole> getCustomRoles() throws AuthStorageException;
 
-	Set<CustomRole> getCustomRoles(Set<String> roleIds)
-			throws AuthStorageException;
-
+	/** Sets custom roles for a user, overwriting the previous set of roles.
+	 * @param userName the user to modify.
+	 * @param roles the roles to give to the user, erasing any previous roles.
+	 * @throws NoSuchUserException if the user doesn't exist.
+	 * @throws NoSuchRoleException if one or more of the input roles do not exist in the database.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs. 
+	 */
 	void setCustomRoles(UserName userName, Set<String> roles)
-			throws NoSuchUserException, AuthStorageException;
+			throws NoSuchUserException, AuthStorageException, NoSuchRoleException;
 
 	// assumes token is unique
 	void storeIdentitiesTemporarily(

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -34,7 +34,7 @@ public class MongoLocalUser extends LocalUser {
 			final MongoStorage storage) {
 		super(userName, email, fullName, roles, created, lastLogin, passwordHash, salt,
 				forceReset);
-		this.customRoles = customRoles;
+		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();
 		}
@@ -44,7 +44,8 @@ public class MongoLocalUser extends LocalUser {
 	@Override
 	public Set<String> getCustomRoles() throws AuthStorageException {
 		if (memoizedCustomRoles == null) {
-			memoizedCustomRoles = storage.getCustomRoles(getUserName(), customRoles);
+			memoizedCustomRoles = Collections.unmodifiableSet(
+					storage.getCustomRoles(getUserName(), customRoles));
 		}
 		return memoizedCustomRoles;
 	}

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -1,12 +1,14 @@
 package us.kbase.auth2.lib.storage.mongo;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
+
+import org.bson.types.ObjectId;
 
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
-import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
 public class MongoLocalUser extends LocalUser {
@@ -14,15 +16,16 @@ public class MongoLocalUser extends LocalUser {
 	//TODO JAVADOC
 	//TODO TESTS
 	
-	//TODO ROLES PERF always get the roles and memoize them. Keep a boolean to see if they've been checked.
 	private final MongoStorage storage;
+	private Set<ObjectId> customRoles;
 	private Set<String> memoizedCustomRoles;
 	
-	public MongoLocalUser(
+	MongoLocalUser(
 			final UserName userName,
 			final String email,
 			final String fullName,
 			final Set<Role> roles,
+			final Set<ObjectId> customRoles,
 			final Date created,
 			final Date lastLogin,
 			final byte[] passwordHash,
@@ -31,21 +34,18 @@ public class MongoLocalUser extends LocalUser {
 			final MongoStorage storage) {
 		super(userName, email, fullName, roles, created, lastLogin, passwordHash, salt,
 				forceReset);
+		this.customRoles = customRoles;
+		if (customRoles.isEmpty()) {
+			memoizedCustomRoles = Collections.emptySet();
+		}
 		this.storage = storage;
 	}
 
 	@Override
 	public Set<String> getCustomRoles() throws AuthStorageException {
 		if (memoizedCustomRoles == null) {
-			try {
-				memoizedCustomRoles = storage.getCustomRoles(getUserName());
-			} catch (NoSuchUserException e) {
-				throw new AuthStorageException(
-						"This user apparently doesn't exist. Something is very wrong: " +
-				e.getMessage(), e);
-			}
+			memoizedCustomRoles = storage.getCustomRoles(getUserName(), customRoles);
 		}
 		return memoizedCustomRoles;
 	}
-
 }

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -1,0 +1,51 @@
+package us.kbase.auth2.lib.storage.mongo;
+
+import java.util.Date;
+import java.util.Set;
+
+import us.kbase.auth2.lib.LocalUser;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.NoSuchUserException;
+import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
+
+public class MongoLocalUser extends LocalUser {
+
+	//TODO JAVADOC
+	//TODO TESTS
+	
+	//TODO ROLES PERF always get the roles and memoize them. Keep a boolean to see if they've been checked.
+	private final MongoStorage storage;
+	private Set<String> memoizedCustomRoles;
+	
+	public MongoLocalUser(
+			final UserName userName,
+			final String email,
+			final String fullName,
+			final Set<Role> roles,
+			final Date created,
+			final Date lastLogin,
+			final byte[] passwordHash,
+			final byte[] salt,
+			final boolean forceReset,
+			final MongoStorage storage) {
+		super(userName, email, fullName, roles, created, lastLogin, passwordHash, salt,
+				forceReset);
+		this.storage = storage;
+	}
+
+	@Override
+	public Set<String> getCustomRoles() throws AuthStorageException {
+		if (memoizedCustomRoles == null) {
+			try {
+				memoizedCustomRoles = storage.getCustomRoles(getUserName());
+			} catch (NoSuchUserException e) {
+				throw new AuthStorageException(
+						"This user apparently doesn't exist. Something is very wrong: " +
+				e.getMessage(), e);
+			}
+		}
+		return memoizedCustomRoles;
+	}
+
+}

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -32,7 +32,7 @@ public class MongoUser extends AuthUser {
 			final Date lastLogin,
 			final MongoStorage storage) {
 		super(userName, email, fullName, identities, roles, created, lastLogin);
-		this.customRoles = customRoles;
+		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();
 		}
@@ -50,7 +50,8 @@ public class MongoUser extends AuthUser {
 	@Override
 	public Set<String> getCustomRoles() throws AuthStorageException {
 		if (memoizedCustomRoles == null) {
-			memoizedCustomRoles = storage.getCustomRoles(getUserName(), customRoles);
+			memoizedCustomRoles = Collections.unmodifiableSet(
+					storage.getCustomRoles(getUserName(), customRoles));
 		}
 		return memoizedCustomRoles;
 	}

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -1,12 +1,14 @@
 package us.kbase.auth2.lib.storage.mongo;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
+
+import org.bson.types.ObjectId;
 
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
-import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
@@ -15,33 +17,40 @@ public class MongoUser extends AuthUser {
 	//TODO JAVADOC
 	//TODO TESTS
 	
-	//TODO ROLES PERF always get the roles and memoize them. Keep a boolean to see if they've been checked.
 	private final MongoStorage storage;
+	private Set<ObjectId> customRoles;
 	private Set<String> memoizedCustomRoles = null;
 	
-	public MongoUser(
+	MongoUser(
 			final UserName userName,
 			final String email,
 			final String fullName,
 			final Set<RemoteIdentityWithID> identities,
 			final Set<Role> roles,
+			final Set<ObjectId> customRoles,
 			final Date created,
 			final Date lastLogin,
 			final MongoStorage storage) {
 		super(userName, email, fullName, identities, roles, created, lastLogin);
+		this.customRoles = customRoles;
+		if (customRoles.isEmpty()) {
+			memoizedCustomRoles = Collections.emptySet();
+		}
 		this.storage = storage;
+	}
+
+	MongoUser(final MongoUser user, final Set<RemoteIdentityWithID> newIDs) {
+		super(user.getUserName(), user.getEmail(), user.getFullName(), newIDs, user.getRoles(),
+				user.getCreated(), user.getLastLogin());
+		this.customRoles = user.customRoles;
+		this.memoizedCustomRoles = user.memoizedCustomRoles;
+		this.storage = user.storage;
 	}
 
 	@Override
 	public Set<String> getCustomRoles() throws AuthStorageException {
 		if (memoizedCustomRoles == null) {
-			try {
-				memoizedCustomRoles = storage.getCustomRoles(getUserName());
-			} catch (NoSuchUserException e) {
-				throw new AuthStorageException(
-						"This user apparently doesn't exist. Something is very wrong: " +
-				e.getMessage(), e);
-			}
+			memoizedCustomRoles = storage.getCustomRoles(getUserName(), customRoles);
 		}
 		return memoizedCustomRoles;
 	}

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -1,0 +1,48 @@
+package us.kbase.auth2.lib.storage.mongo;
+
+import java.util.Date;
+import java.util.Set;
+
+import us.kbase.auth2.lib.AuthUser;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.NoSuchUserException;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
+
+public class MongoUser extends AuthUser {
+
+	//TODO JAVADOC
+	//TODO TESTS
+	
+	//TODO ROLES PERF always get the roles and memoize them. Keep a boolean to see if they've been checked.
+	private final MongoStorage storage;
+	private Set<String> memoizedCustomRoles = null;
+	
+	public MongoUser(
+			final UserName userName,
+			final String email,
+			final String fullName,
+			final Set<RemoteIdentityWithID> identities,
+			final Set<Role> roles,
+			final Date created,
+			final Date lastLogin,
+			final MongoStorage storage) {
+		super(userName, email, fullName, identities, roles, created, lastLogin);
+		this.storage = storage;
+	}
+
+	@Override
+	public Set<String> getCustomRoles() throws AuthStorageException {
+		if (memoizedCustomRoles == null) {
+			try {
+				memoizedCustomRoles = storage.getCustomRoles(getUserName());
+			} catch (NoSuchUserException e) {
+				throw new AuthStorageException(
+						"This user apparently doesn't exist. Something is very wrong: " +
+				e.getMessage(), e);
+			}
+		}
+		return memoizedCustomRoles;
+	}
+}


### PR DESCRIPTION
Lazily fetch custom roles from mongo since they require multiple DB
queries. Check the roles against the roles collection to be sure there
hasn't been a race condition such that the user has a role that's been
deleted.

TODO:
* [x] Keep the roles from the first query in the user class. Only check and
modify the roles on request. Saves a DB query.

* [x] Use ~UUIDs~ Mongo ObjectIds for role IDs so a role can't be deleted and recreated with
different semantics and via race conditions still exist for a user.

The ObjectIds are not exposed in the AuthStorage API.