### PR TITLE
Add link endpoint allowing UI to intercept redirect from 3rd party

### DIFF
--- a/src/us/kbase/auth2/lib/LinkIdentities.java
+++ b/src/us/kbase/auth2/lib/LinkIdentities.java
@@ -15,6 +15,7 @@ public class LinkIdentities {
 	
 	private final AuthUser user;
 	private final Set<RemoteIdentityWithLocalID> idents;
+	private final String provider;
 
 	/** Create a set of identities that are linkable to a user account.
 	 * @param user the user to which the identities may be linked.
@@ -32,6 +33,26 @@ public class LinkIdentities {
 		Utils.noNulls(ids, "null item in ids");
 		this.user = user;
 		this.idents = Collections.unmodifiableSet(new HashSet<>(ids));
+		this.provider = ids.iterator().next().getRemoteID().getProvider();
+	}
+	
+	/** Create an empty identity set, implying that no identities were available for linking
+	 * from this provider.
+	 * @param user the user on which the link was attempted.
+	 * @param provider the provider from which the identities were retrieved.
+	 */
+	public LinkIdentities(
+			final AuthUser user,
+			final String provider) {
+		if (user == null) {
+			throw new NullPointerException("user");
+		}
+		if (provider == null || provider.trim().isEmpty()) {
+			throw new IllegalArgumentException("provider cannot be null or empty");
+		}
+		this.user = user;
+		this.idents = Collections.unmodifiableSet(Collections.emptySet());
+		this.provider = provider;
 	}
 
 	/** Get the user associated with the remote identities.
@@ -42,10 +63,17 @@ public class LinkIdentities {
 	}
 
 	/** Get the remote identities.
-	 * @return the remote identities.
+	 * @return the remote identities. May be empty if no linkable identities are available.
 	 */
 	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return idents;
+	}
+	
+	/** Get the provider of the identities.
+	 * @return the provider name.
+	 */
+	public String getProvider() {
+		return provider;
 	}
 
 }

--- a/src/us/kbase/auth2/lib/LinkToken.java
+++ b/src/us/kbase/auth2/lib/LinkToken.java
@@ -8,30 +8,37 @@ import us.kbase.auth2.lib.token.TemporaryToken;
  * the token will be null.
  * 
  * If there are still more steps to be completed in the linking process, isLinked() will be false
