### PR TITLE
Refactor identity provider factory, add tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -193,6 +193,7 @@
       <test name="us.kbase.test.auth2.cryptutils.TokenGeneratorTest"/>
       <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
       <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
+      <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>

--- a/build.xml
+++ b/build.xml
@@ -194,6 +194,7 @@
       <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
       <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
       <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
+      <test name="us.kbase.test.auth2.lib.identity.IdentityProviderSetTest"/>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>

--- a/src/us/kbase/auth2/cli/AuthCLI.java
+++ b/src/us/kbase/auth2/cli/AuthCLI.java
@@ -39,7 +39,7 @@ import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
-import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+import us.kbase.auth2.lib.identity.IdentityProviderSet;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
 import us.kbase.auth2.lib.identity.RemoteIdentityID;
@@ -72,9 +72,9 @@ public class AuthCLI {
 	public static void main(String[] args) {
 		quietLogger();
 		
-		final IdentityProviderFactory fac = IdentityProviderFactory.getInstance();
-		fac.register(new GlobusIdentityProviderConfigurator());
-		fac.register(new GoogleIdentityProviderConfigurator());
+		final IdentityProviderSet ids = new IdentityProviderSet();
+		ids.register(new GlobusIdentityProviderConfigurator());
+		ids.register(new GoogleIdentityProviderConfigurator());
 		
 		final Args a = new Args();
 		JCommander jc = new JCommander(a);
@@ -93,7 +93,7 @@ public class AuthCLI {
 		final AuthStartupConfig cfg;
 		try {
 			cfg = new KBaseAuthConfig(Paths.get(a.deploy), true);
-			auth = new AuthBuilder(cfg, AuthExternalConfig.DEFAULT).getAuth();
+			auth = new AuthBuilder(ids, cfg, AuthExternalConfig.DEFAULT).getAuth();
 		} catch (AuthConfigurationException | StorageInitException e) {
 			error(e, a);
 			throw new RuntimeException(); // error() stops execution

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1201,8 +1201,7 @@ public class Authentication {
 		if (username.contains("@")) {
 			username = username.split("@")[0];
 			if (username.isEmpty()) {
-				throw new IllegalParameterException(
-						ErrorType.ILLEGAL_USER_NAME,
+				throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME,
 						ri.getDetails().getUsername());
 			}
 		}

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -39,7 +39,7 @@ import us.kbase.auth2.lib.exceptions.UnLinkFailedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
 import us.kbase.auth2.lib.identity.IdentityProvider;
-import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+import us.kbase.auth2.lib.identity.IdentityProviderSet;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
 import us.kbase.auth2.lib.storage.AuthStorage;
@@ -87,14 +87,14 @@ public class Authentication {
 	}
 
 	private final AuthStorage storage;
-	private final IdentityProviderFactory idFactory;
+	private final IdentityProviderSet idProviderSet;
 	private final TokenGenerator tokens;
 	private final PasswordCrypt pwdcrypt;
 	private final ConfigManager cfg;
 	
 	public Authentication(
 			final AuthStorage storage,
-			final IdentityProviderFactory identityProviderFactory,
+			final IdentityProviderSet identityProviderSet,
 			final ExternalConfig defaultExternalConfig)
 			throws StorageInitException {
 		
@@ -107,14 +107,14 @@ public class Authentication {
 		if (storage == null) {
 			throw new NullPointerException("storage");
 		}
-		if (identityProviderFactory == null) {
+		if (identityProviderSet == null) {
 			throw new NullPointerException("identityProviderFactory");
 		}
 		this.storage = storage;
-		this.idFactory = identityProviderFactory;
-		idFactory.lock();
+		this.idProviderSet = identityProviderSet;
+		idProviderSet.lock();
 		final Map<String, ProviderConfig> provs = new HashMap<>();
-		for (final String provname: idFactory.getProviders()) {
+		for (final String provname: idProviderSet.getProviders()) {
 			provs.put(provname, AuthConfig.DEFAULT_PROVIDER_CONFIG);
 		}
 		final AuthConfig ac =  new AuthConfig(AuthConfig.DEFAULT_LOGIN_ALLOWED, provs,
@@ -770,14 +770,14 @@ public class Authentication {
 
 	public List<String> getIdentityProviders() throws AuthStorageException {
 		final AuthConfig ac = cfg.getAppConfig();
-		return idFactory.getProviders().stream()
+		return idProviderSet.getProviders().stream()
 				.filter(p -> ac.getProviderConfig(p).isEnabled())
 				.collect(Collectors.toList());
 	}
 	
 	private IdentityProvider getIdentityProvider(final String provider)
 			throws NoSuchIdentityProviderException, AuthStorageException {
-		final IdentityProvider ip = idFactory.getProvider(provider);
+		final IdentityProvider ip = idProviderSet.getProvider(provider);
 		if (!cfg.getAppConfig().getProviderConfig(provider).isEnabled()) {
 			throw new NoSuchIdentityProviderException(provider);
 		}
@@ -1157,7 +1157,7 @@ public class Authentication {
 		getUser(token, Role.ADMIN);
 		for (final String provider: acs.getCfg().getProviders().keySet()) {
 			//throws an exception if no provider by given name
-			idFactory.getProvider(provider);
+			idProviderSet.getProvider(provider);
 		}
 		storage.updateConfig(acs, true);
 		cfg.updateConfig();

--- a/src/us/kbase/auth2/lib/identity/GlobusIdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/GlobusIdentityProvider.java
@@ -254,7 +254,7 @@ public class GlobusIdentityProvider implements IdentityProvider {
 			final MultivaluedMap<String, String> formParameters,
 			final URI target) {
 		final String bauth = "Basic " + Base64.getEncoder().encodeToString(
-				(cfg.getClientID() + ":" + cfg.getClientSecrect()).getBytes());
+				(cfg.getClientID() + ":" + cfg.getClientSecret()).getBytes());
 		final WebTarget wt = CLI.target(target);
 		Response r = null;
 		try {

--- a/src/us/kbase/auth2/lib/identity/GoogleIdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/GoogleIdentityProvider.java
@@ -166,7 +166,7 @@ public class GoogleIdentityProvider implements IdentityProvider {
 				cfg.getLoginRedirectURL().toString());
 		formParameters.add("grant_type", "authorization_code");
 		formParameters.add("client_id", cfg.getClientID());
-		formParameters.add("client_secret", cfg.getClientSecrect());
+		formParameters.add("client_secret", cfg.getClientSecret());
 		
 		final URI target = UriBuilder.fromUri(toURI(cfg.getApiURL()))
 				.path(TOKEN_PATH).build();

--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -8,6 +8,9 @@ import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 
 /** A provider of OAuth2 identities, for example Google, Globus, Facebook etc.
  * @author gaprice@lbl.gov
+ * 
+ * @see IdentityProviderConfigurator
+ * @see IdentityProviderFactory
  *
  */
 public interface IdentityProvider {

--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -6,14 +6,38 @@ import java.util.Set;
 
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 
+/** A provider of OAuth2 identities, for example Google, Globus, Facebook etc.
+ * @author gaprice@lbl.gov
+ *
+ */
 public interface IdentityProvider {
 
-	//TODO JAVADOC
-	
+	/** Get the name of the identity provider.
+	 * @return the identity provider's name.
+	 */
 	String getProviderName();
+	
+	/** Get a URI for an image associated with the identity provider.
+	 * @return an image.
+	 */
 	URI getImageURI();
-	//note state will be url encoded.
+	
+	/** Get the url to which a user should be redirected to log in to the identity provider.
+	 * @param state the OAuth2 state variable, generally random data large enough to be
+	 * unguessable. The state will be url encoded.
+	 * @param link whether the user should be redirected to a login or link url after completion of
+	 * login at the identity provider.
+	 * @return a login url for the identity provider.
+	 */
 	URL getLoginURL(String state, boolean link);
+	
+	/** Get a set of identities from an identity provider given an identity provider authcode.
+	 * @param authcode the authcode returned from the identity provider on the redirect after
+	 * login.
+	 * @param link whether the authcode was associated with a login or link url.
+	 * @return the set of identities returned from the provider.
+	 * @throws IdentityRetrievalException if getting the idenities failed.
+	 */
 	Set<RemoteIdentity> getIdentities(String authcode, boolean link)
 			throws IdentityRetrievalException;
 }

--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -10,7 +10,7 @@ import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
  * @author gaprice@lbl.gov
  * 
  * @see IdentityProviderConfigurator
- * @see IdentityProviderFactory
+ * @see IdentityProviderSet
  *
  */
 public interface IdentityProvider {

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
@@ -9,7 +9,7 @@ import java.net.URL;
  *
  * @see IdentityProvider
  * @see IdentityProviderConfigurator
- * @see IdentityProviderFactory
+ * @see IdentityProviderSet
  */
 public class IdentityProviderConfig {
 	

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
@@ -4,86 +4,165 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+/** A configuration for an identity provider.
+ * @author gaprice@lbl.gov
+ *
+ * @see IdentityProvider
+ * @see IdentityProviderConfigurator
+ * @see IdentityProviderFactory
+ */
 public class IdentityProviderConfig {
-	
-	//TODO JAVADOC
-	//TODO TEST
 	
 	private final String identityProviderName;
 	private final String clientID;
-	private final String clientSecrect;
+	private final String clientSecret;
 	private final URI imageURI;
 	private final URL loginURL;
 	private final URL apiURL;
 	private final URL loginRedirectURL;
 	private final URL linkRedirectURL;
 	
+	/** Create a configuration for an identity provider.
+	 * @param identityProviderName the name of the identity provider, e.g. Google or Globus.
+	 * @param loginURL the login url for the identity provider; where users should be redirected.
+	 * @param apiURL the api url for the identity provider; where server to server requests should
+	 * be directed.
+	 * @param clientID the client ID for the identity provider.
+	 * @param clientSecret the client secret for the identity provider.
+	 * @param imgURI the uri for an image to associate with the identity provider.
+	 * @param loginRedirectURL the url to which the provider should redirect in the process of a
+	 * login.
+	 * @param linkRedirectURL the url to which the provider should redirect in the process of
+	 * linking accounts.
+	 * @throws IdentityProviderConfigurationException if any of the inputs were unacceptable.
+	 */
 	public IdentityProviderConfig(
 			final String identityProviderName,
 			final URL loginURL,
 			final URL apiURL,
 			final String clientID,
-			final String clientSecrect,
+			final String clientSecret,
 			final URI imgURI,
 			final URL loginRedirectURL,
-			final URL linkRedirectURL) {
-		super();
-		//TODO INPUT check for nulls & empty strings
+			final URL linkRedirectURL)
+			throws IdentityProviderConfigurationException {
+		notNullOrEmpty(identityProviderName, "Identity provider name");
+		notNullOrEmpty(clientID, "Client ID for " + identityProviderName + " identity provider");
+		notNullOrEmpty(clientSecret, "Client secret for " + identityProviderName + 
+				" identity provider");
 		this.identityProviderName = identityProviderName.trim();
 		this.clientID = clientID.trim();
-		this.clientSecrect = clientSecrect.trim();
+		this.clientSecret = clientSecret.trim();
 		this.imageURI = imgURI;
 		this.loginURL = loginURL;
 		this.apiURL = apiURL;
 		this.loginRedirectURL = loginRedirectURL;
 		this.linkRedirectURL = linkRedirectURL;
 
-		checkValidURI(this.loginURL, "Login url");
-		checkValidURI(this.apiURL, "API url");
-		checkValidURI(this.loginRedirectURL, "Login redirect url");
-		checkValidURI(this.linkRedirectURL, "Link redirect url");
+		if (imageURI == null) {
+			throw new IdentityProviderConfigurationException("Image URI for " +
+					identityProviderName + " identity provider cannot be null");
+		}
+		checkValidURI(this.loginURL, "Login URL");
+		checkValidURI(this.apiURL, "API URL");
+		checkValidURI(this.loginRedirectURL, "Login redirect URL");
+		checkValidURI(this.linkRedirectURL, "Link redirect URL");
 	}
 
-	private void checkValidURI(final URL url, final String name) {
-		//TODO TEST ^ is ok in a url, but not in a URI
+	private void checkValidURI(final URL url, final String name)
+			throws IdentityProviderConfigurationException {
+		if (url == null) {
+			throw new IdentityProviderConfigurationException(String.format(
+					"%s for %s identity provider cannot be null", name, identityProviderName));
+		}
 		try {
 			url.toURI();
 		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException(String.format(
+			throw new IdentityProviderConfigurationException(String.format(
 					"%s %s for %s identity provider is not a valid URI: %s",
 					name, url, identityProviderName, e.getMessage()), e);
 		}
 	}
+	
+	private void notNullOrEmpty(final String s, final String name)
+			throws IdentityProviderConfigurationException {
+		if (s == null || s.trim().isEmpty()) {
+			throw new IdentityProviderConfigurationException(name + " cannot be null or empty");
+		}
+	}
 
+	/** Get the name of the identity provider for this configuration.
+	 * @return the identity provider name.
+	 */
 	public String getIdentityProviderName() {
 		return identityProviderName;
 	}
 
+	/** Get the login url to which users should be redirected.
+	 * @return the login url.
+	 */
 	public URL getLoginURL() {
 		return loginURL;
 	}
 	
+	/** Get the API url for server to server requests.
+	 * @return the API url.
+	 */
 	public URL getApiURL() {
 		return apiURL;
 	}
 
+	/** Get the client ID for the account used to interact with the identity provider.
+	 * @return the client ID.
+	 */
 	public String getClientID() {
 		return clientID;
 	}
 
-	public String getClientSecrect() {
-		return clientSecrect;
+	/** Get the client secret for the account used to interact with the identity provider.
+	 * @return the client secret.
+	 */
+	public String getClientSecret() {
+		return clientSecret;
 	}
 
+	/** Get the image URI of an image to associate with the identity provider.
+	 * @return the image URI.
+	 */
 	public URI getImageURI() {
 		return imageURI;
 	}
 
+	/** Get the URL to which the identity provider should redirect when a login is in process.
+	 * @return the login redirect url.
+	 */
 	public URL getLoginRedirectURL() {
 		return loginRedirectURL;
 	}
 	
+	/** Get the URL to which the identity provider should redirect when an account link is in
+	 * process.
+	 * @return the link url.
+	 */
 	public URL getLinkRedirectURL() {
 		return linkRedirectURL;
+	}
+	
+	/** Thrown when the creating an identity provider configuration fails due to bad input.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	@SuppressWarnings("serial")
+	public static class IdentityProviderConfigurationException extends Exception {
+		
+		public IdentityProviderConfigurationException(final String message) {
+			super(message);
+		}
+		
+		public IdentityProviderConfigurationException(
+				final String message,
+				final Throwable cause) {
+			super(message, cause);
+		}
 	}
 }

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderConfigurator.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderConfigurator.java
@@ -1,9 +1,20 @@
 package us.kbase.auth2.lib.identity;
 
+/** A configuration agent for an identity provider. Given an identity provider configuration,
+ * properly creates and configures an identity provider.
+ * @author gaprice@lbl.gov
+ *
+ */
 public interface IdentityProviderConfigurator {
 	
-	//TODO JAVADOC
-	
+	/** Given a configuration, creates an identity provider.
+	 * @param cfg the identity provider configuration.
+	 * @return the new identity provider.
+	 */
 	IdentityProvider configure(IdentityProviderConfig cfg);
+	
+	/** Get the name of the identity provider this configurator is able to configure.
+	 * @return the identity provider name.
+	 */
 	String getProviderName();
 }

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderFactory.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderFactory.java
@@ -14,13 +14,10 @@ public class IdentityProviderFactory {
 	//TODO TESTS
 	//TODO JAVADOC
 	
-	private static final IdentityProviderFactory instance =
-			new IdentityProviderFactory();
+	private static final IdentityProviderFactory instance = new IdentityProviderFactory();
 	
-	private final TreeMap<String, IdentityProvider> providers =
-			new TreeMap<>();
-	private final Map<String, IdentityProviderConfigurator> configs =
-			new HashMap<>();
+	private final TreeMap<String, IdentityProvider> providers = new TreeMap<>();
+	private final Map<String, IdentityProviderConfigurator> configs = new HashMap<>();
 	private boolean locked = false;
 	
 	
@@ -35,10 +32,8 @@ public class IdentityProviderFactory {
 		if (conf == null) {
 			throw new NullPointerException("conf");
 		}
-		if (conf.getProviderName() == null ||
-				conf.getProviderName().isEmpty()) {
-			throw new IllegalArgumentException(
-					"The configurator name cannot be null or empty");
+		if (conf.getProviderName() == null || conf.getProviderName().isEmpty()) {
+			throw new IllegalArgumentException("The configurator name cannot be null or empty");
 		}
 		configs.put(conf.getProviderName(), conf);
 	}
@@ -49,8 +44,7 @@ public class IdentityProviderFactory {
 			throw new IllegalStateException("Factory is locked");
 		}
 		if (!configs.containsKey(cfg.getIdentityProviderName())) {
-			throw new IllegalArgumentException(
-					"Register a configurator before attempting to " +
+			throw new IllegalArgumentException("Register a configurator before attempting to " +
 					"configure it");
 		}
 		providers.put(cfg.getIdentityProviderName(),
@@ -70,8 +64,7 @@ public class IdentityProviderFactory {
 	}
 	
 	public List<String> getProviders() {
-		return Collections.unmodifiableList(new ArrayList<>(
-				providers.navigableKeySet()));
+		return Collections.unmodifiableList(new ArrayList<>(providers.navigableKeySet()));
 	}
 
 	public void lock() {

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
@@ -8,19 +8,25 @@ import java.util.TreeMap;
 
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 
+/** A set of identity providers.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class IdentityProviderSet {
-	
-	//TODO TESTS
-	//TODO JAVADOC
 	
 	private final TreeMap<String, IdentityProvider> providers = new TreeMap<>();
 	private final Map<String, IdentityProviderConfigurator> configs = new HashMap<>();
 	private boolean locked = false;
 	
 	
+	/** Create an identity provider set. */
 	public IdentityProviderSet() {}
 	
-	// note overwrites configs with the same name
+	/** Register an identity provider configurator. A configurator must be registered before a 
+	 * provider can be configured. Registering a configurator with the same provider name as a
+	 * previously registered configurator overwrites the old configurator.
+	 * @param conf the configurator.
+	 */
 	public void register(final IdentityProviderConfigurator conf) {
 		if (conf == null) {
 			throw new NullPointerException("conf");
@@ -31,19 +37,31 @@ public class IdentityProviderSet {
 		configs.put(conf.getProviderName(), conf);
 	}
 	
-	// note overwrites providers with the same name
+	/** Configure an identity provider. The configuration and configurator are matched by the 
+	 * provider name. Reconfiguring an identity provider replaces the old instance of the identity
+	 * provider. 
+	 * @param cfg the identity provider configuration.
+	 */
 	public void configure(final IdentityProviderConfig cfg) {
 		if (locked) {
 			throw new IllegalStateException("Factory is locked");
 		}
+		if (cfg == null) {
+			throw new NullPointerException("cfg");
+		}
 		if (!configs.containsKey(cfg.getIdentityProviderName())) {
-			throw new IllegalArgumentException("Register a configurator before attempting to " +
-					"configure it");
+			throw new IllegalStateException("Register a configurator for identity provider " + 
+					cfg.getIdentityProviderName() + " before attempting to configure it");
 		}
 		providers.put(cfg.getIdentityProviderName(),
 				configs.get(cfg.getIdentityProviderName()).configure(cfg));
 	}
 	
+	/** Get a provider from the provider name.
+	 * @param name the provider name.
+	 * @return an identity provider.
+	 * @throws NoSuchIdentityProviderException if no provider exists that has the given name.
+	 */
 	public IdentityProvider getProvider(final String name)
 			throws NoSuchIdentityProviderException {
 		if (name == null) {
@@ -56,14 +74,26 @@ public class IdentityProviderSet {
 		
 	}
 	
+	/** Returns a sorted list of the currently configured providers.
+	 * @return a list of the providers.
+	 */
 	public List<String> getProviders() {
 		return new ArrayList<>(providers.navigableKeySet());
 	}
 
+	/** Locks this provider set, preventing any more configuration events - thus, the currently
+	 * configured identity providers are rendered immutable.
+	 * 
+	 * Configurators may still be registered, but this has no effect since configuration events
+	 * are prevented.
+	 */
 	public void lock() {
 		locked = true;
 	}
 	
+	/** Check if this provider set is locked.
+	 * @return true if the provider set is locked, false otherwise.
+	 */
 	public boolean isLocked() {
 		return locked;
 	}

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
@@ -1,7 +1,6 @@
 package us.kbase.auth2.lib.identity;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,30 +8,24 @@ import java.util.TreeMap;
 
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 
-public class IdentityProviderFactory {
+public class IdentityProviderSet {
 	
 	//TODO TESTS
 	//TODO JAVADOC
-	
-	private static final IdentityProviderFactory instance = new IdentityProviderFactory();
 	
 	private final TreeMap<String, IdentityProvider> providers = new TreeMap<>();
 	private final Map<String, IdentityProviderConfigurator> configs = new HashMap<>();
 	private boolean locked = false;
 	
 	
-	public static IdentityProviderFactory getInstance() {
-		return instance;
-	}
-	
-	private IdentityProviderFactory() {}
+	public IdentityProviderSet() {}
 	
 	// note overwrites configs with the same name
 	public void register(final IdentityProviderConfigurator conf) {
 		if (conf == null) {
 			throw new NullPointerException("conf");
 		}
-		if (conf.getProviderName() == null || conf.getProviderName().isEmpty()) {
+		if (conf.getProviderName() == null || conf.getProviderName().trim().isEmpty()) {
 			throw new IllegalArgumentException("The configurator name cannot be null or empty");
 		}
 		configs.put(conf.getProviderName(), conf);
@@ -64,7 +57,7 @@ public class IdentityProviderFactory {
 	}
 	
 	public List<String> getProviders() {
-		return Collections.unmodifiableList(new ArrayList<>(providers.navigableKeySet()));
+		return new ArrayList<>(providers.navigableKeySet());
 	}
 
 	public void lock() {

--- a/src/us/kbase/auth2/service/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/service/kbase/KBaseAuthConfig.java
@@ -17,6 +17,7 @@ import org.ini4j.Ini;
 import org.slf4j.LoggerFactory;
 
 import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig.IdentityProviderConfigurationException;
 import us.kbase.auth2.service.AuthStartupConfig;
 import us.kbase.auth2.service.SLF4JAutoLogger;
 import us.kbase.auth2.service.exceptions.AuthConfigurationException;
@@ -27,6 +28,8 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	
 	//TODO JAVADOC
 	//TODO TEST unittests
+	
+	//TODO DOCs document deploy.cfg.example
 	
 	private static final String KB_DEP = "KB_DEPLOYMENT_CONFIG";
 	private static final String CFG_LOC ="authserv2";
@@ -133,11 +136,11 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 			try {
 				ips.add(new IdentityProviderConfig(p, login, api,
 						cliid, clisec, imgURL, loginRedirect, linkRedirect));
-			} catch (IllegalArgumentException e) {
+			} catch (IdentityProviderConfigurationException e) {
 				//TODO TEST ^ is ok in a url, but not in a URI
 				throw new AuthConfigurationException(String.format(
 						"Error building configuration for provider %s in " +
-						"section %s or config file %s: %s",
+						"section %s of config file %s: %s",
 						p, CFG_LOC, cfg.get(TEMP_KEY_CFG_FILE)));
 			}
 		}

--- a/src/us/kbase/auth2/service/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/service/kbase/KBaseAuthConfig.java
@@ -89,10 +89,8 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 				mongop = null; //gc
 				throw new AuthConfigurationException(String.format(
 						"Must provide both %s and %s params in config file " +
-						"%s section %s if MongoDB authentication is to be " +
-						"used",
-						KEY_MONGO_USER, KEY_MONGO_PWD,
-						cfg.get(TEMP_KEY_CFG_FILE), CFG_LOC));
+						"%s section %s if MongoDB authentication is to be used",
+						KEY_MONGO_USER, KEY_MONGO_PWD, cfg.get(TEMP_KEY_CFG_FILE), CFG_LOC));
 			}
 			mongoPwd = mongop == null ? null : mongop.toCharArray();
 			cookieName = getString(KEY_COOKIE_NAME, cfg, true);
@@ -121,21 +119,17 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 				continue;
 			}
 			final String pre = KEY_PREFIX_ID_PROVS + p;
-			final URI imgURL = getURI( // relative url
-					pre + KEY_SUFFIX_ID_PROVS_IMG, cfg);
-			final String cliid = getString(
-					pre + KEY_SUFFIX_ID_PROVS_CLIENT_ID, cfg, true);
-			final String clisec = getString(
-					pre + KEY_SUFFIX_ID_PROVS_CLIENT_SEC, cfg, true);
+			 // relative url
+			final URI imgURL = getURI(pre + KEY_SUFFIX_ID_PROVS_IMG, cfg);
+			final String cliid = getString(pre + KEY_SUFFIX_ID_PROVS_CLIENT_ID, cfg, true);
+			final String clisec = getString(pre + KEY_SUFFIX_ID_PROVS_CLIENT_SEC, cfg, true);
 			final URL login = getURL(pre + KEY_SUFFIX_ID_PROVS_LOGIN_URL, cfg);
 			final URL api = getURL(pre + KEY_SUFFIX_ID_PROVS_API_URL, cfg);
-			final URL loginRedirect = getURL(
-					pre + KEY_SUFFIX_ID_PROVS_LOGIN_REDIRECT, cfg);
-			final URL linkRedirect = getURL(
-					pre + KEY_SUFFIX_ID_PROVS_LINK_REDIRECT, cfg);
+			final URL loginRedirect = getURL(pre + KEY_SUFFIX_ID_PROVS_LOGIN_REDIRECT, cfg);
+			final URL linkRedirect = getURL(pre + KEY_SUFFIX_ID_PROVS_LINK_REDIRECT, cfg);
 			try {
-				ips.add(new IdentityProviderConfig(p, login, api,
-						cliid, clisec, imgURL, loginRedirect, linkRedirect));
+				ips.add(new IdentityProviderConfig(
+						p, login, api, cliid, clisec, imgURL, loginRedirect, linkRedirect));
 			} catch (IdentityProviderConfigurationException e) {
 				//TODO TEST ^ is ok in a url, but not in a URI
 				throw new AuthConfigurationException(String.format(

--- a/src/us/kbase/test/auth2/TestCommon.java
+++ b/src/us/kbase/test/auth2/TestCommon.java
@@ -11,7 +11,7 @@ public class TestCommon {
 			final Exception got,
 			final Exception expected) {
 		assertThat("incorrect exception. trace:\n" + ExceptionUtils.getStackTrace(got),
-				got.getLocalizedMessage(), is(expected.getLocalizedMessage()));
+				got.getMessage(), is(expected.getMessage()));
 		assertThat("incorrect exception type", got, is(expected.getClass()));
 	}
 	

--- a/src/us/kbase/test/auth2/lib/identity/IdentityProviderConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/IdentityProviderConfigTest.java
@@ -1,0 +1,130 @@
+package us.kbase.test.auth2.lib.identity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig.IdentityProviderConfigurationException;
+
+public class IdentityProviderConfigTest {
+
+	@Test
+	public void goodInput() throws Exception {
+		final IdentityProviderConfig c = new IdentityProviderConfig(
+				"MyProv",
+				new URL("http://login.com"),
+				new URL("http://api.com"),
+				"foo",
+				"bar",
+				new URI("http://someimage.com"),
+				new URL("https://loginredirect.com"),
+				new URL("https://linkredirect.com"));
+		assertThat("incorrect api URL", c.getApiURL(), is(new URL("http://api.com")));
+		assertThat("incorrect client id", c.getClientID(), is("foo"));
+		assertThat("incorrect client secret", c.getClientSecret(), is("bar"));
+		assertThat("incorrect provider name", c.getIdentityProviderName(), is("MyProv"));
+		assertThat("incorrect image URI", c.getImageURI(), is(new URI("http://someimage.com")));
+		assertThat("incorrect link redirect URL", c.getLinkRedirectURL(),
+				is(new URL("https://linkredirect.com")));
+		assertThat("incorrect login redirect URL", c.getLoginRedirectURL(),
+				is(new URL("https://loginredirect.com")));
+		assertThat("incorrect login URL", c.getLoginURL(), is(new URL("http://login.com")));
+	}
+	
+	@Test
+	public void badInput() throws Exception {
+		final String name = "MyProv";
+		final URL login = new URL("http://login.com");
+		final URL api = new URL("http://api.com");
+		final String clientID = "foo";
+		final String clientSecret = "bar";
+		final URI image = new URI("http://someimage.com");
+		final URL loginRedirect = new URL("https://loginredirect.com");
+		final URL linkRedirect = new URL("https://linkredirect.com");
+		
+		final String exp = " for " + name + " identity provider cannot be null";
+		final String strexp = exp + " or empty";
+		
+		// id provider name
+		failCreateConfig(null, login, api, clientID, clientSecret, image, loginRedirect,
+				linkRedirect, "Identity provider name cannot be null or empty");
+		failCreateConfig("\t", login, api, clientID, clientSecret, image, loginRedirect,
+				linkRedirect, "Identity provider name cannot be null or empty");
+		
+		//login url
+		failCreateConfig(name, null, api, clientID, clientSecret, image, loginRedirect,
+				linkRedirect, "Login URL" + exp);
+		failCreateConfig(name, new URL("http://login^foo.com"), api, clientID, clientSecret,
+				image, loginRedirect, linkRedirect,
+				"Login URL http://login^foo.com for MyProv identity provider is not a valid " +
+				"URI: Illegal character in authority at index 7: http://login^foo.com");
+		
+		//api url
+		failCreateConfig(name, login, null, clientID, clientSecret, image, loginRedirect,
+				linkRedirect, "API URL" + exp);
+		failCreateConfig(name, login, new URL("http://api^fo.com"), clientID, clientSecret,
+				image, loginRedirect, linkRedirect,
+				"API URL http://api^fo.com for MyProv identity provider is not a valid " +
+				"URI: Illegal character in authority at index 7: http://api^fo.com");
+				// not sure why the index is the same as the login url
+		
+		//client ID
+		failCreateConfig(name, login, api, null, clientSecret, image, loginRedirect,
+				linkRedirect, "Client ID" + strexp);
+		failCreateConfig(name, login, api, "", clientSecret, image, loginRedirect,
+				linkRedirect, "Client ID" + strexp);
+		
+		//client secret
+		failCreateConfig(name, login, api, clientID, null, image, loginRedirect,
+				linkRedirect, "Client secret" + strexp);
+		failCreateConfig(name, login, api, clientID, " ", image, loginRedirect,
+				linkRedirect, "Client secret" + strexp);
+		
+		//image uri
+		failCreateConfig(name, login, api, clientID, clientSecret, null, loginRedirect,
+				linkRedirect, "Image URI" + exp);
+		
+		//login redirect
+		failCreateConfig(name, login, api, clientID, clientSecret, image, null,
+				linkRedirect, "Login redirect URL" + exp);
+		failCreateConfig(name, login, api, clientID, clientSecret,
+				image, new URL("http://lr^f.com"), linkRedirect,
+				"Login redirect URL http://lr^f.com for MyProv identity provider is not a valid " +
+				"URI: Illegal character in authority at index 7: http://lr^f.com");
+		
+		//link redirect
+		failCreateConfig(name, login, api, clientID, clientSecret, image, login,
+				null, "Link redirect URL" + exp);
+		failCreateConfig(name, login, api, clientID, clientSecret,
+				image, login, new URL("http://linkredir^foobar.com"),
+				"Link redirect URL http://linkredir^foobar.com for MyProv identity provider is " +
+				"not a valid URI: Illegal character in authority at index 7: " +
+				"http://linkredir^foobar.com");
+	}
+
+	private void failCreateConfig(
+			final String name,
+			final URL login,
+			final URL api,
+			final String clientID,
+			final String clientSecret,
+			final URI image,
+			final URL loginRedirect,
+			final URL linkRedirect,
+			final String exception) {
+		try {
+			new IdentityProviderConfig(name, login, api, clientID, clientSecret, image,
+					loginRedirect, linkRedirect);
+			fail("created bad id provider config");
+		} catch (IdentityProviderConfigurationException e) {
+			assertThat("incorrect exception message", e.getMessage(), is(exception));
+		}
+	}
+	
+}

--- a/src/us/kbase/test/auth2/lib/identity/IdentityProviderSetTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/IdentityProviderSetTest.java
@@ -1,0 +1,311 @@
+package us.kbase.test.auth2.lib.identity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
+import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
+import us.kbase.auth2.lib.identity.IdentityProvider;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig.IdentityProviderConfigurationException;
+import us.kbase.auth2.lib.identity.IdentityProviderConfigurator;
+import us.kbase.auth2.lib.identity.IdentityProviderSet;
+import us.kbase.auth2.lib.identity.RemoteIdentity;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.test.auth2.TestCommon;
+
+public class IdentityProviderSetTest {
+	
+	private static final IdentityProviderConfig CFG1;
+	private static final IdentityProviderConfig CFG2;
+	static {
+		try {
+			CFG1 = new IdentityProviderConfig(
+					"Test",
+					new URL("http://login.com"),
+					new URL("http://api.com"),
+					"foo",
+					"bar",
+					new URI("https://image.com"),
+					new URL("http://loginre.com"),
+					new URL("http://linkre.com"));
+			CFG2 = new IdentityProviderConfig(
+					"Test2",
+					new URL("http://login2.com"),
+					new URL("http://api2.com"),
+					"foo2",
+					"bar2",
+					new URI("https://image2.com"),
+					new URL("http://loginre2.com"),
+					new URL("http://linkre2.com"));
+		} catch (IdentityProviderConfigurationException | URISyntaxException |
+				MalformedURLException e) {
+			throw new RuntimeException("Fix your tests scrub", e);
+		}
+	}
+
+	private static class TestProviderConfigurator implements IdentityProviderConfigurator {
+
+		private final String name;
+		private final boolean test1;
+		
+		public TestProviderConfigurator(final String name, final boolean test1) {
+			this.name = name;
+			this.test1 = test1;
+		}
+		
+		@Override
+		public IdentityProvider configure(final IdentityProviderConfig cfg) {
+			if (test1) {
+				return new TestProvider(cfg);
+			}
+			return new TestProvider2(cfg);
+		}
+
+		@Override
+		public String getProviderName() {
+			return name;
+		}
+		
+	}
+	
+	private static class TestProvider implements IdentityProvider {
+
+		final IdentityProviderConfig cfg;
+		
+		public TestProvider(final IdentityProviderConfig cfg) {
+			this.cfg = cfg;
+		}
+
+		@Override
+		public String getProviderName() {
+			return cfg.getIdentityProviderName();
+		}
+
+		@Override
+		public URI getImageURI() {
+			return cfg.getImageURI();
+		}
+
+		@Override
+		public URL getLoginURL(final String state, final boolean link) {
+			return cfg.getLoginURL();
+		}
+
+		@Override
+		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
+				throws IdentityRetrievalException {
+			return new HashSet<>(Arrays.asList(new RemoteIdentity(
+					new RemoteIdentityID(cfg.getClientID(), cfg.getClientSecret()),
+					new RemoteIdentityDetails(cfg.getApiURL().toString(),
+							cfg.getLoginRedirectURL().toString(),
+							cfg.getLinkRedirectURL().toString()))));
+		}
+	}
+	
+	private static class TestProvider2 implements IdentityProvider {
+
+		final IdentityProviderConfig cfg;
+		
+		public TestProvider2(final IdentityProviderConfig cfg) {
+			this.cfg = cfg;
+		}
+
+		@Override
+		public String getProviderName() {
+			return cfg.getIdentityProviderName();
+		}
+
+		@Override
+		public URI getImageURI() {
+			return cfg.getImageURI();
+		}
+
+		@Override
+		public URL getLoginURL(final String state, final boolean link) {
+			return cfg.getLoginURL();
+		}
+
+		@Override
+		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
+				throws IdentityRetrievalException {
+			return new HashSet<>();
+		}
+	}
+	
+	@Test
+	public void registerAndLock() throws Exception {
+		final IdentityProviderSet ids = new IdentityProviderSet();
+		ids.register(new TestProviderConfigurator("Test", true));
+		ids.configure(CFG1);
+		assertThat("incorrect provider list", ids.getProviders(), is(Arrays.asList("Test")));
+		assertThat("incorrect locked state", ids.isLocked(), is(false));
+		final IdentityProvider idp = ids.getProvider("Test");
+		assertThat("incorrect provider name", idp.getProviderName(), is("Test"));
+		assertThat("incorrect image URI", idp.getImageURI(), is(new URI("https://image.com")));
+		assertThat("incorrect login URL", idp.getLoginURL("foo", false),
+				is(new URL("http://login.com")));
+		assertThat("incorrect number of identities", idp.getIdentities("foo", false).size(),
+				is(1));
+		
+		final RemoteIdentity ri = idp.getIdentities("foo", false).iterator().next();
+		assertThat("incorrect provider", ri.getRemoteID().getProvider(), is("foo"));
+		assertThat("incorrect id", ri.getRemoteID().getId(), is("bar"));
+		assertThat("incorrect username", ri.getDetails().getUsername(), is("http://api.com"));
+		assertThat("incorrect fullname", ri.getDetails().getFullname(), is("http://loginre.com"));
+		assertThat("incorrect email", ri.getDetails().getEmail(), is("http://linkre.com"));
+		
+		ids.lock();
+		assertThat("incorrect locked state", ids.isLocked(), is(true));
+		ids.register(new TestProviderConfigurator("Test2", false));
+		try {
+			ids.configure(CFG2);
+			fail("registered on locked set");
+		} catch (IllegalStateException e) {
+			assertThat("incorrect exception message", e.getMessage(), is("Factory is locked"));
+		}
+		assertThat("incorrect provider list", ids.getProviders(), is(Arrays.asList("Test")));
+	}
+	
+	@Test
+	public void multipleProviders() throws Exception {
+		final IdentityProviderSet ids = new IdentityProviderSet();
+		ids.register(new TestProviderConfigurator("Test2", false));
+		ids.register(new TestProviderConfigurator("Test", true));
+		ids.configure(CFG2);
+		ids.configure(CFG1);
+		
+		assertThat("incorrect provider list", ids.getProviders(),
+				is(Arrays.asList("Test", "Test2")));
+		assertThat("incorrect locked state", ids.isLocked(), is(false));
+		final IdentityProvider idp = ids.getProvider("Test");
+		assertThat("incorrect provider name", idp.getProviderName(), is("Test"));
+		assertThat("incorrect image URI", idp.getImageURI(), is(new URI("https://image.com")));
+		assertThat("incorrect login URL", idp.getLoginURL("foo", false),
+				is(new URL("http://login.com")));
+		assertThat("incorrect number of identities", idp.getIdentities("foo", false).size(),
+				is(1));
+		
+		final IdentityProvider idp2 = ids.getProvider("Test2");
+		assertThat("incorrect provider name", idp2.getProviderName(), is("Test2"));
+		assertThat("incorrect image URI", idp2.getImageURI(), is(new URI("https://image2.com")));
+		assertThat("incorrect login URL", idp2.getLoginURL("foo", false),
+				is(new URL("http://login2.com")));
+		assertThat("incorrect number of identities", idp2.getIdentities("foo", false).size(),
+				is(0));
+	}
+	
+	@Test
+	public void overwrite() throws Exception {
+		final IdentityProviderSet ids = new IdentityProviderSet();
+		ids.register(new TestProviderConfigurator("Test", true));
+		ids.configure(CFG1);
+		
+		assertThat("incorrect provider list", ids.getProviders(), is(Arrays.asList("Test")));
+		assertThat("incorrect locked state", ids.isLocked(), is(false));
+		final IdentityProvider idp = ids.getProvider("Test");
+		assertThat("incorrect provider name", idp.getProviderName(), is("Test"));
+		assertThat("incorrect image URI", idp.getImageURI(), is(new URI("https://image.com")));
+		assertThat("incorrect login URL", idp.getLoginURL("foo", false),
+				is(new URL("http://login.com")));
+		assertThat("incorrect number of identities", idp.getIdentities("foo", false).size(),
+				is(1));
+		
+		ids.register(new TestProviderConfigurator("Test", false));
+		ids.configure(new IdentityProviderConfig(
+				"Test",
+				new URL("http://login2.com"),
+				new URL("http://api2.com"),
+				"foo2",
+				"bar2",
+				new URI("https://image2.com"),
+				new URL("http://loginre2.com"),
+				new URL("http://linkre2.com")));
+		assertThat("incorrect provider list", ids.getProviders(), is(Arrays.asList("Test")));
+		assertThat("incorrect locked state", ids.isLocked(), is(false));
+		final IdentityProvider idp2 = ids.getProvider("Test");
+		assertThat("incorrect provider name", idp2.getProviderName(), is("Test"));
+		assertThat("incorrect image URI", idp2.getImageURI(), is(new URI("https://image2.com")));
+		assertThat("incorrect login URL", idp2.getLoginURL("foo", false),
+				is(new URL("http://login2.com")));
+		assertThat("incorrect number of identities", idp2.getIdentities("foo", false).size(),
+				is(0));
+	}
+
+	@Test
+	public void failRegisterConfigurator() throws Exception {
+		failRegister(null, new NullPointerException("conf"));
+		final IllegalArgumentException e = new IllegalArgumentException(
+				"The configurator name cannot be null or empty");
+		failRegister(new TestProviderConfigurator(null, false), e);
+		failRegister(new TestProviderConfigurator("\t ", false), e);
+	}
+	
+	private void failRegister(
+			final IdentityProviderConfigurator cfg,
+			final Exception exception) {
+		final IdentityProviderSet set = new IdentityProviderSet();
+		try {
+			set.register(cfg);
+			fail("registered bad config");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, exception);
+		}
+	}
+	
+	@Test
+	public void failConfigure() throws Exception {
+		final IdentityProviderSet set = new IdentityProviderSet();
+		set.register(new TestProviderConfigurator("Test", true));
+		failConfig(set, null, new NullPointerException("cfg"));
+		failConfig(set, CFG2, new IllegalStateException(
+				"Register a configurator for identity provider Test2 before attempting to " +
+				"configure it"));
+	}
+	
+	private void failConfig(
+			final IdentityProviderSet ids,
+			final IdentityProviderConfig cfg,
+			final Exception exception) {
+		try {
+			ids.configure(cfg);
+			fail("configured with bad config");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, exception);
+		}
+	}
+	
+	@Test
+	public void failGetProvider() throws Exception {
+		final IdentityProviderSet ids = new IdentityProviderSet();
+		ids.register(new TestProviderConfigurator("Test", true));
+		failGet(ids, null, new NoSuchIdentityProviderException("Provider name cannot be null"));
+		failGet(ids, "", new NoSuchIdentityProviderException(""));
+		failGet(ids, "foo", new NoSuchIdentityProviderException("foo"));
+	}
+	
+	private void failGet(
+			final IdentityProviderSet ids,
+			final String provider,
+			final Exception exception) {
+		try {
+			ids.getProvider(provider);
+			fail("Got bad provider");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, exception);
+		}
+	}
+	
+}


### PR DESCRIPTION
Refactors the identity provider factory to rename to set and remove singleton pattern. The service itself now manages a single instance which make the set possible to test.

Adds tests for identity provider set and config.