### PR TITLE
Add login endpoint allowing UI to intercept redirect from 3rd party

### DIFF
--- a/src/us/kbase/auth2/lib/LoginState.java
+++ b/src/us/kbase/auth2/lib/LoginState.java
@@ -94,7 +94,12 @@ public class LoginState {
 		}
 	}
 	
-	/** Get the remote identities associated with a given user account.
+	/** Get the remote identities associated with a given user account that granted access to said
+	 * account.
+	 * 
+	 * Note this may be a subset of the identities associated with the account in general, and the
+	 * identities in this set may have different UUIDs than the corresponding identities in
+	 * the user class.
 	 * @param name the user name of the user account.
 	 * @return the set of remote identities.
 	 */

--- a/src/us/kbase/auth2/lib/LoginToken.java
+++ b/src/us/kbase/auth2/lib/LoginToken.java
@@ -9,35 +9,50 @@ import us.kbase.auth2.lib.token.TemporaryToken;
  * 2) A temporary token, indicating that there are more steps to be completed in the login process.
  * The temporary token is associated with the state of the login process in the authorization
  * storage system.
+ * 
+ * The state of the login process is also included.
  * @author gaprice@lbl.gov
  *
  */
 public class LoginToken {
-
+	
 	private final NewToken token;
 	private final TemporaryToken temporaryToken;
+	private final LoginState ls;
 	
 	/** Create a LoginToken with a temporary token, indicating that the login process is
 	 * incomplete.
 	 * @param token the temporary token.
 	 */
-	public LoginToken(final TemporaryToken token) {
+	public LoginToken(final TemporaryToken token, final LoginState loginState) {
 		if (token == null) {
 			throw new NullPointerException("token");
 		}
+		if (loginState == null) {
+			throw new NullPointerException("loginState");
+		}
 		this.temporaryToken = token;
 		this.token = null;
+		this.ls = loginState;
 	}
 	
 	/** Create a LoginToken with a new token, indicating the login process is complete.
 	 * @param token
 	 */
-	public LoginToken(final NewToken token) {
+	public LoginToken(final NewToken token, final LoginState loginState) {
 		if (token == null) {
 			throw new NullPointerException("token");
 		}
+		if (loginState == null) {
+			throw new NullPointerException("loginState");
+		}
 		this.temporaryToken = null;
 		this.token = token;
+		this.ls = loginState;
+		if (loginState.getUsers().size() != 1 || !loginState.getIdentities().isEmpty()) {
+			throw new IllegalStateException(
+					"Login process is complete but user count != 1 or unlinked identities > 0");
+		}
 	}
 
 	/** Returns true if the login process is complete, false otherwise.
@@ -59,5 +74,13 @@ public class LoginToken {
 	 */
 	public TemporaryToken getTemporaryToken() {
 		return temporaryToken;
+	}
+	
+	/** Gets the state of the login process. If the login is complete, the login state will
+	 * contain one user and no unlinked identities.
+	 * @return
+	 */
+	public LoginState getLoginState() {
+		return ls;
 	}
 }

--- a/src/us/kbase/test/auth2/lib/LoginTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginTokenTest.java
@@ -4,21 +4,48 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.UUID;
+
 import org.junit.Test;
 
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
+import us.kbase.auth2.lib.NewUser;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.token.NewToken;
 import us.kbase.auth2.lib.token.TemporaryToken;
 import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.test.auth2.TestCommon;
 
 public class LoginTokenTest {
 
+	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
+			UUID.fromString("ec8a91d3-5923-4638-8d12-0891c56715d8"),
+			new RemoteIdentityID("foo", "bar42"),
+			new RemoteIdentityDetails("user42", "full42", "email42"));
+	
+	private static final LoginState LOGIN_STATE;
+	static {
+		try {
+			LOGIN_STATE = new LoginState.Builder("foo", false)
+					.withUser(new NewUser(new UserName("foo"),
+							new EmailAddress("f@g.com"),
+							new DisplayName("bar"), REMOTE, null), REMOTE).build();
+		} catch (Exception e) {
+			throw new RuntimeException("Fix yer tests nub", e);
+		}
+	}
+	
 	@Test
 	public void constructorNewToken() throws Exception {
 		final NewToken nt = new NewToken(TokenType.EXTENDED_LIFETIME, "foo", new UserName("bar"),
 				10000);
-		final LoginToken lt = new LoginToken(nt);
+		final LoginToken lt = new LoginToken(nt, LOGIN_STATE);
 		assertThat("incorrect isLoggedIn", lt.isLoggedIn(), is(true));
 		assertThat("incorrect token type", lt.getToken().getTokenType(),
 				is(TokenType.EXTENDED_LIFETIME));
@@ -31,12 +58,15 @@ public class LoginTokenTest {
 		assertThat("incorrect token name", lt.getToken().getTokenName(), is((String) null));
 		assertThat("incorrect token username", lt.getToken().getUserName(),
 				is(new UserName("bar")));
+		assertThat("incorrect login state provider", lt.getLoginState().getProvider(), is("foo"));
+		assertThat("incorrect login state login allowed",
+				lt.getLoginState().isNonAdminLoginAllowed(), is(false));
 	}
 	
 	@Test
 	public void constructorTemporaryToken() throws Exception {
 		final TemporaryToken tt = new TemporaryToken("baz", 5000);
-		final LoginToken lt = new LoginToken(tt);
+		final LoginToken lt = new LoginToken(tt, LOGIN_STATE);
 		assertThat("incorrect isLoggedIn", lt.isLoggedIn(), is(false));
 		assertThat("incorrect token id", lt.getTemporaryToken().getId(), is(tt.getId()));
 		assertThat("incorrect token id", lt.getTemporaryToken().getToken(), is("baz"));
@@ -44,25 +74,57 @@ public class LoginTokenTest {
 				is(tt.getCreationDate()));
 		assertThat("incorrect token id", lt.getTemporaryToken().getExpirationDate(),
 				is(tt.getExpirationDate()));
+		assertThat("incorrect login state provider", lt.getLoginState().getProvider(), is("foo"));
+		assertThat("incorrect login state login allowed",
+				lt.getLoginState().isNonAdminLoginAllowed(), is(false));
 	}
 	
 	@Test
-	public void constructFailToken() throws Exception {
+	public void constructFail() throws Exception {
+		final NewToken nt = new NewToken(TokenType.EXTENDED_LIFETIME, "foo", new UserName("bar"),
+				10000);
+		failConstructToken((NewToken) null, LOGIN_STATE, new NullPointerException("token"));
+		failConstructToken(nt, null, new NullPointerException("loginState"));
+		
+		failConstructToken(nt, new LoginState.Builder("foo", false).build(),
+				new IllegalStateException("Login process is complete but user count != 1 " +
+						"or unlinked identities > 0"));
+		failConstructToken(nt, new LoginState.Builder("foo", false)
+				.withUser(LOGIN_STATE.getUser(new UserName("foo")), REMOTE)
+				.withIdentity(REMOTE).build(),
+				new IllegalStateException("Login process is complete but user count != 1 " +
+						"or unlinked identities > 0"));
+		
+		
+		
+		final TemporaryToken tt = new TemporaryToken("baz", 5000);
+		failConstructToken((TemporaryToken) null, LOGIN_STATE, new NullPointerException("token"));
+		failConstructToken(tt, null, new NullPointerException("loginState"));
+	}
+	
+	private void failConstructToken(
+			final NewToken t,
+			final LoginState ls,
+			final Exception e)
+			throws Exception {
 		try {
-			new LoginToken((NewToken) null);
+			new LoginToken(t, ls);
 			fail("expected exception");
-		} catch (NullPointerException npe) {
-			assertThat("incorrect exception message", npe.getMessage(), is("token"));
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
 		}
 	}
 	
-	@Test
-	public void constructFailTempToken() throws Exception {
+	private void failConstructToken(
+			final TemporaryToken t,
+			final LoginState ls,
+			final Exception e)
+			throws Exception {
 		try {
-			new LoginToken((TemporaryToken) null);
+			new LoginToken(t, ls);
 			fail("expected exception");
-		} catch (NullPointerException npe) {
-			assertThat("incorrect exception message", npe.getMessage(), is("token"));
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
 		}
 	}
 }


### PR DESCRIPTION
Adds a /login/complete/{provider} endpoint that assumes a UI element
intercepts the post-login redirect from a 3rd party identity provider,
and then makes an AJAX call with the state and authcode to the service.

The endpoint immediately sends back the same information that would
normally be returned from the /login/choice endpoint, except that when
possible (e.g. the remote identities are all associated with one user) a
token is returned for immediate login.