- * and a temporary token supplied which can be used ot continue the linking process.
+ * and a temporary token supplied which can be used to continue the linking process.
  * @author gaprice@lbl.gov
  *
  */
 public class LinkToken {
 	
 	private final TemporaryToken token;
+	private final LinkIdentities idents;
 	
 	/** Create a LinkToken for the case where the linking process is concluded and no further
 	 * actions are required.
 	 */
 	public LinkToken() {
 		this.token = null;
+		this.idents = null;
 	}
 	
 	/** Create a LinkToken for the case where more actions are required, and thus a token is
 	 * provided to allow continuing with the linking process.
 	 * @param token a temporary token associated with the state of the linking process in the auth
 	 * storage system.
+	 * @param linkIdentities the identities available for linking.
 	 */
-	public LinkToken(final TemporaryToken token) {
+	public LinkToken(final TemporaryToken token, final LinkIdentities linkIdentities) {
 		if (token == null) {
 			throw new NullPointerException("token");
 		}
+		if (linkIdentities == null) {
+			throw new NullPointerException("linkIdentities");
+		}
+		this.idents = linkIdentities;
 		this.token = token;
 	}
 
@@ -47,6 +54,13 @@ public class LinkToken {
 	 */
 	public TemporaryToken getTemporaryToken() {
 		return token;
+	}
+	
+	/** Get the identities available for linking.
+	 * @return the identities available for linking, or null if linking process is complete.
+	 */
+	public LinkIdentities getLinkIdentities() {
+		return idents;
 	}
 
 }

--- a/src/us/kbase/auth2/lib/LoginToken.java
+++ b/src/us/kbase/auth2/lib/LoginToken.java
@@ -23,6 +23,7 @@ public class LoginToken {
 	/** Create a LoginToken with a temporary token, indicating that the login process is
 	 * incomplete.
 	 * @param token the temporary token.
+	 * @param the current login state.
 	 */
 	public LoginToken(final TemporaryToken token, final LoginState loginState) {
 		if (token == null) {
@@ -38,6 +39,7 @@ public class LoginToken {
 	
 	/** Create a LoginToken with a new token, indicating the login process is complete.
 	 * @param token
+	 * @param the current login state.
 	 */
 	public LoginToken(final NewToken token, final LoginState loginState) {
 		if (token == null) {

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -246,6 +246,8 @@ public class Login {
 			throws AuthenticationException, MissingParameterException, AuthStorageException,
 			IllegalParameterException {
 		
+		provider = upperCase(provider);
+		
 		input.exceptOnAdditionalProperties();
 		if (state == null || state.trim().isEmpty()) {
 			throw new MissingParameterException("Couldn't retrieve state value from cookie");

--- a/src/us/kbase/test/auth2/lib/LinkTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkTokenTest.java
@@ -4,24 +4,54 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.util.Date;
+import java.util.UUID;
+
 import org.junit.Test;
 
+import us.kbase.auth2.lib.AuthUser;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.LinkIdentities;
 import us.kbase.auth2.lib.LinkToken;
+import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.auth2.lib.token.TemporaryToken;
+import us.kbase.test.auth2.TestCommon;
 
 public class LinkTokenTest {
 
+	private final static RemoteIdentityWithLocalID REMOTE1 = new RemoteIdentityWithLocalID(
+			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715b9"),
+			new RemoteIdentityID("foo", "bar"),
+			new RemoteIdentityDetails("user", "full", "email"));
+	
+	private final static AuthUser AUTH_USER;
+	static {
+		try {
+			AUTH_USER = new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
+					new DisplayName("bar"), REMOTE1, null);
+		} catch (Exception e) {
+			throw new RuntimeException("fix yer tests newb", e);
+		}
+	}
+	
 	@Test
 	public void emptyConstructor() throws Exception {
 		final LinkToken lt = new LinkToken();
 		assertThat("incorrect isLinked()", lt.isLinked(), is(true));
 		assertThat("incorrect token", lt.getTemporaryToken(), is((TemporaryToken) null));
+		assertThat("incorrect ids", lt.getLinkIdentities(), is((LinkIdentities) null));
 	}
 	
 	@Test
 	public void tokenConstructor() throws Exception {
+		final LinkIdentities linkids = new LinkIdentities(AUTH_USER, "foobar");
 		final TemporaryToken tt = new TemporaryToken("foo", 10000);
-		final LinkToken lt = new LinkToken(tt);
+		final LinkToken lt = new LinkToken(tt, linkids);
 		assertThat("incorrect isLinked()", lt.isLinked(), is(false));
 		assertThat("incorrect token id", lt.getTemporaryToken().getId(), is(tt.getId()));
 		assertThat("incorrect token id", lt.getTemporaryToken().getToken(), is("foo"));
@@ -29,15 +59,48 @@ public class LinkTokenTest {
 				is(tt.getCreationDate()));
 		assertThat("incorrect token id", lt.getTemporaryToken().getExpirationDate(),
 				is(tt.getExpirationDate()));
+		
+		assertThat("incorrect provider", lt.getLinkIdentities().getProvider(), is("foobar"));
+		
+		//check the user is correct
+			assertThat("incorrect username", lt.getLinkIdentities().getUser().getUserName(),
+					is(new UserName("foo")));
+			assertThat("incorrect email", lt.getLinkIdentities().getUser().getEmail(),
+					is(new EmailAddress("f@g.com")));
+			assertThat("incorrect displayname", lt.getLinkIdentities().getUser().getDisplayName(),
+					is(new DisplayName("bar")));
+			assertThat("incorrect user id number",
+					lt.getLinkIdentities().getUser().getIdentities().size(), is(1));
+			assertThat("incorrect user identity",
+					lt.getLinkIdentities().getUser().getIdentities().iterator().next(), is(
+					new RemoteIdentityWithLocalID(
+							UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715b9"),
+							new RemoteIdentityID("foo", "bar"),
+							new RemoteIdentityDetails("user", "full", "email"))));
+			assertThat("incorrect creation date", lt.getLinkIdentities().getUser().getCreated(),
+					is(AUTH_USER.getCreated()));
+			assertThat("incorrect login date", lt.getLinkIdentities().getUser().getLastLogin(),
+					is((Date) null));
 	}
 	
 	@Test
 	public void constructFail() throws Exception {
+		failConstruct(null, new LinkIdentities(AUTH_USER, "foo"),
+				new NullPointerException("token"));
+		failConstruct(new TemporaryToken("foo", 10000), null,
+				new NullPointerException("linkIdentities"));
+	}
+	
+	private void failConstruct(
+			final TemporaryToken token,
+			final LinkIdentities li,
+			final Exception e)
+			throws Exception {
 		try {
-			new LinkToken(null);
-			fail("constructed bad LinkToken");
-		} catch (NullPointerException npe) {
-			assertThat("inccorrect exception message", npe.getMessage(), is("token"));
+			new LinkToken(token, li);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/lib/LinkTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkTokenTest.java
@@ -63,24 +63,24 @@ public class LinkTokenTest {
 		assertThat("incorrect provider", lt.getLinkIdentities().getProvider(), is("foobar"));
 		
 		//check the user is correct
-			assertThat("incorrect username", lt.getLinkIdentities().getUser().getUserName(),
-					is(new UserName("foo")));
-			assertThat("incorrect email", lt.getLinkIdentities().getUser().getEmail(),
-					is(new EmailAddress("f@g.com")));
-			assertThat("incorrect displayname", lt.getLinkIdentities().getUser().getDisplayName(),
-					is(new DisplayName("bar")));
-			assertThat("incorrect user id number",
-					lt.getLinkIdentities().getUser().getIdentities().size(), is(1));
-			assertThat("incorrect user identity",
-					lt.getLinkIdentities().getUser().getIdentities().iterator().next(), is(
-					new RemoteIdentityWithLocalID(
-							UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715b9"),
-							new RemoteIdentityID("foo", "bar"),
-							new RemoteIdentityDetails("user", "full", "email"))));
-			assertThat("incorrect creation date", lt.getLinkIdentities().getUser().getCreated(),
-					is(AUTH_USER.getCreated()));
-			assertThat("incorrect login date", lt.getLinkIdentities().getUser().getLastLogin(),
-					is((Date) null));
+		assertThat("incorrect username", lt.getLinkIdentities().getUser().getUserName(),
+				is(new UserName("foo")));
+		assertThat("incorrect email", lt.getLinkIdentities().getUser().getEmail(),
+				is(new EmailAddress("f@g.com")));
+		assertThat("incorrect displayname", lt.getLinkIdentities().getUser().getDisplayName(),
+				is(new DisplayName("bar")));
+		assertThat("incorrect user id number",
+				lt.getLinkIdentities().getUser().getIdentities().size(), is(1));
+		assertThat("incorrect user identity",
+				lt.getLinkIdentities().getUser().getIdentities().iterator().next(), is(
+				new RemoteIdentityWithLocalID(
+						UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715b9"),
+						new RemoteIdentityID("foo", "bar"),
+						new RemoteIdentityDetails("user", "full", "email"))));
+		assertThat("incorrect creation date", lt.getLinkIdentities().getUser().getCreated(),
+				is(AUTH_USER.getCreated()));
+		assertThat("incorrect login date", lt.getLinkIdentities().getUser().getLastLogin(),
+				is((Date) null));
 	}
 	
 	@Test


### PR DESCRIPTION
Adds a /link/complete/{provider} endpoint that assumes a UI element
intercepts the post-link redirect from a 3rd party identity provider,
and then makes an AJAX call with the state and authcode to the service.

The endpoint immediately sends back the same information that would
normally be returned from the /link/choice endpoint, except that when
possible (e.g. there's only one linkable identity) the link happens
immediately and that fact is returned in the body.