### PR TITLE
Add configuration option to never login a user immediately

### DIFF
--- a/src/us/kbase/auth2/lib/AuthConfig.java
+++ b/src/us/kbase/auth2/lib/AuthConfig.java
@@ -20,7 +20,7 @@ public class AuthConfig {
 	
 	/** Default configuration for a identity provider. */
 	public static final ProviderConfig DEFAULT_PROVIDER_CONFIG =
-			new ProviderConfig(false, false);
+			new ProviderConfig(false, false, false);
 	
 	/** Default for whether non-admin logins are allowed. */
 	public static final boolean DEFAULT_LOGIN_ALLOWED = false;
@@ -60,22 +60,31 @@ public class AuthConfig {
 	public static class ProviderConfig {
 		
 		private final Boolean enabled;
+		private final Boolean forceLoginChoice;
 		private final Boolean forceLinkChoice;
 		
 		/** Create a provider config.
 		 * @param enabled whether the provider is enabled. True if so, false if not, null if no
 		 * change should be applied.
-		 * @param forceLinkChoice if false, an account link will proceed immediately if the
-		 * provider only returns a single account. If true, the authentication will return a list
-		 * of choices for linking populated with all the accounts returned from the provider,
+		 * @param forceLoginChoice if false, an account link will proceed immediately if the
+		 * provider only returns a single remote identity and that identity is already linked
+		 * to a user account. If true, the Authentication class will return a list of choices for
+		 * login or account creation populated with all the accounts returned from the provider,
 		 * regardless of the number of accounts. Null indicates no change should be applied.
+		 * @param forceLinkChoice if false, an account link will proceed immediately if the
+		 * provider only returns a single remote identity. If true, the Authentication class will
+		 * return a list of choices for linking populated with all the accounts returned from the
+		 * provider, regardless of the number of accounts. Null indicates no change should be
+		 * applied.
 		 */
 		public ProviderConfig(
 				final Boolean enabled,
+				final Boolean forceLoginChoice,
 				final Boolean forceLinkChoice) {
 			super();
 			this.enabled = enabled;
 			this.forceLinkChoice = forceLinkChoice;
+			this.forceLoginChoice = forceLoginChoice;
 		}
 
 		/** Returns whether this provider is enabled.
@@ -83,6 +92,15 @@ public class AuthConfig {
 		 */
 		public Boolean isEnabled() {
 			return enabled;
+		}
+		
+		/** Returns whether the authorization instance will always return a list of account choices
+		 * when logging in, regardless of the size of the list.
+		 * @return true if a list is always returned, false if the login proceeds immediately if
+		 * only one account is available for login, null for no change.
+		 */
+		public Boolean isForceLoginChoice() {
+			return forceLoginChoice;
 		}
 
 		/** Returns whether the authorization instance will always return a list of account choices
@@ -100,6 +118,7 @@ public class AuthConfig {
 			int result = 1;
 			result = prime * result + ((enabled == null) ? 0 : enabled.hashCode());
 			result = prime * result + ((forceLinkChoice == null) ? 0 : forceLinkChoice.hashCode());
+			result = prime * result + ((forceLoginChoice == null) ? 0 : forceLoginChoice.hashCode());
 			return result;
 		}
 
@@ -129,6 +148,13 @@ public class AuthConfig {
 			} else if (!forceLinkChoice.equals(other.forceLinkChoice)) {
 				return false;
 			}
+			if (forceLoginChoice == null) {
+				if (other.forceLoginChoice != null) {
+					return false;
+				}
+			} else if (!forceLoginChoice.equals(other.forceLoginChoice)) {
+				return false;
+			}
 			return true;
 		}
 
@@ -137,6 +163,8 @@ public class AuthConfig {
 			StringBuilder builder = new StringBuilder();
 			builder.append("ProviderConfig [enabled=");
 			builder.append(enabled);
+			builder.append(", forceLoginChoice=");
+			builder.append(forceLoginChoice);
 			builder.append(", forceLinkChoice=");
 			builder.append(forceLinkChoice);
 			builder.append("]");

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1133,8 +1133,11 @@ public class Authentication {
 		final Set<RemoteIdentityWithLocalID> ids = ris.stream().map(r -> r.withID())
 				.collect(Collectors.toSet());
 		final LoginState ls = getLoginState(ids);
+		final ProviderConfig pc = cfg.getAppConfig().getProviderConfig(provider);
 		final LoginToken lr;
-		if (ls.getUsers().size() == 1 && ls.getIdentities().isEmpty()) {
+		if (ls.getUsers().size() == 1 &&
+				ls.getIdentities().isEmpty() &&
+				!pc.isForceLoginChoice()) {
 			final UserName user = ls.getUsers().iterator().next();
 			final AuthUser lastUser = ls.getUser(user);
 			/* Don't throw an error here since an auth UI may not be controlling the call -

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -159,6 +159,8 @@ public class Fields {
 	public static final String CONFIG_PROVIDER = "prov";
 	/** Whether a provider is enabled. */
 	public static final String CONFIG_PROVIDER_ENABLED = "enabled";
+	/** Whether a user should always have to choose to login, even if there's only one choice. */
+	public static final String CONFIG_PROVIDER_FORCE_LOGIN_CHOICE = "loginchoice";
 	/** Whether a user should always have to choose to link a remote identity to their account,
 	 * even if there's only one choice.
 	 */

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -1369,6 +1369,10 @@ public class MongoStorage implements AuthStorage {
 			final AuthConfigSet<T> cfgSet,
 			final boolean overwrite)
 			throws AuthStorageException {
+
+		if (cfgSet == null) {
+			throw new NullPointerException("cfgSet");
+		}
 		
 		updateConfig(COL_CONFIG_APPLICATION,
 				Fields.CONFIG_APP_ALLOW_LOGIN, cfgSet.getCfg().isLoginAllowed(), overwrite);
@@ -1380,6 +1384,8 @@ public class MongoStorage implements AuthStorage {
 		for (final Entry<String, ProviderConfig> e: cfgSet.getCfg().getProviders().entrySet()) {
 			updateProviderConfig(e.getKey(), Fields.CONFIG_PROVIDER_ENABLED,
 					e.getValue().isEnabled(), overwrite);
+			updateProviderConfig(e.getKey(), Fields.CONFIG_PROVIDER_FORCE_LOGIN_CHOICE,
+					e.getValue().isForceLoginChoice(), overwrite);
 			updateProviderConfig(e.getKey(), Fields.CONFIG_PROVIDER_FORCE_LINK_CHOICE,
 					e.getValue().isForceLinkChoice(), overwrite);
 		}
@@ -1414,6 +1420,8 @@ public class MongoStorage implements AuthStorage {
 			final ProviderConfig pc = new ProviderConfig(
 					d.getValue().get(Fields.CONFIG_PROVIDER_ENABLED)
 							.getBoolean(Fields.CONFIG_VALUE),
+					d.getValue().get(Fields.CONFIG_PROVIDER_FORCE_LOGIN_CHOICE)
+							.getBoolean(Fields.CONFIG_VALUE),
 					d.getValue().get(Fields.CONFIG_PROVIDER_FORCE_LINK_CHOICE)
 							.getBoolean(Fields.CONFIG_VALUE));
 			provs.put(d.getKey(), pc);
@@ -1425,6 +1433,10 @@ public class MongoStorage implements AuthStorage {
 	public <T extends ExternalConfig> AuthConfigSet<T> getConfig(
 			final ExternalConfigMapper<T> mapper)
 			throws AuthStorageException, ExternalConfigMappingException {
+		
+		if (mapper == null) {
+			throw new NullPointerException("mapper");
+		}
 		try {
 			final FindIterable<Document> extiter = db.getCollection(COL_CONFIG_EXTERNAL).find();
 			final Map<String, String> ext = new HashMap<>();

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -605,12 +605,13 @@ public class Admin {
 			@Context final HttpHeaders headers,
 			@FormParam("provname") final String provname,
 			@FormParam("enabled") final String enabled,
+			@FormParam("forceloginchoice") final String forceLogin,
 			@FormParam("forcelinkchoice") final String forcelink)
 			throws MissingParameterException, InvalidTokenException,
 			UnauthorizedException, NoTokenProvidedException,
 			AuthStorageException, NoSuchIdentityProviderException {
 		final ProviderConfig pc = new ProviderConfig(
-				!nullOrEmpty(enabled), !nullOrEmpty(forcelink));
+				!nullOrEmpty(enabled), !nullOrEmpty(forceLogin), !nullOrEmpty(forcelink));
 		if (provname == null || provname.isEmpty()) {
 			throw new MissingParameterException("provname");
 		}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
@@ -16,6 +16,7 @@ import us.kbase.auth2.lib.AuthConfig.TokenLifetimeType;
 import us.kbase.auth2.lib.AuthConfigSet;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
+import us.kbase.test.auth2.TestCommon;
 import us.kbase.test.auth2.lib.TestExternalConfig;
 import us.kbase.test.auth2.lib.TestExternalConfig.TestExternalConfigMapper;
 
@@ -34,8 +35,8 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(false, true),
-								"prov2", new ProviderConfig(true, false)),
+								"prov1", new ProviderConfig(false, true, false),
+								"prov2", new ProviderConfig(true, false, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
@@ -44,8 +45,8 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		
 		final AuthConfig expected = new AuthConfig(true,
 				ImmutableMap.of(
-						"prov1", new ProviderConfig(false, true),
-						"prov2", new ProviderConfig(true, false)),
+						"prov1", new ProviderConfig(false, true, false),
+						"prov2", new ProviderConfig(true, false, true)),
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L));
@@ -60,8 +61,8 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(false, true),
-								"prov2", new ProviderConfig(true, false)),
+								"prov1", new ProviderConfig(false, true, false),
+								"prov2", new ProviderConfig(true, false, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
@@ -71,9 +72,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(false,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(true, true),
-								"prov2", new ProviderConfig(true, true),
-								"prov3", new ProviderConfig(true, true)),
+								"prov1", new ProviderConfig(true, true, true),
+								"prov2", new ProviderConfig(true, true, true),
+								"prov3", new ProviderConfig(true, true, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.LOGIN, 600000L,
@@ -83,9 +84,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		
 		final AuthConfig expected = new AuthConfig(true,
 				ImmutableMap.of(
-						"prov1", new ProviderConfig(false, true),
-						"prov2", new ProviderConfig(true, false),
-						"prov3", new ProviderConfig(true, true)),
+						"prov1", new ProviderConfig(false, true, false),
+						"prov2", new ProviderConfig(true, false, true),
+						"prov3", new ProviderConfig(true, true, true)),
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L,
@@ -101,8 +102,8 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(false, true),
-								"prov2", new ProviderConfig(true, false)),
+								"prov1", new ProviderConfig(false, true, false),
+								"prov2", new ProviderConfig(true, false, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
@@ -112,9 +113,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(false,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(true, true),
-								"prov2", new ProviderConfig(true, true),
-								"prov3", new ProviderConfig(true, true)),
+								"prov1", new ProviderConfig(true, true, true),
+								"prov2", new ProviderConfig(true, true, true),
+								"prov3", new ProviderConfig(true, true, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.LOGIN, 600000L,
@@ -124,9 +125,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		
 		final AuthConfig expected = new AuthConfig(false,
 				ImmutableMap.of(
-						"prov1", new ProviderConfig(true, true),
-						"prov2", new ProviderConfig(true, true),
-						"prov3", new ProviderConfig(true, true)),
+						"prov1", new ProviderConfig(true, true, true),
+						"prov2", new ProviderConfig(true, true, true),
+						"prov3", new ProviderConfig(true, true, true)),
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 600000L,
@@ -144,8 +145,8 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(false, true),
-								"prov2", new ProviderConfig(true, false)),
+								"prov1", new ProviderConfig(false, true, false),
+								"prov2", new ProviderConfig(true, false, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
@@ -155,9 +156,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(null,
 						ImmutableMap.of(
-								"prov1", new ProviderConfig(true, true),
-								"prov2", new ProviderConfig(null, null),
-								"prov3", new ProviderConfig(true, true)),
+								"prov1", new ProviderConfig(true, true, true),
+								"prov2", new ProviderConfig(null, null, null),
+								"prov3", new ProviderConfig(true, true, true)),
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.SERV, 800000L)),
@@ -166,9 +167,9 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		
 		final AuthConfig expected = new AuthConfig(true,
 				ImmutableMap.of(
-						"prov1", new ProviderConfig(true, true),
-						"prov2", new ProviderConfig(true, false),
-						"prov3", new ProviderConfig(true, true)),
+						"prov1", new ProviderConfig(true, true, true),
+						"prov2", new ProviderConfig(true, false, true),
+						"prov3", new ProviderConfig(true, true, true)),
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 300000L,
@@ -195,6 +196,26 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 			fail("expected exception");
 		} catch (ExternalConfigMappingException e) {
 			assertThat("correct exception message", e.getMessage(), is("borkborkbork"));
+		}
+	}
+	
+	@Test
+	public void getConfigFail() throws Exception {
+		try {
+			storage.getConfig(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("mapper"));
+		}
+	}
+	
+	@Test
+	public void updateConfigFail() throws Exception {
+		try {
+			storage.updateConfig(null, true);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("cfgSet"));
 		}
 	}
 }

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -78,6 +78,14 @@ provider, e.g. a choice of accounts is required.
 <p>When linking accounts show link choices even if there's only one choice:
 <input type="checkbox" name="forcelinkchoice" {{#forcelinkchoice}}checked{{/forcelinkchoice}}/>
 </p>
+<p>On login show login choices even if there's only one choice:
+<input type="checkbox" name="forceloginchoice" {{#forceloginchoice}}checked{{/forceloginchoice}}/></br>
+Select this option if a custom UI is setting its own login cookies but is not intercepting the 
+3rd party identity provider redirect. The server will then always
+redirect to the UI prior to logging in a user (but after processing the return from the identity
+provider), so the UI can then use JSON endpoints that don't
+set a cookie with a login token.
+</p>
 <input type="reset" value="Reset"/>
 <input type="submit" value="Update"/>
 </form>


### PR DESCRIPTION
Instead redirect to the UI and allow UI to handle the login. This is
useful for UIs that don't intercept the 3rd party redirect but want to
use the JSON endpoints that return the login token in the body rather
than in a cookie (or at least will in the future).