### PR TITLE
Add remote identity tests + more

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -195,6 +195,7 @@
       <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
       <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
       <test name="us.kbase.test.auth2.lib.identity.IdentityProviderSetTest"/>
+      <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>

--- a/build.xml
+++ b/build.xml
@@ -180,7 +180,7 @@
              splitindex="true"
              use="true"
              version="true">
-      <link href="http://download.oracle.com/javase/8/docs/api/"/>
+      <link href="http://docs.oracle.com/javase/8/docs/api/"/>
     </javadoc>
   </target>
 	

--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import us.kbase.auth2.lib.identity.RemoteIdentity;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
 public abstract class AuthUser {
@@ -22,7 +22,7 @@ public abstract class AuthUser {
 	private final UserName userName;
 	private final Set<Role> roles;
 	private Set<Role> canGrantRoles = null;
-	private final Set<RemoteIdentityWithID> identities;
+	private final Set<RemoteIdentityWithLocalID> identities;
 	private final long created;
 	private final Long lastLogin;
 	private final UserDisabledState disabledState;
@@ -31,7 +31,7 @@ public abstract class AuthUser {
 			final UserName userName,
 			final EmailAddress email,
 			final DisplayName displayName,
-			Set<RemoteIdentityWithID> identities,
+			Set<RemoteIdentityWithLocalID> identities,
 			Set<Role> roles,
 			final Date created,
 			final Date lastLogin,
@@ -107,7 +107,7 @@ public abstract class AuthUser {
 
 	public abstract Set<String> getCustomRoles() throws AuthStorageException;
 	
-	public Set<RemoteIdentityWithID> getIdentities() {
+	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return identities;
 	}
 	
@@ -139,8 +139,8 @@ public abstract class AuthUser {
 		return disabledState;
 	}
 
-	public RemoteIdentityWithID getIdentity(final RemoteIdentity ri) {
-		for (final RemoteIdentityWithID rid: identities) {
+	public RemoteIdentityWithLocalID getIdentity(final RemoteIdentity ri) {
+		for (final RemoteIdentityWithLocalID rid: identities) {
 			if (rid.getRemoteID().equals(ri.getRemoteID())) {
 				return rid;
 			}

--- a/src/us/kbase/auth2/lib/LinkIdentities.java
+++ b/src/us/kbase/auth2/lib/LinkIdentities.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 
 public class LinkIdentities {
 	
@@ -12,11 +12,11 @@ public class LinkIdentities {
 	//TODO JAVADOC
 	
 	private final AuthUser user;
-	private final Set<RemoteIdentityWithID> idents;
+	private final Set<RemoteIdentityWithLocalID> idents;
 
 	public LinkIdentities(
 			final AuthUser user,
-			Set<RemoteIdentityWithID> ids) {
+			Set<RemoteIdentityWithLocalID> ids) {
 		if (user == null) {
 			throw new NullPointerException("user");
 		}
@@ -31,7 +31,7 @@ public class LinkIdentities {
 		return user;
 	}
 
-	public Set<RemoteIdentityWithID> getIdentities() {
+	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return idents;
 	}
 

--- a/src/us/kbase/auth2/lib/LoginState.java
+++ b/src/us/kbase/auth2/lib/LoginState.java
@@ -6,16 +6,16 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 
 public class LoginState {
 
 	//TODO JAVADOC
 	//TODO TEST
 	
-	private final Map<UserName, Set<RemoteIdentityWithID>> userIDs = new HashMap<>();
+	private final Map<UserName, Set<RemoteIdentityWithLocalID>> userIDs = new HashMap<>();
 	private final Map<UserName, AuthUser> users = new HashMap<>();
-	private final Set<RemoteIdentityWithID> noUser = new HashSet<>();
+	private final Set<RemoteIdentityWithLocalID> noUser = new HashSet<>();
 	private final String provider;
 	private final boolean nonAdminLoginAllowed;
 
@@ -37,7 +37,7 @@ public class LoginState {
 		return Role.isAdmin(users.get(name).getRoles());
 	}
 	
-	public Set<RemoteIdentityWithID> getIdentities() {
+	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return Collections.unmodifiableSet(noUser);
 	}
 	
@@ -56,7 +56,7 @@ public class LoginState {
 		}
 	}
 	
-	public Set<RemoteIdentityWithID> getIdentities(final UserName name) {
+	public Set<RemoteIdentityWithLocalID> getIdentities(final UserName name) {
 		checkUser(name);
 		return Collections.unmodifiableSet(userIDs.get(name));
 	}
@@ -73,7 +73,7 @@ public class LoginState {
 			ls = new LoginState(provider, nonAdminLoginAllowed);
 		}
 
-		public void addIdentity(final RemoteIdentityWithID remoteID) {
+		public void addIdentity(final RemoteIdentityWithLocalID remoteID) {
 			if (remoteID == null) {
 				throw new NullPointerException("remoteID");
 			}
@@ -81,14 +81,14 @@ public class LoginState {
 			ls.noUser.add(remoteID);
 		}
 
-		private void checkProvider(final RemoteIdentityWithID remoteID) {
+		private void checkProvider(final RemoteIdentityWithLocalID remoteID) {
 			if (!ls.provider.equals(remoteID.getRemoteID().getProvider())) {
 				throw new IllegalStateException(
 						"Cannot have multiple providers in the same login state");
 			}
 		}
 
-		public void addUser(final AuthUser user, final RemoteIdentityWithID remoteID) {
+		public void addUser(final AuthUser user, final RemoteIdentityWithLocalID remoteID) {
 			if (user == null) {
 				throw new NullPointerException("user");
 			}

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -4,7 +4,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 
 public class NewUser extends AuthUser {
 	
@@ -15,7 +15,7 @@ public class NewUser extends AuthUser {
 			final UserName userName,
 			final EmailAddress email,
 			final DisplayName displayName,
-			final Set<RemoteIdentityWithID> identities,
+			final Set<RemoteIdentityWithLocalID> identities,
 			final Date created,
 			final Date lastLogin) {
 		super(userName, email, displayName, identities, Collections.emptySet(), created,

--- a/src/us/kbase/auth2/lib/ViewableUser.java
+++ b/src/us/kbase/auth2/lib/ViewableUser.java
@@ -3,7 +3,7 @@ package us.kbase.auth2.lib;
 import java.util.Date;
 import java.util.Set;
 
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
 /* this is a user profile that the requesting user has permission to view. Fields which the
@@ -67,7 +67,7 @@ public class ViewableUser {
 		return user == null ? null : user.getCustomRoles();
 	}
 	
-	public Set<RemoteIdentityWithID> getIdentities() {
+	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return user == null ? null : user.getIdentities();
 	}
 	

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderSet.java
@@ -27,7 +27,7 @@ public class IdentityProviderSet {
 	 * previously registered configurator overwrites the old configurator.
 	 * @param conf the configurator.
 	 */
-	public void register(final IdentityProviderConfigurator conf) {
+	public IdentityProviderSet register(final IdentityProviderConfigurator conf) {
 		if (conf == null) {
 			throw new NullPointerException("conf");
 		}
@@ -35,6 +35,7 @@ public class IdentityProviderSet {
 			throw new IllegalArgumentException("The configurator name cannot be null or empty");
 		}
 		configs.put(conf.getProviderName(), conf);
+		return this;
 	}
 	
 	/** Configure an identity provider. The configuration and configurator are matched by the 
@@ -42,7 +43,7 @@ public class IdentityProviderSet {
 	 * provider. 
 	 * @param cfg the identity provider configuration.
 	 */
-	public void configure(final IdentityProviderConfig cfg) {
+	public IdentityProviderSet configure(final IdentityProviderConfig cfg) {
 		if (locked) {
 			throw new IllegalStateException("Factory is locked");
 		}
@@ -55,6 +56,7 @@ public class IdentityProviderSet {
 		}
 		providers.put(cfg.getIdentityProviderName(),
 				configs.get(cfg.getIdentityProviderName()).configure(cfg));
+		return this;
 	}
 	
 	/** Get a provider from the provider name.
@@ -87,8 +89,9 @@ public class IdentityProviderSet {
 	 * Configurators may still be registered, but this has no effect since configuration events
 	 * are prevented.
 	 */
-	public void lock() {
+	public IdentityProviderSet lock() {
 		locked = true;
+		return this;
 	}
 	
 	/** Check if this provider set is locked.

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
@@ -25,12 +25,12 @@ public class RemoteIdentity {
 		this.details = details;
 	}
 	
-	public RemoteIdentityWithID withID() {
+	public RemoteIdentityWithLocalID withID() {
 		return withID(UUID.randomUUID());
 	}
 	
-	public RemoteIdentityWithID withID(final UUID id) {
-		return new RemoteIdentityWithID(id, this.remoteID, this.details);
+	public RemoteIdentityWithLocalID withID(final UUID id) {
+		return new RemoteIdentityWithLocalID(id, this.remoteID, this.details);
 	}
 
 	public RemoteIdentityID getRemoteID() {

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
@@ -2,19 +2,24 @@ package us.kbase.auth2.lib.identity;
 
 import java.util.UUID;
 
+/** An identity provided by a 3rd party identity provider such as Google, Globus, etc.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class RemoteIdentity {
-	
-	//TODO JAVADOC
-	//TODO TEST
 	
 	private final RemoteIdentityID remoteID;
 	private final RemoteIdentityDetails details;
 	
+	/** Create a remote identity.
+	 * @param remoteID the immutable ID of this identity. The identity provider should not change
+	 * any part of this ID.
+	 * @param details other details about the identity. These details may be changed by the
+	 * identity provider.
+	 */
 	public RemoteIdentity(
 			final RemoteIdentityID remoteID,
 			final RemoteIdentityDetails details) {
-		super();
-		//TODO INPUT check for null & .trim().isEmpty()
 		if (remoteID == null) {
 			throw new NullPointerException("id");
 		}
@@ -25,18 +30,31 @@ public class RemoteIdentity {
 		this.details = details;
 	}
 	
+	/** Add a new, random local ID to this remote identity. 
+	 * @return this remote identity with a new local ID.
+	 */
 	public RemoteIdentityWithLocalID withID() {
 		return withID(UUID.randomUUID());
 	}
 	
+	/** Associate a pre-existing local ID to this remote identity.
+	 * @param id the ID to associate with this identity.
+	 * @return this remote idenity with the provided local ID.
+	 */
 	public RemoteIdentityWithLocalID withID(final UUID id) {
 		return new RemoteIdentityWithLocalID(id, this.remoteID, this.details);
 	}
 
+	/** Get the immutable ID for this identity.
+	 * @return the ID.
+	 */
 	public RemoteIdentityID getRemoteID() {
 		return remoteID;
 	}
 	
+	/** Get the details for this identity.
+	 * @return the identity details.
+	 */
 	public RemoteIdentityDetails getDetails() {
 		return details;
 	}
@@ -45,8 +63,8 @@ public class RemoteIdentity {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((details == null) ? 0 : details.hashCode());
-		result = prime * result + ((remoteID == null) ? 0 : remoteID.hashCode());
+		result = prime * result + details.hashCode();
+		result = prime * result + remoteID.hashCode();
 		return result;
 	}
 
@@ -62,18 +80,10 @@ public class RemoteIdentity {
 			return false;
 		}
 		RemoteIdentity other = (RemoteIdentity) obj;
-		if (details == null) {
-			if (other.details != null) {
-				return false;
-			}
-		} else if (!details.equals(other.details)) {
+		if (!details.equals(other.details)) {
 			return false;
 		}
-		if (remoteID == null) {
-			if (other.remoteID != null) {
-				return false;
-			}
-		} else if (!remoteID.equals(other.remoteID)) {
+		if (!remoteID.equals(other.remoteID)) {
 			return false;
 		}
 		return true;

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentity.java
@@ -21,7 +21,7 @@ public class RemoteIdentity {
 			final RemoteIdentityID remoteID,
 			final RemoteIdentityDetails details) {
 		if (remoteID == null) {
-			throw new NullPointerException("id");
+			throw new NullPointerException("remoteID");
 		}
 		if (details == null) {
 			throw new NullPointerException("details");

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityDetails.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityDetails.java
@@ -11,12 +11,12 @@ public class RemoteIdentityDetails {
 	
 	public RemoteIdentityDetails(
 			final String username,
-			String fullname,
-			String email) {
+			final String fullname,
+			final String email) {
 		super();
 		if (username == null || username.trim().isEmpty()) {
 			throw new IllegalArgumentException(
-					"fullname cannot be null or empty");
+					"username cannot be null or empty");
 		}
 		this.username = username.trim();
 		if (fullname == null || fullname.trim().isEmpty()) {
@@ -49,7 +49,7 @@ public class RemoteIdentityDetails {
 		int result = 1;
 		result = prime * result + ((email == null) ? 0 : email.hashCode());
 		result = prime * result + ((fullname == null) ? 0 : fullname.hashCode());
-		result = prime * result + ((username == null) ? 0 : username.hashCode());
+		result = prime * result + username.hashCode();
 		return result;
 	}
 
@@ -79,11 +79,7 @@ public class RemoteIdentityDetails {
 		} else if (!fullname.equals(other.fullname)) {
 			return false;
 		}
-		if (username == null) {
-			if (other.username != null) {
-				return false;
-			}
-		} else if (!username.equals(other.username)) {
+		if (!username.equals(other.username)) {
 			return false;
 		}
 		return true;

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityDetails.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityDetails.java
@@ -1,14 +1,21 @@
 package us.kbase.auth2.lib.identity;
 
+/** A set of potentially mutable details about a remote identity. The identity provider may
+ * change these details at any time.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class RemoteIdentityDetails {
 
-	//TODO TEST
-	//TODO JAVADOC
-	
 	private final String username;
 	private final String fullname;
 	private final String email;
 	
+	/** Create a new set of details.
+	 * @param username the user name of the identity.
+	 * @param fullname the full name of the identity. Null is acceptable.
+	 * @param email the email address of the identity. Null is acceptable.
+	 */
 	public RemoteIdentityDetails(
 			final String username,
 			final String fullname,
@@ -31,14 +38,22 @@ public class RemoteIdentityDetails {
 		}
 	}
 
+	/** Get the user name for the identity.
+	 * @return the user name.
+	 */
 	public String getUsername() {
 		return username;
 	}
 
+	/** Get the full name for the identity, or null if none was provided.
+	 * @return the full name.
+	 */
 	public String getFullname() {
 		return fullname;
 	}
-
+	/** Get the email address for the identity, or null if none was provided.
+	 * @return the email address.
+	 */
 	public String getEmail() {
 		return email;
 	}

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityID.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityID.java
@@ -1,30 +1,40 @@
 package us.kbase.auth2.lib.identity;
 
+/** An ID for a remote identity, consisting of the identity provider's name and a unique, immutable
+ * ID for the identity created by the provider.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class RemoteIdentityID {
 
-	//TODO TEST
-	//TODO JAVADOC
-	
 	private final String provider;
 	private final String id;
 
+	/** Create a remote identity ID.
+	 * @param provider the name of the provider that is providing the identity.
+	 * @param id the unique, immutable ID the provider uses for the identity.
+	 */
 	public RemoteIdentityID(final String provider, final String id) {
 		if (provider == null || provider.trim().isEmpty()) {
-			throw new IllegalArgumentException(
-					"provider cannot be null or empty");
+			throw new IllegalArgumentException("provider cannot be null or empty");
 		}
 		if (id == null || id.trim().isEmpty()) {
-			throw new IllegalArgumentException(
-					"id cannot be null or empty");
+			throw new IllegalArgumentException("id cannot be null or empty");
 		}
 		this.provider = provider.trim();
 		this.id = id.trim();
 	}
 	
+	/** Get the provider name.
+	 * @return the provider name.
+	 */
 	public String getProvider() {
 		return provider;
 	}
 	
+	/** Get the identity ID.
+	 * @return the identity ID.
+	 */
 	public String getId() {
 		return id;
 	}
@@ -33,8 +43,8 @@ public class RemoteIdentityID {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
-		result = prime * result + ((provider == null) ? 0 : provider.hashCode());
+		result = prime * result + id.hashCode();
+		result = prime * result + provider.hashCode();
 		return result;
 	}
 	
@@ -50,18 +60,10 @@ public class RemoteIdentityID {
 			return false;
 		}
 		RemoteIdentityID other = (RemoteIdentityID) obj;
-		if (id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		} else if (!id.equals(other.id)) {
+		if (!id.equals(other.id)) {
 			return false;
 		}
-		if (provider == null) {
-			if (other.provider != null) {
-				return false;
-			}
-		} else if (!provider.equals(other.provider)) {
+		if (!provider.equals(other.provider)) {
 			return false;
 		}
 		return true;

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
@@ -57,7 +57,7 @@ public class RemoteIdentityWithLocalID extends RemoteIdentity {
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("RemoteIdentityWithID [id=");
+		builder.append("RemoteIdentityWithLocalID [id=");
 		builder.append(id);
 		builder.append(", getRemoteID()=");
 		builder.append(getRemoteID());

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
@@ -2,13 +2,20 @@ package us.kbase.auth2.lib.identity;
 
 import java.util.UUID;
 
+/** An identity provided by a 3rd party identity provider such as Google, Globus, etc., with an
+ * associated local ID.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class RemoteIdentityWithLocalID extends RemoteIdentity {
-	
-	//TODO JAVADOC
-	//TODO TEST
 	
 	private final UUID id;
 	
+	/** Create a remote identity with a local ID.
+	 * @param id the local ID.
+	 * @param remoteID the remote identity ID.
+	 * @param details the identity details.
+	 */
 	public RemoteIdentityWithLocalID(
 			final UUID id,
 			final RemoteIdentityID remoteID,
@@ -20,6 +27,9 @@ public class RemoteIdentityWithLocalID extends RemoteIdentity {
 		this.id = id;
 	}
 	
+	/** Get the local ID.
+	 * @return the local ID.
+	 */
 	public UUID getID() {
 		return id;
 	}
@@ -28,7 +38,7 @@ public class RemoteIdentityWithLocalID extends RemoteIdentity {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((id == null) ? 0 : id.hashCode());
+		result = prime * result + id.hashCode();
 		return result;
 	}
 
@@ -37,18 +47,11 @@ public class RemoteIdentityWithLocalID extends RemoteIdentity {
 		if (this == obj) {
 			return true;
 		}
-		if (!super.equals(obj)) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
+		if (!super.equals(obj)) { // this'll handle different class
 			return false;
 		}
 		RemoteIdentityWithLocalID other = (RemoteIdentityWithLocalID) obj;
-		if (id == null) {
-			if (other.id != null) {
-				return false;
-			}
-		} else if (!id.equals(other.id)) {
+		if (!id.equals(other.id)) {
 			return false;
 		}
 		return true;

--- a/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
+++ b/src/us/kbase/auth2/lib/identity/RemoteIdentityWithLocalID.java
@@ -2,14 +2,14 @@ package us.kbase.auth2.lib.identity;
 
 import java.util.UUID;
 
-public class RemoteIdentityWithID extends RemoteIdentity {
+public class RemoteIdentityWithLocalID extends RemoteIdentity {
 	
 	//TODO JAVADOC
 	//TODO TEST
 	
 	private final UUID id;
 	
-	public RemoteIdentityWithID(
+	public RemoteIdentityWithLocalID(
 			final UUID id,
 			final RemoteIdentityID remoteID,
 			final RemoteIdentityDetails details) {
@@ -43,7 +43,7 @@ public class RemoteIdentityWithID extends RemoteIdentity {
 		if (getClass() != obj.getClass()) {
 			return false;
 		}
-		RemoteIdentityWithID other = (RemoteIdentityWithID) obj;
+		RemoteIdentityWithLocalID other = (RemoteIdentityWithLocalID) obj;
 		if (id == null) {
 			if (other.id != null) {
 				return false;

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -27,7 +27,7 @@ import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.exceptions.UnLinkFailedException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.IncomingHashedToken;
@@ -320,7 +320,7 @@ public interface AuthStorage {
 	 */
 	void storeIdentitiesTemporarily(
 			TemporaryHashedToken token,
-			Set<RemoteIdentityWithID> ids)
+			Set<RemoteIdentityWithLocalID> ids)
 			throws AuthStorageException;
 
 	/** Get a set of identities associated with a token.
@@ -330,7 +330,7 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	Set<RemoteIdentityWithID> getTemporaryIdentities(
+	Set<RemoteIdentityWithLocalID> getTemporaryIdentities(
 			IncomingHashedToken token)
 			throws AuthStorageException, NoSuchTokenException;
 
@@ -343,7 +343,7 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	void link(UserName userName, RemoteIdentityWithID remoteID)
+	void link(UserName userName, RemoteIdentityWithLocalID remoteID)
 			throws NoSuchUserException, AuthStorageException,
 			LinkFailedException;
 

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -267,6 +267,7 @@ public class MongoStorage implements AuthStorage {
 	}
 
 	private List<String> getCanonicalDisplayName(final DisplayName display) {
+		//TODO SEARCH remove punctuation
 		final String[] parts = display.getName().toLowerCase().split("\\s");
 		final List<String> ret = new LinkedList<>();
 		for (String p: parts) {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoUser.java
@@ -12,7 +12,7 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
 public class MongoUser extends AuthUser {
@@ -28,7 +28,7 @@ public class MongoUser extends AuthUser {
 			final UserName userName,
 			final EmailAddress email,
 			final DisplayName displayName,
-			final Set<RemoteIdentityWithID> identities,
+			final Set<RemoteIdentityWithLocalID> identities,
 			final Set<Role> roles,
 			final Set<ObjectId> customRoles,
 			final Date created,
@@ -43,7 +43,7 @@ public class MongoUser extends AuthUser {
 		this.storage = storage;
 	}
 
-	MongoUser(final MongoUser user, final Set<RemoteIdentityWithID> newIDs) {
+	MongoUser(final MongoUser user, final Set<RemoteIdentityWithLocalID> newIDs) {
 		super(user.getUserName(), user.getEmail(), user.getDisplayName(), newIDs, user.getRoles(),
 				user.getCreated(), user.getLastLogin(), user.getDisabledState());
 		this.customRoles = user.customRoles;

--- a/src/us/kbase/auth2/service/AppEventListener.java
+++ b/src/us/kbase/auth2/service/AppEventListener.java
@@ -3,14 +3,19 @@ package us.kbase.auth2.service;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import us.kbase.auth2.lib.identity.GoogleIdentityProvider.GoogleIdentityProviderConfigurator;
+import us.kbase.auth2.lib.identity.GlobusIdentityProvider.GlobusIdentityProviderConfigurator;
 import us.kbase.auth2.service.exceptions.AuthConfigurationException;
 import us.kbase.auth2.service.kbase.KBaseAuthConfig;
 
 public class AppEventListener implements ServletContextListener {
 	
 	@Override
-	public void contextInitialized(ServletContextEvent arg0) {
+	public void contextInitialized(final ServletContextEvent arg0) {
 		try {
+			AuthenticationService.getIdentitySet()
+					.register(new GoogleIdentityProviderConfigurator())
+					.register(new GlobusIdentityProviderConfigurator());
 			AuthenticationService.setConfig(new KBaseAuthConfig());
 		} catch (AuthConfigurationException e) {
 			e.printStackTrace();
@@ -19,7 +24,7 @@ public class AppEventListener implements ServletContextListener {
 	}
 	
 	@Override
-	public void contextDestroyed(ServletContextEvent arg0) {
+	public void contextDestroyed(final ServletContextEvent arg0) {
 		//TODO TEST manually test this shuts down the mongo connection.
 		//this seems very wrong, but for now I'm not sure how else to do it.
 		AuthenticationService.shutdown();

--- a/src/us/kbase/auth2/service/AuthenticationService.java
+++ b/src/us/kbase/auth2/service/AuthenticationService.java
@@ -14,10 +14,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.ExternalConfig;
-import us.kbase.auth2.lib.identity.GlobusIdentityProvider
-		.GlobusIdentityProviderConfigurator;
-import us.kbase.auth2.lib.identity.GoogleIdentityProvider
-		.GoogleIdentityProviderConfigurator;
 import us.kbase.auth2.lib.identity.IdentityProviderSet;
 import us.kbase.auth2.lib.storage.exceptions.StorageInitException;
 import us.kbase.auth2.service.LoggingFilter;
@@ -46,7 +42,6 @@ public class AuthenticationService extends ResourceConfig {
 		cfg = config;
 	}
 	
-	// for testing purposes, so test identity providers can be added.
 	public static IdentityProviderSet getIdentitySet() {
 		return identities;
 	}
@@ -82,8 +77,6 @@ public class AuthenticationService extends ResourceConfig {
 			final AuthStartupConfig c,
 			final ExternalConfig defaultExternalConfig)
 			throws StorageInitException, AuthConfigurationException {
-		identities.register(new GlobusIdentityProviderConfigurator());
-		identities.register(new GoogleIdentityProviderConfigurator());
 		final AuthBuilder ab;
 		synchronized(this) {
 			if (mc == null) {

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -26,7 +26,7 @@ import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 
 @Path(APIPaths.API_V2_ME)
@@ -58,7 +58,7 @@ public class Me {
 				.collect(Collectors.toList()));
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put("idents", idents);
-		for (final RemoteIdentityWithID ri: u.getIdentities()) {
+		for (final RemoteIdentityWithLocalID ri: u.getIdentities()) {
 			final Map<String, String> i = new HashMap<>();
 			i.put("provider", ri.getRemoteID().getProvider());
 			i.put("username", ri.getDetails().getUsername());

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -49,7 +49,7 @@ import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.lib.token.TemporaryToken;
@@ -257,7 +257,7 @@ public class Link {
 				.iterator().next().getRemoteID().getProvider());
 		final List<Map<String, String>> ris = new LinkedList<>();
 		ret.put("ids", ris);
-		for (final RemoteIdentityWithID ri: ids.getIdentities()) {
+		for (final RemoteIdentityWithLocalID ri: ids.getIdentities()) {
 			final Map<String, String> s = new HashMap<>();
 			s.put("id", ri.getID().toString());
 			s.put("prov_username", ri.getDetails().getUsername());

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -51,7 +51,7 @@ import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.lib.token.NewToken;
@@ -297,7 +297,7 @@ public class Login {
 		ret.put("create", create);
 		ret.put("login", login);
 		
-		for (final RemoteIdentityWithID id: loginState.getIdentities()) {
+		for (final RemoteIdentityWithLocalID id: loginState.getIdentities()) {
 			final Map<String, String> c = new HashMap<>();
 			c.put("id", id.getID().toString());
 			final String suggestedUserName = id.getDetails().getUsername().split("@")[0];
@@ -318,7 +318,7 @@ public class Login {
 			l.put("adminonly", loginRestricted);
 			l.put("id", loginState.getIdentities(userName).iterator().next().getID());
 			final List<String> remoteIDs = new LinkedList<>();
-			for (final RemoteIdentityWithID id: loginState.getIdentities(userName)) {
+			for (final RemoteIdentityWithLocalID id: loginState.getIdentities(userName)) {
 				remoteIDs.add(id.getDetails().getUsername());
 			}
 			l.put("prov_usernames", remoteIDs);

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -35,7 +35,7 @@ import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.exceptions.UnLinkFailedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
-import us.kbase.auth2.lib.identity.RemoteIdentityWithID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
@@ -84,7 +84,7 @@ public class Me {
 		ret.put("hasRoles", !roles.isEmpty());
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put("idents", idents);
-		for (final RemoteIdentityWithID ri: u.getIdentities()) {
+		for (final RemoteIdentityWithLocalID ri: u.getIdentities()) {
 			final Map<String, String> i = new HashMap<>();
 			i.put("provider", ri.getRemoteID().getProvider());
 			i.put("username", ri.getDetails().getUsername());

--- a/src/us/kbase/test/auth2/StartAuthServer.java
+++ b/src/us/kbase/test/auth2/StartAuthServer.java
@@ -6,6 +6,8 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.servlet.ServletContainer;
 
+import us.kbase.auth2.lib.identity.GlobusIdentityProvider.GlobusIdentityProviderConfigurator;
+import us.kbase.auth2.lib.identity.GoogleIdentityProvider.GoogleIdentityProviderConfigurator;
 import us.kbase.auth2.service.AuthenticationService;
 import us.kbase.auth2.service.kbase.KBaseAuthConfig;
 
@@ -13,8 +15,11 @@ public class StartAuthServer {
 
 	public static void main(String[] args) throws Exception {
 
-		
+		AuthenticationService.getIdentitySet()
+			.register(new GoogleIdentityProviderConfigurator())
+			.register(new GlobusIdentityProviderConfigurator());
 		AuthenticationService.setConfig(new KBaseAuthConfig());
+		
 		final Server server = new Server(Integer.valueOf(args[0]));
 
 		final ServletContextHandler context = new ServletContextHandler();

--- a/src/us/kbase/test/auth2/lib/identity/IdentityProviderSetTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/IdentityProviderSetTest.java
@@ -148,8 +148,10 @@ public class IdentityProviderSetTest {
 	@Test
 	public void registerAndLock() throws Exception {
 		final IdentityProviderSet ids = new IdentityProviderSet();
-		ids.register(new TestProviderConfigurator("Test", true));
-		ids.configure(CFG1);
+		IdentityProviderSet ret = ids.register(new TestProviderConfigurator("Test", true));
+		assertThat("fluent interface failed", ret, is(ids));
+		ret = ids.configure(CFG1);
+		assertThat("fluent interface failed", ret, is(ids));
 		assertThat("incorrect provider list", ids.getProviders(), is(Arrays.asList("Test")));
 		assertThat("incorrect locked state", ids.isLocked(), is(false));
 		final IdentityProvider idp = ids.getProvider("Test");
@@ -167,7 +169,8 @@ public class IdentityProviderSetTest {
 		assertThat("incorrect fullname", ri.getDetails().getFullname(), is("http://loginre.com"));
 		assertThat("incorrect email", ri.getDetails().getEmail(), is("http://linkre.com"));
 		
-		ids.lock();
+		ret = ids.lock();
+		assertThat("fluent interface failed", ret, is(ids));
 		assertThat("incorrect locked state", ids.isLocked(), is(true));
 		ids.register(new TestProviderConfigurator("Test2", false));
 		try {

--- a/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
@@ -213,7 +213,7 @@ public class RemoteIdentityTest {
 	
 	@Test
 	public void identityFail() throws Exception {
-		failCreateIdentity(null, new RemoteIdentityDetails("u", "f", "e"), "id");
+		failCreateIdentity(null, new RemoteIdentityDetails("u", "f", "e"), "remoteID");
 		failCreateIdentity(new RemoteIdentityID("p", "i"), null, "details");
 	}
 	
@@ -227,6 +227,73 @@ public class RemoteIdentityTest {
 		} catch (NullPointerException e) {
 			assertThat("incorrect exception message", e.getMessage(), is(exception));
 		}
+	}
+	
+	@Test
+	public void identityLocalID() throws Exception {
+		final UUID id = UUID.fromString("8c3a3495-50fe-46aa-8e6b-d447e9ecfa46");
+		final RemoteIdentityID rid = new RemoteIdentityID("p", "i");
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("u", "f", "e");
+		final RemoteIdentityWithLocalID ri = new RemoteIdentityWithLocalID(id, rid, dets);
+		assertThat("incorrect id", ri.getID(), is(id));
+		assertThat("incorrect remote id", ri.getRemoteID(), is(rid));
+		assertThat("incorrect details", ri.getDetails(), is(dets));
+		assertThat("incorrect hashcode", ri.hashCode(), is(-1027993528));
+		assertThat("incorrect toString()", ri.toString(),
+				is("RemoteIdentityWithLocalID [id=8c3a3495-50fe-46aa-8e6b-d447e9ecfa46, " +
+						"getRemoteID()=RemoteIdentityID [provider=p, id=i], " +
+						"getDetails()=RemoteIdentityDetails [username=u, fullname=f, email=e]]"));
+	}
+	
+	@Test
+	public void identityLocalIDfail() throws Exception {
+		final UUID id = UUID.fromString("8c3a3495-50fe-46aa-8e6b-d447e9ecfa46");
+		final RemoteIdentityID rid = new RemoteIdentityID("p", "i");
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("u", "f", "e");
+		failCreateIdentWithLocalID(null, rid, dets, "id");
+		failCreateIdentWithLocalID(id, null, dets, "remoteID");
+		failCreateIdentWithLocalID(id, rid, null, "details");
+	}
+	
+	private void failCreateIdentWithLocalID(
+			final UUID id,
+			final RemoteIdentityID rid,
+			final RemoteIdentityDetails dets,
+			final String exception) {
+		try {
+			new RemoteIdentityWithLocalID(id, rid, dets);
+			fail("created bad remote id");
+		} catch (NullPointerException e) {
+			assertThat("incorrect exception message", e.getMessage(), is(exception));
+		}
+	}
+	
+	@Test
+	public void identityLocalIDequals() throws Exception {
+		final UUID id = UUID.fromString("8c3a3495-50fe-46aa-8e6b-d447e9ecfa46");
+		final RemoteIdentityID rid = new RemoteIdentityID("p", "i");
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("u", "f", "e");
+		final RemoteIdentityWithLocalID ri = new RemoteIdentityWithLocalID(id, rid, dets);
+		
+		//identity
+		assertThat("incorrect equals", ri.equals(ri), is(true));
+		//equal
+		assertThat("incorrect equals", ri.equals(new RemoteIdentityWithLocalID(
+				id, new RemoteIdentityID("p", "i"), new RemoteIdentityDetails("u", "f", "e"))),
+				is(true));
+		//null obj
+		assertThat("incorrect equals", ri.equals(null), is(false));
+		//class
+		assertThat("incorrect equals", ri.equals(new Object()), is(false));
+		//id
+		assertThat("incorrect equals", ri.equals(new RemoteIdentityWithLocalID(
+				UUID.fromString("8c3a3495-50fe-46aa-8e6b-d447e9ecfa47"), rid, dets)), is(false));
+		//remote id
+		assertThat("incorrect equals", ri.equals(new RemoteIdentityWithLocalID(
+				id, new RemoteIdentityID("q", "i"), dets)), is(false));
+		//details
+		assertThat("incorrect equals", ri.equals(new RemoteIdentityWithLocalID(
+				id, rid, new RemoteIdentityDetails("t", "f", "e"))), is(false));
 	}
 	
 }

--- a/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
@@ -1,0 +1,103 @@
+package us.kbase.test.auth2.lib.identity;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+
+
+public class RemoteIdentityTest {
+	
+	@Test
+	public void detailsWithAllFields() throws Exception {
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("user", "full", "email");
+		assertThat("incorrect username", dets.getUsername(), is("user"));
+		assertThat("incorrect fullname", dets.getFullname(), is("full"));
+		assertThat("incorrect email", dets.getEmail(), is("email"));
+		assertThat("incorrect hashcode", dets.hashCode(), is(-1536596969));
+		assertThat("incorrect toString()", dets.toString(),
+				is("RemoteIdentityDetails [username=user, fullname=full, email=email]"));
+	}
+	
+	@Test
+	public void detailsWithEmptyFields() throws Exception {
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("user", "\t ", " \n");
+		assertThat("incorrect username", dets.getUsername(), is("user"));
+		assertThat("incorrect fullname", dets.getFullname(), is((String) null));
+		assertThat("incorrect email", dets.getEmail(), is((String) null));
+		assertThat("incorrect hashcode", dets.hashCode(), is(3629098));
+		assertThat("incorrect toString()", dets.toString(),
+				is("RemoteIdentityDetails [username=user, fullname=null, email=null]"));
+		
+		final RemoteIdentityDetails dets2 = new RemoteIdentityDetails("user", null, null);
+		assertThat("incorrect username", dets2.getUsername(), is("user"));
+		assertThat("incorrect fullname", dets2.getFullname(), is((String) null));
+		assertThat("incorrect email", dets2.getEmail(), is((String) null));
+		assertThat("incorrect hashcode", dets2.hashCode(), is(3629098));
+		assertThat("incorrect toString()", dets2.toString(),
+				is("RemoteIdentityDetails [username=user, fullname=null, email=null]"));
+	}
+	
+	@Test
+	public void detailsFail() throws Exception {
+		failCreateDetails(null);
+		failCreateDetails("              \n       ");
+	}
+	
+	private void failCreateDetails(final String user) {
+		try {
+			new RemoteIdentityDetails(user, "foo", "bar");
+			fail("created bad user");
+		} catch (IllegalArgumentException e) {
+			assertThat("incorrect exception msg", e.getMessage(),
+					is("username cannot be null or empty"));
+		}
+	}
+	
+	@Test
+	public void detailsEquals() throws Exception {
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("foo", "bar", "baz");
+		final RemoteIdentityDetails nulldets = new RemoteIdentityDetails("foo", null, null);
+		
+		//identity
+		assertThat("incorrect equals", dets.equals(dets), is(true));
+		//equal
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("foo", "bar", "baz")), is(true));
+		assertThat("incorrect equals", nulldets.equals(
+				new RemoteIdentityDetails("foo", null, null)), is(true));
+		//null obj
+		assertThat("incorrect equals", dets.equals(null), is(false));
+		//class
+		assertThat("incorrect equals", dets.equals(new Object()), is(false));
+
+		//unequal user
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("fo", "bar", "baz")), is(false));
+		
+		//null full 1
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("foo", null, "baz")), is(false));
+		//null full 2
+		assertThat("incorrect equals", nulldets.equals(
+				new RemoteIdentityDetails("foo", "bar", null)), is(false));
+		//unequal full
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("foo", "bad", "baz")), is(false));
+		
+		//null email 1
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("foo", "bar", null)), is(false));
+		//null email 2
+		assertThat("incorrect equals", nulldets.equals(
+				new RemoteIdentityDetails("foo", null, "baz")), is(false));
+		//unequal email
+		assertThat("incorrect equals", dets.equals(
+				new RemoteIdentityDetails("foo", "bar", "bad")), is(false));
+		
+	}
+
+}

--- a/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
@@ -4,10 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.UUID;
+
 import org.junit.Test;
 
+import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
 import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 
 
 public class RemoteIdentityTest {
@@ -146,6 +150,82 @@ public class RemoteIdentityTest {
 		} catch (IllegalArgumentException e) {
 			assertThat("incorrect exception msg", e.getMessage(),
 					is(exception));
+		}
+	}
+	
+	@Test
+	public void identity() throws Exception {
+		final RemoteIdentityID id = new RemoteIdentityID("p", "i");
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("u", "f", "e");
+		final RemoteIdentity ri = new RemoteIdentity(id, dets);
+		assertThat("incorrect id", ri.getRemoteID(), is(id));
+		assertThat("incorrect details", ri.getDetails(), is(dets));
+		assertThat("incorrect hashcode", ri.hashCode(), is(4039350));
+		assertThat("incorrect toString()", ri.toString(),
+				is("RemoteIdentity [remoteID=RemoteIdentityID [provider=p, id=i], " +
+						"details=RemoteIdentityDetails [username=u, fullname=f, email=e]]"));
+		
+		final RemoteIdentityWithLocalID ril = ri.withID();
+		assertThat("incorrect local id class", ril.getID(), is(UUID.class));
+		assertThat("incorrect id", ril.getRemoteID(), is(id));
+		assertThat("incorrect details", ril.getDetails(), is(dets));
+		
+		final RemoteIdentityID id2 = new RemoteIdentityID("p2", "i");
+		final RemoteIdentityDetails dets2 = new RemoteIdentityDetails("u2", "f", "e");
+		final RemoteIdentity ri2 = new RemoteIdentity(id2, dets2);
+		
+		final UUID uuid = UUID.randomUUID();
+		final RemoteIdentityWithLocalID ril2 = ri2.withID(uuid);
+		assertThat("incorrect local id class", ril2.getID(), is(uuid));
+		assertThat("incorrect id", ril2.getRemoteID(), is(id2));
+		assertThat("incorrect details", ril2.getDetails(), is(dets2));
+		
+		try {
+			ri2.withID(null);
+			fail("created bad remote id");
+		} catch (NullPointerException e) {
+			assertThat("incorrect exception message", e.getMessage(), is("id"));
+		}
+	}
+	
+	@Test
+	public void identityEquals() throws Exception {
+		final RemoteIdentityID id = new RemoteIdentityID("p", "i");
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("u", "f", "e");
+		final RemoteIdentity ri = new RemoteIdentity(id, dets);
+		
+		//identity
+		assertThat("incorrect equals", ri.equals(ri), is(true));
+		//equal
+		assertThat("incorrect equals", ri.equals(new RemoteIdentity(new RemoteIdentityID("p", "i"),
+				new RemoteIdentityDetails("u", "f", "e"))), is(true));
+		//null obj
+		assertThat("incorrect equals", ri.equals(null), is(false));
+		//class
+		assertThat("incorrect equals", ri.equals(new Object()), is(false));
+		//id
+		assertThat("incorrect equals", ri.equals(new RemoteIdentity(
+				new RemoteIdentityID("q", "i"), dets)), is(false));
+		//details
+		assertThat("incorrect equals", ri.equals(new RemoteIdentity(
+				id, new RemoteIdentityDetails("t", "f", "e"))), is(false));
+	}
+	
+	@Test
+	public void identityFail() throws Exception {
+		failCreateIdentity(null, new RemoteIdentityDetails("u", "f", "e"), "id");
+		failCreateIdentity(new RemoteIdentityID("p", "i"), null, "details");
+	}
+	
+	private void failCreateIdentity(
+			final RemoteIdentityID remoteID,
+			final RemoteIdentityDetails details,
+			final String exception) {
+		try {
+			new RemoteIdentity(remoteID, details);
+			fail("created bad identity");
+		} catch (NullPointerException e) {
+			assertThat("incorrect exception message", e.getMessage(), is(exception));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
@@ -7,13 +7,14 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
 
 
 public class RemoteIdentityTest {
 	
 	@Test
-	public void detailsWithAllFields() throws Exception {
-		final RemoteIdentityDetails dets = new RemoteIdentityDetails("user", "full", "email");
+	public void remoteDetailsWithAllFields() throws Exception {
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails("user ", " full", "\temail");
 		assertThat("incorrect username", dets.getUsername(), is("user"));
 		assertThat("incorrect fullname", dets.getFullname(), is("full"));
 		assertThat("incorrect email", dets.getEmail(), is("email"));
@@ -23,7 +24,7 @@ public class RemoteIdentityTest {
 	}
 	
 	@Test
-	public void detailsWithEmptyFields() throws Exception {
+	public void remoteDetailsWithEmptyFields() throws Exception {
 		final RemoteIdentityDetails dets = new RemoteIdentityDetails("user", "\t ", " \n");
 		assertThat("incorrect username", dets.getUsername(), is("user"));
 		assertThat("incorrect fullname", dets.getFullname(), is((String) null));
@@ -42,7 +43,7 @@ public class RemoteIdentityTest {
 	}
 	
 	@Test
-	public void detailsFail() throws Exception {
+	public void remoteDetailsFail() throws Exception {
 		failCreateDetails(null);
 		failCreateDetails("              \n       ");
 	}
@@ -50,7 +51,7 @@ public class RemoteIdentityTest {
 	private void failCreateDetails(final String user) {
 		try {
 			new RemoteIdentityDetails(user, "foo", "bar");
-			fail("created bad user");
+			fail("created bad details");
 		} catch (IllegalArgumentException e) {
 			assertThat("incorrect exception msg", e.getMessage(),
 					is("username cannot be null or empty"));
@@ -58,8 +59,8 @@ public class RemoteIdentityTest {
 	}
 	
 	@Test
-	public void detailsEquals() throws Exception {
-		final RemoteIdentityDetails dets = new RemoteIdentityDetails("foo", "bar", "baz");
+	public void remoteDetailsEquals() throws Exception {
+		final RemoteIdentityDetails dets = new RemoteIdentityDetails(" foo", "bar ", "\nbaz");
 		final RemoteIdentityDetails nulldets = new RemoteIdentityDetails("foo", null, null);
 		
 		//identity
@@ -97,7 +98,55 @@ public class RemoteIdentityTest {
 		//unequal email
 		assertThat("incorrect equals", dets.equals(
 				new RemoteIdentityDetails("foo", "bar", "bad")), is(false));
-		
 	}
 
+	@Test
+	public void remoteId() throws Exception {
+		final RemoteIdentityID id = new RemoteIdentityID("foo", "bar");
+		assertThat("incorrect provider name", id.getProvider(), is("foo"));
+		assertThat("incorrect provider id", id.getId(), is("bar"));
+		assertThat("incorrect hashcode", id.hashCode(), is(3118804));
+		assertThat("incorrect toString()", id.toString(),
+				is("RemoteIdentityID [provider=foo, id=bar]"));
+	}
+	
+	@Test
+	public void remoteIdEquals() throws Exception {
+		final RemoteIdentityID id = new RemoteIdentityID("whee", "whoo");
+		
+		//identity
+		assertThat("incorrect equals", id.equals(id), is(true));
+		//equal
+		assertThat("incorrect equals", id.equals(new RemoteIdentityID("whee", "whoo")), is(true));
+		//null obj
+		assertThat("incorrect equals", id.equals(null), is(false));
+		//class
+		assertThat("incorrect equals", id.equals(new Object()), is(false));
+		//unequal provider
+		assertThat("incorrect equals", id.equals(new RemoteIdentityID("wheo", "whoo")), is(false));
+		//unequal id
+		assertThat("incorrect equals", id.equals(new RemoteIdentityID("whee", "whoe")), is(false));
+	}
+	
+	@Test
+	public void remoteIDFail() throws Exception {
+		final String providererr = "provider cannot be null or empty";
+		final String iderr = "id cannot be null or empty";
+		failCreateID(null, "f", providererr);
+		failCreateID(" \t", "f", providererr);
+		failCreateID("p", null, iderr);
+		failCreateID("p", " \n   \t  ", iderr);
+		
+	}
+	
+	private void failCreateID(final String provider, final String id, final String exception) {
+		try {
+			new RemoteIdentityID(provider, id);
+			fail("created bad id");
+		} catch (IllegalArgumentException e) {
+			assertThat("incorrect exception msg", e.getMessage(),
+					is(exception));
+		}
+	}
+	
 }


### PR DESCRIPTION
Adds tests for the 4 remote identity classes.

Refactors registering of ID provider configurators outside the application server class. 

Adds a fluent interface for IdentityProviderSet.

Rename RemoteIdentityWithID to RemoteIdentityWithLocalID.