### PR TITLE
Add option to link all other unlinked identities on login, create, or link

### DIFF
--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1591,6 +1591,7 @@ public class Authentication {
 			LinkFailedException {
 		final AuthUser au = getUser(token); // checks user isn't disabled
 		final Set<RemoteIdentityWithLocalID> identities = getTemporaryIdentities(linkToken);
+		filterLinkCandidates(identities);
 		link(au.getUserName(), identities);
 	}
 

--- a/templates/linkchoice.mustache
+++ b/templates/linkchoice.mustache
@@ -14,5 +14,11 @@ Provider username: {{prov_username}}<br/>
 </form>
 {{/ids}}
 
+<p> or
+<form action="{{pickurl}}" method="post">
+	<input type="submit" value="Link all"/>
+</form>
+</p>
+
 </html>
 </body>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -35,6 +35,7 @@ Email is only visible to you, software acting on your behalf, and system adminis
 	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
 	Display name: <input type="text" name="display" value="{{prov_fullname}}"/><br/>
 	Email: <input type="text" name="email" value="{{prov_email}}"/></br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked"/><br/>
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Create"/>
 </form>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -14,6 +14,7 @@ Provider usernames: {{prov_usernames}}<br/>
 {{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked"/><br/>
 	<input type="submit" value="Login"/>
 </form>
 {{/loginallowed}}

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -14,7 +14,7 @@ Provider usernames: {{prov_usernames}}<br/>
 {{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
-	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="submit" value="Login"/>
 </form>
 {{/loginallowed}}
@@ -35,7 +35,7 @@ Email is only visible to you, software acting on your behalf, and system adminis
 	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
 	Display name: <input type="text" name="display" value="{{prov_fullname}}"/><br/>
 	Email: <input type="text" name="email" value="{{prov_email}}"/></br/>
-	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Create"/>
 </form>


### PR DESCRIPTION
Adds an option to link any other identities the user possesses to the current account when logging in or creating an account. Also adds an option to link all the identities the user possesses to the logged-in account when linking accounts rather than just one.

This keeps the UI simple (i.e. no picking from lists of identities) and covers 99.99999% of the use cases (probably). The user can always link specific identities from the link endpoint or link all identities and then remove specific identities from the /me endpoint.