### PR TITLE
make display name public to users & email private + more

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,9 +39,8 @@ Auth service work
   * User documentation and education (probably need doc team help here)
   * Login & signup very different
 * API
-  * Email & full name privacy option
   * /user/<name> - get user details
-  * /me
+  * /me - view auth profile & update display name & email
 * Admin functionality
   * Find users
     * By name (regex)

--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -16,25 +16,25 @@ public abstract class AuthUser {
 	
 	//a local auth user can never have identities, a regular auth user must
 	// have at least one
-	private final String fullName;
-	private final String email;
+	private final DisplayName displayName;
+	private final EmailAddress email;
 	private final UserName userName;
 	private final Set<Role> roles;
 	private final Set<RemoteIdentityWithID> identities;
-	private final Date created;
-	private final Date lastLogin;
+	private final long created;
+	private final Long lastLogin;
 	
 	public AuthUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			Set<RemoteIdentityWithID> identities,
 			Set<Role> roles,
 			final Date created,
 			final Date lastLogin) {
 		super();
-		//TODO INPUT check for nulls & empty strings - should email & fullName be allowed as null or empty strings?
-		this.fullName = fullName;
+		//TODO INPUT check for nulls
+		this.displayName = displayName;
 		this.email = email;
 		this.userName = userName;
 		if (identities == null) {
@@ -45,19 +45,22 @@ public abstract class AuthUser {
 			roles = new HashSet<>();
 		}
 		this.roles = Collections.unmodifiableSet(roles);
-		this.created = created;
-		this.lastLogin = lastLogin;
+		if (created == null) {
+			throw new NullPointerException("created");
+		}
+		this.created = created.getTime();
+		this.lastLogin = lastLogin == null ? null : lastLogin.getTime();
 	}
 
 	public boolean isRoot() {
 		return userName.isRoot();
 	}
 	
-	public String getFullName() {
-		return fullName;
+	public DisplayName getDisplayName() {
+		return displayName;
 	}
 
-	public String getEmail() {
+	public EmailAddress getEmail() {
 		return email;
 	}
 
@@ -80,11 +83,11 @@ public abstract class AuthUser {
 	}
 	
 	public Date getCreated() {
-		return created;
+		return new Date(created);
 	}
 
 	public Date getLastLogin() {
-		return lastLogin;
+		return lastLogin == null ? null : new Date(lastLogin);
 	}
 
 	public RemoteIdentityWithID getIdentity(final RemoteIdentity ri) {

--- a/src/us/kbase/auth2/lib/DisplayName.java
+++ b/src/us/kbase/auth2/lib/DisplayName.java
@@ -1,0 +1,59 @@
+package us.kbase.auth2.lib;
+
+import static us.kbase.auth2.lib.Utils.checkString;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+public class DisplayName {
+
+	//TODO TEST
+	//TODO JAVADOC
+	
+	private final static int MAX_NAME_LENGTH = 100;
+	
+	/* What's ok for a display name? for now just a non-empty string < 100 chars, trimmed. */
+	
+	private final String name;
+	
+	public DisplayName(final String name)
+			throws MissingParameterException, IllegalParameterException {
+		checkString(name, "display name", MAX_NAME_LENGTH);
+		this.name = name.trim();
+	}
+	
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		DisplayName other = (DisplayName) obj;
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		return true;
+	}
+	
+}

--- a/src/us/kbase/auth2/lib/EmailAddress.java
+++ b/src/us/kbase/auth2/lib/EmailAddress.java
@@ -1,0 +1,64 @@
+package us.kbase.auth2.lib;
+
+import static us.kbase.auth2.lib.Utils.checkString;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+public class EmailAddress {
+
+	//TODO TEST
+	//TODO JAVADOC
+	
+	public final static EmailAddress UNKNOWN = new EmailAddress(); // maybe want a specific class rather than just returning null
+	private final static int MAX_EMAIL_LENGTH = 1000;
+	
+	private final String email;
+	
+	private EmailAddress() {
+		this.email = null;
+	}
+	
+	public EmailAddress(final String email)
+			throws MissingParameterException, IllegalParameterException {
+		//TODO EMAIL do some validation here - ideally find a library. DO NOT actually validate by sending an email.
+		checkString(email, "email address", MAX_EMAIL_LENGTH);
+		this.email = email.trim();
+	}
+
+	public String getAddress() {
+		return email;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((email == null) ? 0 : email.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		EmailAddress other = (EmailAddress) obj;
+		if (email == null) {
+			if (other.email != null) {
+				return false;
+			}
+		} else if (!email.equals(other.email)) {
+			return false;
+		}
+		return true;
+	}
+
+	
+}

--- a/src/us/kbase/auth2/lib/LocalUser.java
+++ b/src/us/kbase/auth2/lib/LocalUser.java
@@ -15,8 +15,8 @@ public abstract class LocalUser extends AuthUser {
 	
 	public LocalUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			final Set<Role> roles,
 			final Date created,
 			final Date lastLogin,
@@ -24,7 +24,7 @@ public abstract class LocalUser extends AuthUser {
 			final byte[] salt,
 			final boolean forceReset,
 			final Date lastReset) {
-		super(userName, email, fullName, null, roles, created, lastLogin);
+		super(userName, email, displayName, null, roles, created, lastLogin);
 		// what's the right # here? Have to rely on user to some extent
 		if (passwordHash == null || passwordHash.length < 10) {
 			throw new IllegalArgumentException(

--- a/src/us/kbase/auth2/lib/NewLocalUser.java
+++ b/src/us/kbase/auth2/lib/NewLocalUser.java
@@ -11,14 +11,14 @@ public class NewLocalUser extends LocalUser {
 	
 	public NewLocalUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			final Date created,
 			final Date lastLogin,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset) {
-		super(userName, email, fullName, Collections.emptySet(), created, lastLogin,
+		super(userName, email, displayName, Collections.emptySet(), created, lastLogin,
 				passwordHash, salt, forceReset, null);
 	}
 

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -13,12 +13,13 @@ public class NewUser extends AuthUser {
 
 	public NewUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			final Set<RemoteIdentityWithID> identities,
 			final Date created,
 			final Date lastLogin) {
-		super(userName, email, fullName, identities, Collections.emptySet(), created, lastLogin);
+		super(userName, email, displayName, identities, Collections.emptySet(), created,
+				lastLogin);
 	}
 
 	@Override

--- a/src/us/kbase/auth2/lib/UserUpdate.java
+++ b/src/us/kbase/auth2/lib/UserUpdate.java
@@ -6,34 +6,30 @@ public class UserUpdate {
 	//TODO JAVADOC
 	//TODO INPUT needs input checking
 	
-	private String fullname;
-	private String email;
+	private DisplayName displayName;
+	private EmailAddress email;
 	
 	public UserUpdate() {}
 	
-	public UserUpdate withFullName(final String fullname) {
-		this.fullname = get(fullname);
+	public UserUpdate withDisplayName(final DisplayName displayName) {
+		this.displayName = displayName;
 		return this;
 	}
 	
-	public UserUpdate withEmail(final String email) {
-		this.email = get(email);
+	public UserUpdate withEmail(final EmailAddress email) {
+		this.email = email;
 		return this;
 	}
 	
-	private String get(final String p) {
-		return (p != null && p.isEmpty()) ? null : p;
+	public DisplayName getDisplayName() {
+		return displayName;
 	}
 
-	public String getFullname() {
-		return fullname;
-	}
-
-	public String getEmail() {
+	public EmailAddress getEmail() {
 		return email;
 	}
 	
 	public boolean hasUpdates() {
-		return fullname != null && email != null;
+		return displayName != null && email != null;
 	}
 }

--- a/src/us/kbase/auth2/lib/ViewableUser.java
+++ b/src/us/kbase/auth2/lib/ViewableUser.java
@@ -1,0 +1,81 @@
+package us.kbase.auth2.lib;
+
+import java.util.Date;
+import java.util.Set;
+
+import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
+
+/* this is a user profile that the requesting user has permission to view. Fields which the
+ * requesting user cannot view will be null.
+ * 
+ * The user name and display name are never null.
+ * 
+ * Although ViewableUser and AuthUser do not and should not implement a common Java interface,
+ * their interface is identical except that ViewableUser may return null for many fields.
+ */
+
+public class ViewableUser {
+
+	//TODO TEST unit test
+	//TODO JAVADOC
+	
+	private final UserName userName;
+	private final DisplayName displayName;
+	private final boolean local;
+	private final AuthUser user;
+	
+	public ViewableUser(final AuthUser user, boolean fullView) throws AuthStorageException {
+		if (user == null) {
+			throw new NullPointerException("user");
+		}
+		this.userName = user.getUserName();
+		this.displayName = user.getDisplayName();
+		this.local = user.getIdentities().isEmpty();
+		if (fullView) {
+			this.user = user;
+		} else {
+			this.user = null;
+		}
+	}
+
+	public boolean isRoot() {
+		return userName.isRoot();
+	}
+	
+	public DisplayName getDisplayName() {
+		return displayName;
+	}
+
+	public EmailAddress getEmail() {
+		return user == null ? null : user.getEmail();
+	}
+
+	public UserName getUserName() {
+		return userName;
+	}
+
+	public boolean isLocal() {
+		return local;
+	}
+
+	public Set<Role> getRoles() {
+		return user == null ? null : user.getRoles();
+	}
+
+	public Set<String> getCustomRoles() throws AuthStorageException {
+		return user == null ? null : user.getCustomRoles();
+	}
+	
+	public Set<RemoteIdentityWithID> getIdentities() {
+		return user == null ? null : user.getIdentities();
+	}
+	
+	public Date getCreated() {
+		return user == null ? null : user.getCreated();
+	}
+
+	public Date getLastLogin() {
+		return user == null ? null : user.getLastLogin();
+	}
+}

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import us.kbase.auth2.lib.AuthConfigSet;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.CustomRole;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.ExternalConfig;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.LocalUser;
@@ -35,12 +37,12 @@ public interface AuthStorage {
 
 	/** Create or update the root user.
 	 * The password hash and salt are cleared as soon as possible.
-	 * fullName, email, and created are only set when creating the root user
+	 * displayName, email, and created are only set when creating the root user
 	 * for the first time.
 	 * Custom roles are set to the null set when creating the root user, but
 	 * are otherwise left alone.
 	 * @param root the root user name
-	 * @param fullName the root user's full name.
+	 * @param displayName the root user's full name.
 	 * @param email the root user's email.
 	 * @param roles the root user's roles.
 	 * @param created the root user account's creation date.
@@ -49,7 +51,7 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs. 
 	 */
-	void createRoot(UserName root, String fullName, String email,
+	void createRoot(UserName root, DisplayName displayName, EmailAddress email,
 			Set<Role> roles, Date created, byte[] passwordHash,
 			byte[] salt) throws AuthStorageException;
 	

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -10,7 +10,7 @@ public class Fields {
 	
 	//user fields
 	public static final String USER_NAME = "user";
-	public static final String USER_FULL_NAME = "full";
+	public static final String USER_DISPLAY_NAME = "display";
 	public static final String USER_EMAIL = "email";
 	public static final String USER_IDENTITIES = "idents";
 	public static final String USER_LOCAL = "lcl";

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import org.bson.types.ObjectId;
 
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
@@ -22,8 +24,8 @@ public class MongoLocalUser extends LocalUser {
 	
 	MongoLocalUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			final Set<Role> roles,
 			final Set<ObjectId> customRoles,
 			final Date created,
@@ -33,7 +35,7 @@ public class MongoLocalUser extends LocalUser {
 			final boolean forceReset,
 			final Date lastReset,
 			final MongoStorage storage) {
-		super(userName, email, fullName, roles, created, lastLogin, passwordHash, salt,
+		super(userName, email, displayName, roles, created, lastLogin, passwordHash, salt,
 				forceReset, lastReset);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -366,6 +366,9 @@ public class MongoStorage implements AuthStorage {
 	}
 	
 	private EmailAddress getEmail(final String email) throws AuthStorageException {
+		if (email == null) {
+			return EmailAddress.UNKNOWN;
+		}
 		try {
 			return new EmailAddress(email);
 		} catch (IllegalParameterException | MissingParameterException e) {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -38,6 +38,8 @@ import us.kbase.auth2.lib.AuthConfig.TokenLifetimeType;
 import us.kbase.auth2.lib.AuthConfigSet;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.CustomRole;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.ExternalConfig;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.LocalUser;
@@ -258,8 +260,8 @@ public class MongoStorage implements AuthStorage {
 	@Override
 	public void createRoot(
 			final UserName root,
-			final String fullName,
-			final String email,
+			final DisplayName displayName,
+			final EmailAddress email,
 			final Set<Role> roles,
 			final Date created,
 			final byte[] passwordHash,
@@ -279,8 +281,8 @@ public class MongoStorage implements AuthStorage {
 				.append(Fields.USER_PWD_HSH, encpwd)
 				.append(Fields.USER_SALT, encsalt);
 		final Document setIfMissing = new Document(
-				Fields.USER_EMAIL, email)
-				.append(Fields.USER_FULL_NAME, fullName)
+				Fields.USER_EMAIL, email.getAddress())
+				.append(Fields.USER_DISPLAY_NAME, displayName.getName())
 				.append(Fields.USER_CUSTOM_ROLES, Collections.emptyList())
 				.append(Fields.USER_CREATED, created)
 				.append(Fields.USER_LAST_LOGIN, null)
@@ -305,8 +307,8 @@ public class MongoStorage implements AuthStorage {
 		final Document u = new Document(
 				Fields.USER_NAME, local.getUserName().getName())
 				.append(Fields.USER_LOCAL, true)
-				.append(Fields.USER_EMAIL, local.getEmail())
-				.append(Fields.USER_FULL_NAME, local.getFullName())
+				.append(Fields.USER_EMAIL, local.getEmail().getAddress())
+				.append(Fields.USER_DISPLAY_NAME, local.getDisplayName().getName())
 				.append(Fields.USER_ROLES, new LinkedList<String>())
 				.append(Fields.USER_CUSTOM_ROLES, new LinkedList<String>())
 				.append(Fields.USER_CREATED, local.getCreated())
@@ -342,8 +344,8 @@ public class MongoStorage implements AuthStorage {
 		final List<ObjectId> custroles = (List<ObjectId>) user.get(Fields.USER_CUSTOM_ROLES);
 		return new MongoLocalUser(
 				getUserName(user.getString(Fields.USER_NAME)),
-				user.getString(Fields.USER_EMAIL),
-				user.getString(Fields.USER_FULL_NAME),
+				getEmail(user.getString(Fields.USER_EMAIL)),
+				getDisplayName(user.getString(Fields.USER_DISPLAY_NAME)),
 				new HashSet<>(roles),
 				new HashSet<>(custroles),
 				user.getDate(Fields.USER_CREATED),
@@ -355,11 +357,26 @@ public class MongoStorage implements AuthStorage {
 				this);
 	}
 	
+	private DisplayName getDisplayName(final String displayName) throws AuthStorageException {
+		try {
+			return new DisplayName(displayName);
+		} catch (IllegalParameterException | MissingParameterException e) {
+			throw new AuthStorageException("Illegal data stored in the database" , e);
+		}
+	}
+	
+	private EmailAddress getEmail(final String email) throws AuthStorageException {
+		try {
+			return new EmailAddress(email);
+		} catch (IllegalParameterException | MissingParameterException e) {
+			throw new AuthStorageException("Illegal data stored in the database" , e);
+		}
+	}	
 	@Override
-	public void changePassword(final UserName name, final byte[] pwd, final byte[] salt)
+	public void changePassword(final UserName name, final byte[] pwdHash, final byte[] salt)
 			throws NoSuchUserException, AuthStorageException {
 		getUserDoc(name, true); //check the user actually is local
-		final String pwdhsh = Base64.getEncoder().encodeToString(pwd);
+		final String pwdhsh = Base64.getEncoder().encodeToString(pwdHash);
 		final String encsalt = Base64.getEncoder().encodeToString(salt);
 		final Document set = new Document(Fields.USER_RESET_PWD, false)
 				.append(Fields.USER_RESET_PWD_LAST, new Date())
@@ -384,8 +401,8 @@ public class MongoStorage implements AuthStorage {
 		final Document u = new Document(
 				Fields.USER_NAME, user.getUserName().getName())
 				.append(Fields.USER_LOCAL, false)
-				.append(Fields.USER_EMAIL, user.getEmail())
-				.append(Fields.USER_FULL_NAME, user.getFullName())
+				.append(Fields.USER_EMAIL, user.getEmail().getAddress())
+				.append(Fields.USER_DISPLAY_NAME, user.getDisplayName().getName())
 				.append(Fields.USER_ROLES, new LinkedList<String>())
 				.append(Fields.USER_CUSTOM_ROLES, new LinkedList<String>())
 				.append(Fields.USER_IDENTITIES, Arrays.asList(id))
@@ -545,8 +562,8 @@ public class MongoStorage implements AuthStorage {
 		final List<Document> ids = (List<Document>) user.get(Fields.USER_IDENTITIES);
 		return new MongoUser(
 				getUserName(user.getString(Fields.USER_NAME)),
-				user.getString(Fields.USER_EMAIL),
-				user.getString(Fields.USER_FULL_NAME),
+				getEmail(user.getString(Fields.USER_EMAIL)),
+				getDisplayName(user.getString(Fields.USER_DISPLAY_NAME)),
 				toIdentities(ids),
 				new HashSet<>(roles),
 				new HashSet<>(custroles),
@@ -972,11 +989,11 @@ public class MongoStorage implements AuthStorage {
 			return; //noop
 		}
 		final Document d = new Document();
-		if (update.getFullname() != null) {
-			d.append(Fields.USER_FULL_NAME, update.getFullname());
+		if (update.getDisplayName() != null) {
+			d.append(Fields.USER_DISPLAY_NAME, update.getDisplayName().getName());
 		}
 		if (update.getEmail() != null) {
-			d.append(Fields.USER_EMAIL, update.getEmail());
+			d.append(Fields.USER_EMAIL, update.getEmail().getAddress());
 		}
 		updateUser(userName, d);
 	}

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import org.bson.types.ObjectId;
 
 import us.kbase.auth2.lib.AuthUser;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
@@ -23,15 +25,15 @@ public class MongoUser extends AuthUser {
 	
 	MongoUser(
 			final UserName userName,
-			final String email,
-			final String fullName,
+			final EmailAddress email,
+			final DisplayName displayName,
 			final Set<RemoteIdentityWithID> identities,
 			final Set<Role> roles,
 			final Set<ObjectId> customRoles,
 			final Date created,
 			final Date lastLogin,
 			final MongoStorage storage) {
-		super(userName, email, fullName, identities, roles, created, lastLogin);
+		super(userName, email, displayName, identities, roles, created, lastLogin);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();
@@ -40,7 +42,7 @@ public class MongoUser extends AuthUser {
 	}
 
 	MongoUser(final MongoUser user, final Set<RemoteIdentityWithID> newIDs) {
-		super(user.getUserName(), user.getEmail(), user.getFullName(), newIDs, user.getRoles(),
+		super(user.getUserName(), user.getEmail(), user.getDisplayName(), newIDs, user.getRoles(),
 				user.getCreated(), user.getLastLogin());
 		this.customRoles = user.customRoles;
 		this.memoizedCustomRoles = user.memoizedCustomRoles;

--- a/src/us/kbase/auth2/service/api/LegacyGlobus.java
+++ b/src/us/kbase/auth2/service/api/LegacyGlobus.java
@@ -16,9 +16,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
-import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.ViewableUser;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.AuthException;
@@ -115,7 +115,7 @@ public class LegacyGlobus {
 			token = bits[1];
 		}
 		token = getGlobusToken(xtoken, token);
-		final AuthUser u;
+		final ViewableUser u;
 		try {
 			u = auth.getUser(new IncomingToken(token), new UserName(user));
 		} catch (InvalidTokenException e) {
@@ -123,16 +123,17 @@ public class LegacyGlobus {
 			throw new UnauthorizedException(
 					e.getErr(), "Authentication failed.");
 		}
+		final String email = u.getEmail() == null ? null : u.getEmail().getAddress(); 
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put("username", u.getUserName().getName());
 		ret.put("email_validated", false);
 		ret.put("ssh_pubkeys", new LinkedList<String>());
 		ret.put("resource_type", "users");
-		ret.put("full_name", u.getFullName());
+		ret.put("full_name", u.getDisplayName().getName());
 		ret.put("organization", null);
-		ret.put("fullname", u.getFullName());
+		ret.put("fullname", u.getDisplayName().getName());
 		ret.put("user_name", u.getUserName().getName());
-		ret.put("email", u.getEmail());
+		ret.put("email", email);
 		ret.put("custom_fields", new HashMap<String,String>());
 		return ret;
 	}

--- a/src/us/kbase/auth2/service/api/LegacyKBase.java
+++ b/src/us/kbase/auth2/service/api/LegacyKBase.java
@@ -83,10 +83,10 @@ public class LegacyKBase {
 		if (name || email) {
 			final AuthUser u = auth.getUser(in);
 			if (name) {
-				ret.put("name", u.getFullName());
+				ret.put("name", u.getDisplayName().getName());
 			}
 			if (email) {
-				ret.put("email", u.getEmail());
+				ret.put("email", u.getEmail().getAddress());
 			}
 			ret.put("user_id", u.getUserName().getName());
 		} else {

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -40,6 +40,8 @@ import us.kbase.auth2.lib.AuthConfigSet;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.CustomRole;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
@@ -104,23 +106,19 @@ public class Admin {
 	public Map<String, String> createLocalAccountComplete(
 			@Context final HttpHeaders headers,
 			@FormParam("user") final String userName,
-			@FormParam("full") final String fullName,
+			@FormParam("display") final String displayName,
 			@FormParam("email") final String email)
 			throws AuthStorageException, UserExistsException,
 			MissingParameterException, IllegalParameterException,
 			UnauthorizedException, InvalidTokenException,
 			NoTokenProvidedException {
 		//TODO LOG log
-		//TODO INPUT email class with proper checking (probably not validation)
-		if (userName == null) {
-			throw new MissingParameterException("userName");
-		}
 		final Password pwd = auth.createLocalUser(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()),
-				new UserName(userName), fullName, email);
+				new UserName(userName), new DisplayName(displayName), new EmailAddress(email));
 		final Map<String, String> ret = ImmutableMap.of(
 				"user", userName,
-				"full", fullName,
+				"display", displayName,
 				"email", email,
 				"password", new String(pwd.getPassword())); // char[] won't work
 		pwd.clear(); // not that this helps much...
@@ -150,8 +148,8 @@ public class Admin {
 		ret.put("customroleurl", relativize(uriInfo,
 				UIPaths.ADMIN_ROOT_USER + SEP + user + SEP + UIPaths.ADMIN_CUSTOM_ROLES));
 		ret.put("user", au.getUserName().getName());
-		ret.put("full", au.getFullName());
-		ret.put("email", au.getEmail());
+		ret.put("display", au.getDisplayName().getName());
+		ret.put("email", au.getEmail().getAddress());
 		ret.put("local", au.isLocal());
 		ret.put("created", au.getCreated().getTime());
 		final Date lastLogin = au.getLastLogin();

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -40,6 +40,8 @@ import org.glassfish.jersey.server.mvc.Viewable;
 
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LoginToken;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
@@ -322,10 +324,8 @@ public class Login {
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
 			@FormParam("id") final UUID identityID,
 			@FormParam("user") final String userName,
-			@FormParam("full") final String fullName,
-			@FormParam("email") final String email,
-			@FormParam("stayLoggedIn") final String stayLoggedIn,
-			@FormParam("private") final String nameAndEmailPrivate)
+			@FormParam("display") final String displayName,
+			@FormParam("email") final String email)
 			throws AuthenticationException, AuthStorageException,
 				UserExistsException, NoTokenProvidedException,
 				MissingParameterException, IllegalParameterException,
@@ -334,12 +334,10 @@ public class Login {
 			throw new NoTokenProvidedException("Missing " + IN_PROCESS_LOGIN_TOKEN);
 		}
 		//TODO INPUT sanity check inputs
-		final boolean sessionLogin = stayLoggedIn == null || stayLoggedIn.isEmpty();
-		final boolean priv = nameAndEmailPrivate != null && nameAndEmailPrivate.isEmpty();
 		
 		// might want to enapsulate the user data in a NewUser class
-		final NewToken newtoken = auth.createUser(new IncomingToken(token),
-				identityID, new UserName(userName), fullName, email, sessionLogin, priv);
+		final NewToken newtoken = auth.createUser(new IncomingToken(token), identityID,
+				new UserName(userName), new DisplayName(displayName), new EmailAddress(email));
 		return Response.seeOther(getPostLoginRedirectURI(redirect, UIPaths.ME_ROOT))
 				//TODO LOGIN get keep me logged in from cookie set at start of login
 				.cookie(getLoginCookie(cfg.getTokenCookieName(), newtoken, true))

--- a/templates/adminlocalaccount.mustache
+++ b/templates/adminlocalaccount.mustache
@@ -3,7 +3,7 @@
 Create a new local user:
 <form action="{{targeturl}}" method="post">
 	User name: <input type="text" name="user"/><br/>
-	Full name: <input type="text" name="full"/><br/>
+	Display name: <input type="text" name="display"/><br/>
 	Email: <input type="text" name="email"/></br/>
 	<input type="submit" value="Create"/>
 </form>

--- a/templates/adminlocalaccountcreated.mustache
+++ b/templates/adminlocalaccountcreated.mustache
@@ -2,7 +2,7 @@
 <body>
 Account created!</br>
 User name: {{user}}</br>
-Full name: {{full}}</br>
+Display name: {{display}}</br>
 Email: {{email}}</br>
 Temporary password: {{password}}</br>
 Will require a reset. There is no way to see this password again once you

--- a/templates/adminuser.mustache
+++ b/templates/adminuser.mustache
@@ -2,7 +2,7 @@
 <body>
 <h3>User info</h3>
 User name: {{user}}<br/>
-Full name: {{full}}<br/>
+Display name: {{display}}<br/>
 Email: {{email}}<br/>
 Created: {{created}}<br/>
 Last login: {{lastlogin}}<br/>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -16,15 +16,18 @@ Username: {{username}}<br/>
 {{/login}}
 
 <h3>Create account</h3>
+<p>
+User name is public.</br>
+Display name is public to other system users.</br>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
 {{#create}}
 <p>Create an account linked to {{prov_username}}</p>
 </p>
 <form action="{{createurl}}" method="post">
 	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
-	Full name: <input type="text" name="full" value="{{prov_fullname}}"/><br/>
+	Display name: <input type="text" name="display" value="{{prov_fullname}}"/><br/>
 	Email: <input type="text" name="email" value="{{prov_email}}"/></br/>
-	Don't expire my sessions when I close my browser: <input type="checkbox" name="stayLoggedIn"/></br/>
-	Keep name and email private: <input type="checkbox" name="private"/></br/>
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Create"/>
 </form>

--- a/templates/me.mustache
+++ b/templates/me.mustache
@@ -16,8 +16,13 @@ Local account<br/>
 {{.}}<br/>
 {{/customroles}}
 <h3>User details</h3>
+<p>
+User name is public.</br>
+Display name is public to other system users.</br>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
 <form action="{{userupdateurl}}" method="post">
-	Full name: <input type="text" name="fullname" value="{{fullname}}"/><br/>
+	Display name: <input type="text" name="display" value="{{display}}"/><br/>
 	Email: <input type="text" name="email" value="{{email}}"/><br/>
 	<input type="submit" value="Update"/>
 </form>


### PR DESCRIPTION
Fullname renamed to display name. display name is visible to all other
system users.

Email is only visible to the user and admins.

Made wrapper classes for display name and email. Display name is
probably ok as is, email needs better validation of the address (see
TODO in class).

Updated Globus endpoint to only return email if the user is querying on
their own name

Also get rid of the session login stored in DB stuff. The plan is to
have a toggle on the first login page that'll set that.