### PR TITLE
Add account disabling to admin UI

### DIFF
--- a/src/us/kbase/auth2/cli/AuthCLI.java
+++ b/src/us/kbase/auth2/cli/AuthCLI.java
@@ -403,7 +403,8 @@ public class AuthCLI {
 		
 		@Parameter(names = {"-r", "--set-root-password"}, description =
 				"Set the root user password. If this option is selected no " +
-				"other specified operations will be executed.")
+				"other specified operations will be executed. If the root account is disabled " +
+				"it will be enabled with the enabling user set to null.")
 		private boolean setroot;
 		
 		@Parameter(names = {"-n", "--nexus-token"}, description =

--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -25,6 +25,7 @@ public abstract class AuthUser {
 	private final Long lastLogin;
 	private final String disableReason;
 	private final UserName lastAdminDisable; // really enable or disable
+	private final Long disabled; //really enable or disable
 	
 	public AuthUser(
 			final UserName userName,
@@ -35,7 +36,8 @@ public abstract class AuthUser {
 			final Date created,
 			final Date lastLogin,
 			final UserName lastAdminDisable,
-			final String disableReason) {
+			final String disableReason,
+			final Date disabled) {
 		super();
 		//TODO INPUT check for nulls
 		this.displayName = displayName;
@@ -60,6 +62,7 @@ public abstract class AuthUser {
 		}
 		this.disableReason = disableReason;
 		this.lastAdminDisable = lastAdminDisable;
+		this.disabled = disabled == null ? null : disabled.getTime();
 	}
 
 	public boolean isRoot() {
@@ -110,6 +113,10 @@ public abstract class AuthUser {
 	
 	public UserName getAdminThatToggledEnabledState() {
 		return lastAdminDisable;
+	}
+	
+	public Date getEnableToggleDate() {
+		return disabled == null ? null : new Date(disabled);
 	}
 
 	public RemoteIdentityWithID getIdentity(final RemoteIdentity ri) {

--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -23,6 +23,8 @@ public abstract class AuthUser {
 	private final Set<RemoteIdentityWithID> identities;
 	private final long created;
 	private final Long lastLogin;
+	private final String disableReason;
+	private final UserName lastAdminDisable; // really enable or disable
 	
 	public AuthUser(
 			final UserName userName,
@@ -31,7 +33,9 @@ public abstract class AuthUser {
 			Set<RemoteIdentityWithID> identities,
 			Set<Role> roles,
 			final Date created,
-			final Date lastLogin) {
+			final Date lastLogin,
+			final UserName lastAdminDisable,
+			final String disableReason) {
 		super();
 		//TODO INPUT check for nulls
 		this.displayName = displayName;
@@ -50,6 +54,12 @@ public abstract class AuthUser {
 		}
 		this.created = created.getTime();
 		this.lastLogin = lastLogin == null ? null : lastLogin.getTime();
+		if (disableReason != null && disableReason.isEmpty()) {
+			throw new IllegalArgumentException("disableReason must be either null, signifying " +
+					"an enabled account, or have at least one character");
+		}
+		this.disableReason = disableReason;
+		this.lastAdminDisable = lastAdminDisable;
 	}
 
 	public boolean isRoot() {
@@ -88,6 +98,18 @@ public abstract class AuthUser {
 
 	public Date getLastLogin() {
 		return lastLogin == null ? null : new Date(lastLogin);
+	}
+	
+	public boolean isDisabled() {
+		return disableReason != null;
+	}
+	
+	public String getReasonForDisabled() {
+		return disableReason;
+	}
+	
+	public UserName getAdminThatToggledEnabledState() {
+		return lastAdminDisable;
 	}
 
 	public RemoteIdentityWithID getIdentity(final RemoteIdentity ri) {

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -711,7 +711,7 @@ public class Authentication {
 
 
 	public LoginState getLoginState(final IncomingToken token)
-			throws AuthStorageException, InvalidTokenException, UnauthorizedException {
+			throws AuthStorageException, InvalidTokenException {
 		final Set<RemoteIdentityWithID> ids = getTemporaryIdentities(token);
 		if (ids.isEmpty()) {
 			throw new RuntimeException(

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -918,6 +918,10 @@ public class Authentication {
 			throw new NullPointerException("user");
 		}
 		if (disable) {
+			if (user.isRoot() && !admin.isRoot()) {
+				throw new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Only the root user can disable the root account");
+			}
 			if (reason == null || reason.isEmpty()) {
 				throw new IllegalParameterException(
 						"Must provide a reason why the account was disabled");

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -346,7 +346,6 @@ public class Authentication {
 		}
 	}
 
-	//TODO NOW always reenable ROOT when setting the password from the command line
 	public NewToken createToken(
 			final IncomingToken token,
 			final String tokenName,

--- a/src/us/kbase/auth2/lib/LocalUser.java
+++ b/src/us/kbase/auth2/lib/LocalUser.java
@@ -20,11 +20,14 @@ public abstract class LocalUser extends AuthUser {
 			final Set<Role> roles,
 			final Date created,
 			final Date lastLogin,
+			final UserName lastAdminDisable,
+			final String disableReason,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset,
 			final Date lastReset) {
-		super(userName, email, displayName, null, roles, created, lastLogin);
+		super(userName, email, displayName, null, roles, created, lastLogin, lastAdminDisable,
+				disableReason);
 		// what's the right # here? Have to rely on user to some extent
 		if (passwordHash == null || passwordHash.length < 10) {
 			throw new IllegalArgumentException(

--- a/src/us/kbase/auth2/lib/LocalUser.java
+++ b/src/us/kbase/auth2/lib/LocalUser.java
@@ -22,12 +22,13 @@ public abstract class LocalUser extends AuthUser {
 			final Date lastLogin,
 			final UserName lastAdminDisable,
 			final String disableReason,
+			final Date disabled,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset,
 			final Date lastReset) {
 		super(userName, email, displayName, null, roles, created, lastLogin, lastAdminDisable,
-				disableReason);
+				disableReason, disabled);
 		// what's the right # here? Have to rely on user to some extent
 		if (passwordHash == null || passwordHash.length < 10) {
 			throw new IllegalArgumentException(

--- a/src/us/kbase/auth2/lib/LoginState.java
+++ b/src/us/kbase/auth2/lib/LoginState.java
@@ -1,0 +1,94 @@
+package us.kbase.auth2.lib;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+
+public class LoginState {
+
+	//TODO JAVADOC
+	//TODO TEST
+	
+	private final Map<UserName, Set<RemoteIdentityWithID>> userIDs = new HashMap<>();
+	private final Map<UserName, AuthUser> users = new HashMap<>();
+	private final Set<RemoteIdentityWithID> noUser = new HashSet<>();
+	private String provider;
+
+	public String getProvider() {
+		return provider;
+	}
+	
+	public Set<RemoteIdentityWithID> getIdentities() {
+		return Collections.unmodifiableSet(noUser);
+	}
+	
+	public Set<UserName> getUsers() {
+		return Collections.unmodifiableSet(users.keySet());
+	}
+	
+	public AuthUser getUser(final UserName name) {
+		checkUser(name);
+		return users.get(name);
+	}
+
+	private void checkUser(final UserName name) {
+		if (!users.containsKey(name)) {
+			throw new IllegalArgumentException("No such user: " + name.getName());
+		}
+	}
+	
+	public Set<RemoteIdentityWithID> getIdentities(final UserName name) {
+		checkUser(name);
+		return Collections.unmodifiableSet(userIDs.get(name));
+	}
+	
+
+	public static class Builder {
+		
+		private final LoginState ls = new LoginState();
+
+		public void addIdentity(final RemoteIdentityWithID remoteID) {
+			if (remoteID == null) {
+				throw new NullPointerException("remoteID");
+			}
+			checkProvider(remoteID);
+			ls.noUser.add(remoteID);
+		}
+
+		private void checkProvider(final RemoteIdentityWithID remoteID) {
+			if (ls.provider == null) {
+				ls.provider = remoteID.getRemoteID().getProvider();
+			} else if (!ls.provider.equals(remoteID.getRemoteID().getProvider())) {
+				throw new IllegalStateException(
+						"Cannot have multiple providers in the same login state");
+			}
+		}
+
+		public void addUser(final AuthUser user, final RemoteIdentityWithID remoteID) {
+			if (user == null) {
+				throw new NullPointerException("user");
+			}
+			if (remoteID == null) {
+				throw new NullPointerException("remoteID");
+			}
+			checkProvider(remoteID);
+			final UserName name = user.getUserName();
+			ls.users.put(name, user);
+			if (!ls.userIDs.containsKey(name)) {
+				ls.userIDs.put(name, new HashSet<>());
+			}
+			ls.userIDs.get(name).add(remoteID);
+		}
+
+		public LoginState build() {
+			return ls;
+		}
+	}
+
+	private LoginState() {}
+
+}

--- a/src/us/kbase/auth2/lib/NewLocalUser.java
+++ b/src/us/kbase/auth2/lib/NewLocalUser.java
@@ -18,7 +18,7 @@ public class NewLocalUser extends LocalUser {
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset) {
-		super(userName, email, displayName, Collections.emptySet(), created, lastLogin,
+		super(userName, email, displayName, Collections.emptySet(), created, lastLogin, null, null,
 				passwordHash, salt, forceReset, null);
 	}
 

--- a/src/us/kbase/auth2/lib/NewLocalUser.java
+++ b/src/us/kbase/auth2/lib/NewLocalUser.java
@@ -18,8 +18,8 @@ public class NewLocalUser extends LocalUser {
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset) {
-		super(userName, email, displayName, Collections.emptySet(), created, lastLogin, null, null,
-				passwordHash, salt, forceReset, null);
+		super(userName, email, displayName, Collections.emptySet(), created, lastLogin,
+				null, null, null, passwordHash, salt, forceReset, null);
 	}
 
 	@Override

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -19,7 +19,7 @@ public class NewUser extends AuthUser {
 			final Date created,
 			final Date lastLogin) {
 		super(userName, email, displayName, identities, Collections.emptySet(), created,
-				lastLogin, null, null);
+				lastLogin, null, null, null);
 	}
 
 	@Override

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -19,7 +19,7 @@ public class NewUser extends AuthUser {
 			final Date created,
 			final Date lastLogin) {
 		super(userName, email, displayName, identities, Collections.emptySet(), created,
-				lastLogin);
+				lastLogin, null, null);
 	}
 
 	@Override

--- a/src/us/kbase/auth2/lib/UserName.java
+++ b/src/us/kbase/auth2/lib/UserName.java
@@ -5,6 +5,7 @@ import static us.kbase.auth2.lib.Utils.checkString;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 
@@ -38,7 +39,7 @@ public class UserName {
 		} else {
 			final Matcher m = INVALID_USER_NAME.matcher(name);
 			if (m.find()) {
-				throw new IllegalParameterException(String.format(
+				throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, String.format(
 						"Illegal character in user name %s: %s", name, m.group()));
 			}
 			this.name = name.trim();

--- a/src/us/kbase/auth2/lib/Utils.java
+++ b/src/us/kbase/auth2/lib/Utils.java
@@ -1,7 +1,5 @@
 package us.kbase.auth2.lib;
 
-import java.util.Date;
-
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 
@@ -45,13 +43,6 @@ public class Utils {
 		if (s == null || s.trim().isEmpty()) {
 			throw new IllegalArgumentException("Missing argument: " + name);
 		}
-	}
-	
-	public static long dateToSec(final Date date) {
-		if (date == null) {
-			throw new NullPointerException("date");
-		}
-		return (long) Math.floor(date.getTime() / 1000.0);
 	}
 
 	// prevents overflows by returning max long if a + b > maxlong

--- a/src/us/kbase/auth2/lib/exceptions/DisabledUserException.java
+++ b/src/us/kbase/auth2/lib/exceptions/DisabledUserException.java
@@ -1,0 +1,16 @@
+package us.kbase.auth2.lib.exceptions;
+
+/** Thrown when trying to access a user whose account has been disabled.
+ * @author gaprice@lbl.gov 
+ */
+@SuppressWarnings("serial")
+public class DisabledUserException extends UnauthorizedException {
+	
+	public DisabledUserException(final String message) {
+		super(ErrorType.DISABLED, message);
+	}
+	
+	public DisabledUserException(final String message, final Throwable cause) {
+		super(ErrorType.DISABLED, message, cause);
+	}
+}

--- a/src/us/kbase/auth2/lib/exceptions/ErrorType.java
+++ b/src/us/kbase/auth2/lib/exceptions/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
 	INVALID_TOKEN			(10002, "Invalid token"),
 	ID_RETRIEVAL_FAILED		(10003, "Identity retrieval failed"),
 	UNAUTHORIZED			(20000, "Unauthorized"),
+	DISABLED				(20001, "Account disabled"),
 	MISSING_PARAMETER		(30000, "Missing input parameter"),
 	ILLEGAL_PARAMETER		(30001, "Illegal input parameter"),
 	ILLEGAL_USER_NAME		(30002, "Illegal user name"),

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -13,6 +13,8 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.ExternalConfig;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.LocalUser;
+import us.kbase.auth2.lib.NewLocalUser;
+import us.kbase.auth2.lib.NewUser;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.SearchField;
 import us.kbase.auth2.lib.UserName;
@@ -63,13 +65,13 @@ public interface AuthStorage {
 	 * system occurs.
 	 * @throws UserExistsException if the user already exists.
 	 */
-	void createLocalUser(LocalUser local)
+	void createLocalUser(NewLocalUser local)
 			throws AuthStorageException, UserExistsException;
 
 	void changePassword(UserName userName, byte[] passwordHash, byte[] salt)
 			throws NoSuchUserException, AuthStorageException;
 	
-	void createUser(AuthUser authUser)
+	void createUser(NewUser authUser)
 			throws UserExistsException, AuthStorageException;
 
 	void disableAccount(UserName user, UserName admin, String reason)

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -72,6 +72,12 @@ public interface AuthStorage {
 	void createUser(AuthUser authUser)
 			throws UserExistsException, AuthStorageException;
 
+	void disableAccount(UserName user, UserName admin, String reason)
+			throws NoSuchUserException, AuthStorageException;
+
+	void enableAccount(UserName user, UserName admin)
+			throws NoSuchUserException, AuthStorageException;
+	
 	AuthUser getUser(UserName userName)
 			throws AuthStorageException, NoSuchUserException;
 	

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -19,11 +19,12 @@ public class Fields {
 	public static final String USER_CUSTOM_ROLES = "custrls";
 	public static final String USER_CREATED = "create";
 	public static final String USER_LAST_LOGIN = "login";
-	/* these 2 are really used for disabled or enabled. reason will be null for enabled accounts,
-	 * admin will be the admin that enabled or disabled the account last
+	/* these 3 are really used for disabled or enabled. reason will be null for enabled accounts,
+	 * admin will be the admin that enabled or disabled the account last, date is same
 	 */
 	public static final String USER_DISABLED_ADMIN = "dsbleadmin";
 	public static final String USER_DISABLED_REASON = "dsblereas";
+	public static final String USER_DISABLED_DATE = "dsbledate";
 	// these 3 are for local accounts only
 	public static final String USER_PWD_HSH = "pwdhsh";
 	public static final String USER_SALT = "salt";

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -19,6 +19,11 @@ public class Fields {
 	public static final String USER_CUSTOM_ROLES = "custrls";
 	public static final String USER_CREATED = "create";
 	public static final String USER_LAST_LOGIN = "login";
+	/* these 2 are really used for disabled or enabled. reason will be null for enabled accounts,
+	 * admin will be the admin that enabled or disabled the account last
+	 */
+	public static final String USER_DISABLED_ADMIN = "dsbleadmin";
+	public static final String USER_DISABLED_REASON = "dsblereas";
 	// these 3 are for local accounts only
 	public static final String USER_PWD_HSH = "pwdhsh";
 	public static final String USER_SALT = "salt";

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -30,13 +30,15 @@ public class MongoLocalUser extends LocalUser {
 			final Set<ObjectId> customRoles,
 			final Date created,
 			final Date lastLogin,
+			final UserName lastAdminDisable,
+			final String disableReason,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset,
 			final Date lastReset,
 			final MongoStorage storage) {
-		super(userName, email, displayName, roles, created, lastLogin, passwordHash, salt,
-				forceReset, lastReset);
+		super(userName, email, displayName, roles, created, lastLogin, lastAdminDisable,
+				disableReason, passwordHash, salt, forceReset, lastReset);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoLocalUser.java
@@ -32,13 +32,14 @@ public class MongoLocalUser extends LocalUser {
 			final Date lastLogin,
 			final UserName lastAdminDisable,
 			final String disableReason,
+			final Date disabled,
 			final byte[] passwordHash,
 			final byte[] salt,
 			final boolean forceReset,
 			final Date lastReset,
 			final MongoStorage storage) {
 		super(userName, email, displayName, roles, created, lastLogin, lastAdminDisable,
-				disableReason, passwordHash, salt, forceReset, lastReset);
+				disableReason, disabled, passwordHash, salt, forceReset, lastReset);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -489,8 +489,7 @@ public class MongoStorage implements AuthStorage {
 	}
 
 	private boolean isDuplicateKeyException(final MongoWriteException mwe) {
-		return mwe.getError().getCategory().equals(
-				ErrorCategory.DUPLICATE_KEY);
+		return mwe.getError().getCategory().equals(ErrorCategory.DUPLICATE_KEY);
 	}
 	
 	@Override
@@ -994,7 +993,7 @@ public class MongoStorage implements AuthStorage {
 		while (!complete) {
 			count++;
 			if (count > 5) {
-				throw new LinkFailedException("Attempted link update 5 times without success. " +
+				throw new RuntimeException("Attempted link update 5 times without success. " +
 						"There's probably a programming error here.");
 			}
 			complete = addIdentity(user, remoteID);
@@ -1004,8 +1003,7 @@ public class MongoStorage implements AuthStorage {
 	private boolean addIdentity(
 			final UserName userName,
 			final RemoteIdentityWithID remoteID)
-			throws NoSuchUserException, AuthStorageException,
-			LinkFailedException {
+			throws NoSuchUserException, AuthStorageException, LinkFailedException {
 		/* This method is written as it is to avoid adding the same provider ID to a user twice.
 		 * Since mongodb unique indexes only enforce uniqueness between documents, not within
 		 * documents, adding the same provider ID to a single document twice is possible without

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -952,15 +952,13 @@ public class MongoStorage implements AuthStorage {
 			throw new NoSuchTokenException("Token not found");
 		}
 		@SuppressWarnings("unchecked")
-		final List<Document> ids =
-				(List<Document>) d.get(Fields.TEMP_TOKEN_IDENTITIES);
-		if (ids == null || ids.isEmpty()) {
+		final List<Document> ids = (List<Document>) d.get(Fields.TEMP_TOKEN_IDENTITIES);
+		if (ids == null) {
 			final String tid = d.getString(Fields.TEMP_TOKEN_ID);
 			throw new AuthStorageException(String.format(
-					"Temporary token %s has no associated IDs", tid));
+					"Temporary token %s has no associated IDs field", tid));
 		}
-		final Set<RemoteIdentityWithID> ret = toIdentities(ids);
-		return ret;
+		return toIdentities(ids);
 	}
 
 	private Set<RemoteIdentityWithID> toIdentities(final List<Document> ids) {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -44,6 +44,8 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.ExternalConfig;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.LocalUser;
+import us.kbase.auth2.lib.NewLocalUser;
+import us.kbase.auth2.lib.NewUser;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.SearchField;
 import us.kbase.auth2.lib.UserName;
@@ -319,7 +321,7 @@ public class MongoStorage implements AuthStorage {
 	}
 	
 	@Override
-	public void createLocalUser(final LocalUser local)
+	public void createLocalUser(final NewLocalUser local)
 			throws UserExistsException, AuthStorageException {
 		final String pwdhsh = Base64.getEncoder().encodeToString(
 				local.getPasswordHash());
@@ -432,7 +434,7 @@ public class MongoStorage implements AuthStorage {
 	}
 	
 	@Override
-	public void createUser(final AuthUser user)
+	public void createUser(final NewUser user)
 			throws UserExistsException, AuthStorageException {
 		if (user.isLocal()) {
 			throw new IllegalArgumentException("cannot create a local user");

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -294,7 +294,12 @@ public class MongoStorage implements AuthStorage {
 				.append(Fields.USER_ROLES, rolestr)
 				.append(Fields.USER_RESET_PWD, false)
 				.append(Fields.USER_PWD_HSH, encpwd)
-				.append(Fields.USER_SALT, encsalt);
+				.append(Fields.USER_SALT, encsalt)
+				// ideally only set name to  root if 1) the root account already exists and 2)
+				// the field isn't set to root, but that's too much trouble for now
+				// could do it with an insert/update cycle
+				.append(Fields.USER_DISABLED_ADMIN, null)
+				.append(Fields.USER_DISABLED_REASON, null);// always enable
 		final Document setIfMissing = new Document(
 				Fields.USER_EMAIL, email.getAddress())
 				.append(Fields.USER_DISPLAY_NAME, displayName.getName())
@@ -302,9 +307,7 @@ public class MongoStorage implements AuthStorage {
 				.append(Fields.USER_CUSTOM_ROLES, Collections.emptyList())
 				.append(Fields.USER_CREATED, created)
 				.append(Fields.USER_LAST_LOGIN, null)
-				.append(Fields.USER_RESET_PWD_LAST, null)
-				.append(Fields.USER_DISABLED_ADMIN, null)
-				.append(Fields.USER_DISABLED_REASON, null);
+				.append(Fields.USER_RESET_PWD_LAST, null);
 		final Document u = new Document("$set", set)
 				.append("$setOnInsert", setIfMissing);
 		try {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -32,8 +32,11 @@ public class MongoUser extends AuthUser {
 			final Set<ObjectId> customRoles,
 			final Date created,
 			final Date lastLogin,
+			final UserName lastAdminDisable,
+			final String disableReason,
 			final MongoStorage storage) {
-		super(userName, email, displayName, identities, roles, created, lastLogin);
+		super(userName, email, displayName, identities, roles, created, lastLogin,
+				lastAdminDisable, disableReason);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();
@@ -43,7 +46,8 @@ public class MongoUser extends AuthUser {
 
 	MongoUser(final MongoUser user, final Set<RemoteIdentityWithID> newIDs) {
 		super(user.getUserName(), user.getEmail(), user.getDisplayName(), newIDs, user.getRoles(),
-				user.getCreated(), user.getLastLogin());
+				user.getCreated(), user.getLastLogin(), user.getAdminThatToggledEnabledState(),
+				user.getReasonForDisabled());
 		this.customRoles = user.customRoles;
 		this.memoizedCustomRoles = user.memoizedCustomRoles;
 		this.storage = user.storage;

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -34,9 +34,10 @@ public class MongoUser extends AuthUser {
 			final Date lastLogin,
 			final UserName lastAdminDisable,
 			final String disableReason,
+			final Date disabled,
 			final MongoStorage storage) {
 		super(userName, email, displayName, identities, roles, created, lastLogin,
-				lastAdminDisable, disableReason);
+				lastAdminDisable, disableReason, disabled);
 		this.customRoles = Collections.unmodifiableSet(customRoles);
 		if (customRoles.isEmpty()) {
 			memoizedCustomRoles = Collections.emptySet();
@@ -47,7 +48,7 @@ public class MongoUser extends AuthUser {
 	MongoUser(final MongoUser user, final Set<RemoteIdentityWithID> newIDs) {
 		super(user.getUserName(), user.getEmail(), user.getDisplayName(), newIDs, user.getRoles(),
 				user.getCreated(), user.getLastLogin(), user.getAdminThatToggledEnabledState(),
-				user.getReasonForDisabled());
+				user.getReasonForDisabled(), user.getEnableToggleDate());
 		this.customRoles = user.customRoles;
 		this.memoizedCustomRoles = user.memoizedCustomRoles;
 		this.storage = user.storage;

--- a/src/us/kbase/auth2/service/api/LegacyGlobus.java
+++ b/src/us/kbase/auth2/service/api/LegacyGlobus.java
@@ -1,7 +1,5 @@
 package us.kbase.auth2.service.api;
 
-import static us.kbase.auth2.lib.Utils.dateToSec;
-
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -92,6 +90,11 @@ public class LegacyGlobus {
 			}
 		}
 		return token.trim();
+	}
+	
+	
+	private long dateToSec(final Date date) {
+		return (long) Math.floor(date.getTime() / 1000.0);
 	}
 	
 	// note does not return identity_id

--- a/src/us/kbase/auth2/service/api/LegacyKBase.java
+++ b/src/us/kbase/auth2/service/api/LegacyKBase.java
@@ -16,6 +16,7 @@ import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
@@ -56,7 +57,7 @@ public class LegacyKBase {
 			@FormParam("token") final String token,
 			@FormParam("fields") String fields)
 			throws AuthStorageException,
-			MissingParameterException, InvalidTokenException {
+			MissingParameterException, InvalidTokenException, DisabledUserException {
 		if (token == null || token.trim().isEmpty()) {
 			throw new MissingParameterException("token");
 		}

--- a/src/us/kbase/auth2/service/api/LegacyKBase.java
+++ b/src/us/kbase/auth2/service/api/LegacyKBase.java
@@ -96,6 +96,4 @@ public class LegacyKBase {
 		}
 		return ret;
 	}
-	
-
 }

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -22,6 +22,7 @@ import javax.ws.rs.core.MediaType;
 
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
@@ -40,7 +41,8 @@ public class Me {
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> me(@HeaderParam(APIConstants.HEADER_TOKEN) final String token)
-			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException {
+			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
+			DisabledUserException {
 		// this code is almost identical to ui.Me but I don't want to couple the API and UI outputs
 		final AuthUser u = auth.getUser(getToken(token));
 		final Map<String, Object> ret = new HashMap<String, Object>();

--- a/src/us/kbase/auth2/service/api/Token.java
+++ b/src/us/kbase/auth2/service/api/Token.java
@@ -38,8 +38,8 @@ public class Token {
 		ret.put("cachefor", auth.getSuggestedTokenCacheTime());
 		ret.put("user", ht.getUserName().getName());
 		ret.put("type", ht.getTokenType().getID());
-		ret.put("created", ht.getCreationDate().getTime() / 1000);
-		ret.put("expires", ht.getExpirationDate().getTime() / 1000);
+		ret.put("created", ht.getCreationDate().getTime());
+		ret.put("expires", ht.getExpirationDate().getTime());
 		ret.put("name", ht.getTokenName());
 		ret.put("id", ht.getId().toString());
 		return ret;

--- a/src/us/kbase/auth2/service/api/Users.java
+++ b/src/us/kbase/auth2/service/api/Users.java
@@ -21,6 +21,7 @@ import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.SearchField;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -56,8 +57,8 @@ public class Users {
 			try {
 				uns.add(new UserName(u));
 			} catch (MissingParameterException | IllegalParameterException e) {
-				throw new IllegalParameterException(String.format("Illegal username [%s]: %s",
-						u, e.getMessage()));
+				throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, String.format(
+						"Illegal username [%s]: %s", u, e.getMessage()));
 			}
 		}
 		final Map<UserName, DisplayName> dns = auth.getUserDisplayNames(getToken(token), uns);
@@ -76,7 +77,6 @@ public class Users {
 			@QueryParam("fields") final String fields)
 			throws InvalidTokenException, NoTokenProvidedException, AuthStorageException,
 			IllegalParameterException {
-		//TODO NOW limit to 10K names
 		final Set<SearchField> searchFields = new HashSet<>();
 		if (fields != null) {
 			final String[] splitFields = fields.split(",");

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -156,8 +156,9 @@ public class Admin {
 		ret.put("lastlogin", lastLogin == null ? null : lastLogin.getTime());
 		ret.put("disabled", au.isDisabled());
 		ret.put("disabledreason", au.getReasonForDisabled());
+		final Date disabled = au.getEnableToggleDate();
+		ret.put("enabletoggledate", disabled == null ? null : disabled.getTime());
 		final UserName admin = au.getAdminThatToggledEnabledState();
-		//TODO NOW add date of enable / disable
 		ret.put("enabledtoggledby", admin == null ? null : admin.getName());
 		final Set<Role> r = au.getRoles();
 		ret.put("admin", Role.ADMIN.isSatisfiedBy(r));
@@ -433,10 +434,10 @@ public class Admin {
 					"Server token expiration time must be at least 1");
 		}
 		final Map<TokenLifetimeType, Long> t = new HashMap<>();
-		t.put(TokenLifetimeType.EXT_CACHE, safeMult(sugcache, 60 * 1000L));
-		t.put(TokenLifetimeType.LOGIN, safeMult(login, 24 * 60 * 60 * 1000L));
-		t.put(TokenLifetimeType.DEV, safeMult(dev, 24 * 60 * 60 * 1000L));
-		t.put(TokenLifetimeType.SERV, safeMult(serv, 24 * 60 * 60 * 1000L));
+		t.put(TokenLifetimeType.EXT_CACHE, safeMult(sugcache, MIN_IN_MS));
+		t.put(TokenLifetimeType.LOGIN, safeMult(login, DAY_IN_MS));
+		t.put(TokenLifetimeType.DEV, safeMult(dev, DAY_IN_MS));
+		t.put(TokenLifetimeType.SERV, safeMult(serv, DAY_IN_MS));
 		try {
 			auth.updateConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					new AuthConfigSet<>(new AuthConfig(null, null, t),

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -140,13 +140,13 @@ public class Admin {
 		final IncomingToken adminToken = getTokenFromCookie(headers, cfg.getTokenCookieName());
 		final AuthUser au = auth.getUserAsAdmin(adminToken, new UserName(user));
 		final Set<CustomRole> roles = auth.getCustomRoles(adminToken, true);
+		final String userPrefix = UIPaths.ADMIN_ROOT_USER + SEP + user + SEP;
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put("custom", setUpCustomRoles(roles, au.getCustomRoles()));
 		ret.put("hascustom", !roles.isEmpty());
-		ret.put("roleurl", relativize(uriInfo,
-				UIPaths.ADMIN_ROOT_USER + SEP + user + SEP + UIPaths.ADMIN_ROLES));
-		ret.put("customroleurl", relativize(uriInfo,
-				UIPaths.ADMIN_ROOT_USER + SEP + user + SEP + UIPaths.ADMIN_CUSTOM_ROLES));
+		ret.put("roleurl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_ROLES));
+		ret.put("customroleurl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_CUSTOM_ROLES));
+		ret.put("disableurl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_DISABLE));
 		ret.put("user", au.getUserName().getName());
 		ret.put("display", au.getDisplayName().getName());
 		ret.put("email", au.getEmail().getAddress());
@@ -154,8 +154,12 @@ public class Admin {
 		ret.put("created", au.getCreated().getTime());
 		final Date lastLogin = au.getLastLogin();
 		ret.put("lastlogin", lastLogin == null ? null : lastLogin.getTime());
+		ret.put("disabled", au.isDisabled());
+		ret.put("disabledreason", au.getReasonForDisabled());
+		final UserName admin = au.getAdminThatToggledEnabledState();
+		//TODO NOW add date of enable / disable
+		ret.put("enabledtoggledby", admin == null ? null : admin.getName());
 		final Set<Role> r = au.getRoles();
-		//TODO ADMIN only show create-admin & admin buttons when appropriate
 		ret.put("admin", Role.ADMIN.isSatisfiedBy(r));
 		ret.put("serv", Role.SERV_TOKEN.isSatisfiedBy(r));
 		ret.put("dev", Role.DEV_TOKEN.isSatisfiedBy(r));
@@ -177,6 +181,24 @@ public class Admin {
 		return ret;
 	}
 
+	@POST
+	@Path(UIPaths.ADMIN_USER_DISABLE)
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+	public void disableUser(
+			@Context final HttpHeaders headers,
+			@PathParam("user") final String user,
+			@FormParam("disable") final String disableStr,
+			@FormParam("reason") final String reason)
+			throws MissingParameterException, IllegalParameterException, NoTokenProvidedException,
+			InvalidTokenException, UnauthorizedException, AuthStorageException,
+			NoSuchUserException {
+		final boolean disable = disableStr != null;
+		final UserName un = new UserName(user);
+		final IncomingToken token = getTokenFromCookie(headers, cfg.getTokenCookieName());
+		auth.disableAccount(token, un, disable, reason);
+	}
+			
+	
 	@POST
 	@Path(UIPaths.ADMIN_USER_ROLES)
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -42,6 +42,7 @@ import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.LinkIdentities;
 import us.kbase.auth2.lib.LinkToken;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
@@ -78,7 +79,7 @@ public class Link {
 			@QueryParam("provider") final String provider,
 			@Context UriInfo uriInfo)
 			throws NoSuchIdentityProviderException, NoTokenProvidedException,
-			InvalidTokenException, AuthStorageException {
+			InvalidTokenException, AuthStorageException, DisabledUserException {
 
 		final IncomingToken incToken = getTokenFromCookie(headers, cfg.getTokenCookieName());
 		
@@ -129,7 +130,7 @@ public class Link {
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthenticationException,
 			NoSuchProviderException, AuthStorageException,
-			NoTokenProvidedException, LinkFailedException {
+			NoTokenProvidedException, LinkFailedException, DisabledUserException {
 		//TODO INPUT handle error in params (provider, state)
 		provider = upperCase(provider);
 		final MultivaluedMap<String, String> qps = uriInfo.getQueryParameters();
@@ -214,7 +215,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, LinkFailedException {
+			InvalidTokenException, LinkFailedException, DisabledUserException {
 		return linkChoice(headers, linktoken, uriInfo);
 	}
 	
@@ -227,7 +228,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, LinkFailedException {
+			InvalidTokenException, LinkFailedException, DisabledUserException {
 		return linkChoice(headers, linktoken, uriInfo);
 	}
 
@@ -236,7 +237,7 @@ public class Link {
 			final String linktoken,
 			final UriInfo uriInfo)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			LinkFailedException {
+			LinkFailedException, DisabledUserException {
 		if (linktoken == null || linktoken.trim().isEmpty()) {
 			throw new NoTokenProvidedException("Missing " + IN_PROCESS_LINK_COOKIE);
 		}
@@ -273,7 +274,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@FormParam("id") final UUID identityID)
 			throws NoTokenProvidedException, AuthenticationException,
-			AuthStorageException, LinkFailedException {
+			AuthStorageException, LinkFailedException, DisabledUserException {
 		
 		pickAccount(headers, linktoken, identityID);
 		return Response.seeOther(getPostLinkRedirectURI(UIPaths.ME_ROOT))
@@ -288,7 +289,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@QueryParam("id") final UUID identityID)
 			throws NoTokenProvidedException, AuthenticationException,
-			AuthStorageException, LinkFailedException {
+			AuthStorageException, LinkFailedException, DisabledUserException {
 		
 		pickAccount(headers, linktoken, identityID);
 		return Response.noContent().cookie(getLinkInProcessCookie(null)).build();
@@ -299,7 +300,7 @@ public class Link {
 			final String linktoken,
 			final UUID identityID)
 			throws NoTokenProvidedException, AuthStorageException, AuthenticationException,
-			LinkFailedException {
+			LinkFailedException, DisabledUserException {
 		if (linktoken == null || linktoken.trim().isEmpty()) {
 			throw new NoTokenProvidedException("Missing " + IN_PROCESS_LINK_COOKIE);
 		}

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -243,8 +243,7 @@ public class Login {
 	public Map<String, Object> loginChoiceHTML(
 			@CookieParam(IN_PROCESS_LOGIN_TOKEN) final String token,
 			@Context final UriInfo uriInfo)
-			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, UnauthorizedException {
+			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException {
 		return loginChoice(token, uriInfo);
 	}
 
@@ -255,14 +254,12 @@ public class Login {
 	public Map<String, Object> loginChoiceJSON(
 			@CookieParam(IN_PROCESS_LOGIN_TOKEN) final String token,
 			@Context final UriInfo uriInfo)
-			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, UnauthorizedException {
+			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException {
 		return loginChoice(token, uriInfo);
 	}
 	
 	private Map<String, Object> loginChoice(final String token, final UriInfo uriInfo)
-			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException,
-			UnauthorizedException {
+			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException {
 		if (token == null || token.trim().isEmpty()) {
 			throw new NoTokenProvidedException("Missing " + IN_PROCESS_LOGIN_TOKEN);
 		}

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -276,7 +276,7 @@ public class Login {
 		ret.put("provider", ids.keySet().iterator().next().getRemoteID().getProvider());
 		
 		final List<Map<String, String>> create = new LinkedList<>();
-		final List<Map<String, String>> login = new LinkedList<>();
+		final List<Map<String, Object>> login = new LinkedList<>();
 		ret.put("create", create);
 		ret.put("login", login);
 		
@@ -292,10 +292,12 @@ public class Login {
 				c.put("prov_email", id.getDetails().getEmail());
 				create.add(c);
 			} else {
-				final Map<String, String> l = new HashMap<>();
+				final Map<String, Object> l = new HashMap<>();
 				l.put("id", id.getID().toString());
 				l.put("prov_username", id.getDetails().getUsername());
 				l.put("username", e.getValue().getUserName().getName());
+				l.put("disabled", e.getValue().isDisabled());
+				//TODO NOW add disabled to UI
 				login.add(l);
 			}
 		}

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -26,6 +26,7 @@ import org.glassfish.jersey.server.mvc.Template;
 
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
@@ -52,7 +53,7 @@ public class Me {
 			@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, InvalidTokenException,
-			AuthStorageException {
+			AuthStorageException, DisabledUserException {
 		final AuthUser u = auth.getUser(getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put("userupdateurl", relativize(uriInfo, UIPaths.ME_ROOT));

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -32,6 +32,7 @@ import org.glassfish.jersey.server.mvc.Template;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
@@ -61,7 +62,7 @@ public class Tokens {
 			@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException {
+			NoTokenProvidedException, DisabledUserException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		t.put("user", ((UIToken) t.get("current")).getUser());
@@ -77,7 +78,7 @@ public class Tokens {
 			@Context final HttpHeaders headers,
 			@HeaderParam("authentication") final String headerToken)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException {
+			NoTokenProvidedException, DisabledUserException {
 		final IncomingToken cookieToken = getTokenFromCookie(
 				headers, cfg.getTokenCookieName(), false);
 		return getTokens(cookieToken == null ? getToken(headerToken) : cookieToken);
@@ -174,7 +175,7 @@ public class Tokens {
 
 	private Map<String, Object> getTokens(final IncomingToken token)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException {
+			InvalidTokenException, DisabledUserException {
 		final AuthUser au = auth.getUser(token);
 		final TokenSet ts = auth.getTokens(token);
 		final Map<String, Object> ret = new HashMap<>();

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -28,6 +28,9 @@ public class UIPaths {
 
 	public static final String ADMIN_ROOT_USER = ADMIN_ROOT + USER;
 	public static final String ADMIN_USER_PARAM = USER + SEP + "{user}";
+	
+	public static final String ADMIN_DISABLE = "disable";
+	public static final String ADMIN_USER_DISABLE = ADMIN_USER_PARAM + SEP + ADMIN_DISABLE;
 
 	public static final String ADMIN_ROLES = "roles";
 	public static final String ADMIN_USER_ROLES = ADMIN_USER_PARAM + SEP + ADMIN_ROLES;

--- a/src/us/kbase/auth2/service/ui/UIToken.java
+++ b/src/us/kbase/auth2/service/ui/UIToken.java
@@ -1,7 +1,5 @@
 package us.kbase.auth2.service.ui;
 
-import static us.kbase.auth2.lib.Utils.dateToSec;
-
 import java.util.Date;
 import java.util.UUID;
 
@@ -38,8 +36,8 @@ public class UIToken {
 		this.id = id.toString();
 		this.name = tokenName;
 		this.user = userName.getName();
-		this.expires = dateToSec(expirationDate);
-		this.created = dateToSec(creationDate);
+		this.expires = expirationDate.getTime();
+		this.created = creationDate.getTime();
 	}
 	
 	public String getType() {

--- a/templates/adminuser.mustache
+++ b/templates/adminuser.mustache
@@ -1,15 +1,15 @@
 <html>
 <body>
 <h3>User info</h3>
-User name: {{user}}</br>
+User name: {{user}}<br/>
 {{#disabled}}
 <p>
 DISABLED by {{enabledtoggledby}} on {{enabletoggledate}}. Reason given:<br/>
 {{disabledreason}}
 {{/disabled}}</p>
-{{^disabled}}
+{{^disabled}}{{#enabletoggledate}}
 Account re-enabled on {{enabletoggledate}} {{#enabledtoggledby}} by {{enabledtoggledby}}{{/enabledtoggledby}}<br/>
-{{/disabled}}
+{{/enabletoggledate}}{{/disabled}}
 Display name: {{display}}<br/>
 Email: {{email}}<br/>
 Created: {{created}}<br/>

--- a/templates/adminuser.mustache
+++ b/templates/adminuser.mustache
@@ -1,7 +1,15 @@
 <html>
 <body>
 <h3>User info</h3>
-User name: {{user}}<br/>
+User name: {{user}}</br>
+{{#disabled}}
+<p>
+DISABLED by {{enabledtoggledby}}. Reason given:<br/>
+{{disabledreason}}
+{{/disabled}}</p>
+{{^disabled}}{{#enabledtoggledby}}
+Account re-enabled by: {{enabledtoggledby}}<br/>
+{{/enabledtoggledby}}{{/disabled}}
 Display name: {{display}}<br/>
 Email: {{email}}<br/>
 Created: {{created}}<br/>
@@ -9,10 +17,10 @@ Last login: {{lastlogin}}<br/>
 Local: {{local}}<br/>
 <h3>Roles:</h3>
 <form action="{{roleurl}}" method="post">
-	Create developer token: <input type="checkbox" name="dev" {{#dev}}checked{{/dev}}/><br/>
-	Create server token: <input type="checkbox" name="serv" {{#serv}}checked{{/serv}}/><br/>
-	Admin: <input type="checkbox" name="admin" {{#admin}}checked{{/admin}}/><br/>
-	Create admin: <input type="checkbox" name="createadmin" {{#createadmin}}checked{{/createadmin}}/><br/>
+	Create developer token: <input type="checkbox" name="dev" {{#dev}}checked{{/dev}} /><br/>
+	Create server token: <input type="checkbox" name="serv" {{#serv}}checked{{/serv}} /><br/>
+	Admin: <input type="checkbox" name="admin" {{#admin}}checked{{/admin}} /><br/>
+	Create admin: <input type="checkbox" name="createadmin" {{#createadmin}}checked{{/createadmin}} /><br/>
 <input type="reset" value="Reset"/>
 <input type="submit" value="Update"/>
 </form>
@@ -34,5 +42,12 @@ Description:<br/>
 </form>
 {{/hascustom}}
 
+Note that if all admins are disabled you can reenable the root account from the manage_auth script.
+<form action="{{disableurl}}" method="post" id="disableform">
+	Disabled: <input type="checkbox" name="disable" {{#disabled}}checked{{/disabled}} /><br/>
+	Reason: <textarea name="reason" form="disableform" cols="40" rows="5"></textarea><br/>
+	<input type="reset" value="Reset"/>
+	<input type="submit" value="Update"/>
+</form>
 </body>
 </html>

--- a/templates/adminuser.mustache
+++ b/templates/adminuser.mustache
@@ -4,12 +4,12 @@
 User name: {{user}}</br>
 {{#disabled}}
 <p>
-DISABLED by {{enabledtoggledby}}. Reason given:<br/>
+DISABLED by {{enabledtoggledby}} on {{enabletoggledate}}. Reason given:<br/>
 {{disabledreason}}
 {{/disabled}}</p>
-{{^disabled}}{{#enabledtoggledby}}
-Account re-enabled by: {{enabledtoggledby}}<br/>
-{{/enabledtoggledby}}{{/disabled}}
+{{^disabled}}
+Account re-enabled on {{enabletoggledate}} {{#enabledtoggledby}} by {{enabledtoggledby}}{{/enabledtoggledby}}<br/>
+{{/disabled}}
 Display name: {{display}}<br/>
 Email: {{email}}<br/>
 Created: {{created}}<br/>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -7,12 +7,15 @@
 <p>The login information from the provider allows you to access these
 accounts:</p>
 {{#login}}
-Provider username: {{prov_username}}<br/>
-Username: {{username}}<br/>
+Username: {{username}} {{#disabled}}DISABLED{{/disabled}}<br/>
+Provider usernames: {{prov_usernames}}<br/>
+{{^disabled}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Login"/>
 </form>
+{{/disabled}}
+<br/>
 {{/login}}
 
 <h3>Create account</h3>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -7,14 +7,14 @@
 <p>The login information from the provider allows you to access these
 accounts:</p>
 {{#login}}
-Username: {{username}} {{#disabled}}DISABLED{{/disabled}}<br/>
+Username: {{username}} {{#disabled}}DISABLED{{/disabled}} {{#adminonly}}***Currently only admin accounts can log in***{{/adminonly}}<br/>
 Provider usernames: {{prov_usernames}}<br/>
-{{^disabled}}
+{{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Login"/>
 </form>
-{{/disabled}}
+{{/loginallowed}}
 <br/>
 {{/login}}
 
@@ -25,6 +25,7 @@ Display name is public to other system users.</br>
 Email is only visible to you, software acting on your behalf, and system administrators.
 </p>
 {{#create}}
+{{#creationallowed}}
 <p>Create an account linked to {{prov_username}}</p>
 </p>
 <form action="{{createurl}}" method="post">
@@ -34,6 +35,11 @@ Email is only visible to you, software acting on your behalf, and system adminis
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Create"/>
 </form>
+{{/creationallowed}}
+{{^creationallowed}}
+Provider username: {{prov_username}}<br/>
+Sorry, account creation is currently disabled.<br/>
+{{/creationallowed}}
 {{/create}}
 
 </html>


### PR DESCRIPTION
Also wound up fixing some issues where avoidable exceptions could be thrown on redirect from the 3rd party identity provider to the link or login endpoints, meaning any external UI can't intercept and handle the exceptions. Where possible, the exceptions are thrown at the choice endpoints.

Also also fixed some bugs:
* User could be presented with two choices for login, both of which are the same KBase user but different remote identities
* Show all remote identities linked to a user on the login choice endpoint, rather than just one random identity