### PR TITLE
Update travis tests and test time window on acct creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,29 @@ jdk:
 
 env:
   global:
-    - MONGODB_VERSION=2.6.12
+    - MONGODB_VER_26=mongodb-linux-x86_64-2.6.12
+    - MONGODB_VER_30=mongodb-linux-x86_64-3.0.14
+    - MONGODB_VER_32=mongodb-linux-x86_64-3.2.12
+    - MONGODB_VER_34=mongodb-linux-x86_64-3.4.2
 
 before_install:
-    # get and install mongodb, set MONGOD to the mongod executable
-    - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-    - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-    - export MONGOD=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin/mongod
-    - echo $MONGOD
+    # get and install various mongodb versions
+    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER_26.tgz
+    - tar xfz $MONGODB_VER_26.tgz
+    - export MONGOD26=`pwd`/$MONGODB_VER_26/bin/mongod
+
+    #- wget http://fastdl.mongodb.org/linux/$MONGODB_VER_30.tgz
+    #- tar xfz $MONGODB_VER_30.tgz
+    #- export MONGOD30=`pwd`/$MONGODB_VER_30/bin/mongod
+
+    #- wget http://fastdl.mongodb.org/linux/$MONGODB_VER_32.tgz
+    #- tar xfz $MONGODB_VER_32.tgz
+    #- export MONGOD32=`pwd`/$MONGODB_VER_32/bin/mongod
+
+    #- wget http://fastdl.mongodb.org/linux/$MONGODB_VER_34.tgz
+    #- tar xfz $MONGODB_VER_34.tgz
+    #- export MONGOD34=`pwd`/$MONGODB_VER_34/bin/mongod
+
 
 install:
     - cd ..
@@ -26,14 +41,19 @@ install:
 
 script:
     - cp -n test.cfg.example test.cfg
+
+    - mkdir temp_test_dir
     # Note: using # as delimiter instead of / since / is in the mongod path
     # If there are # in the mongod path, this will fail.
-    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD#" test.cfg
-    - mkdir temp_test_dir
     - sed -i "s#^test.temp.dir=.*#test.temp.dir=temp_test_dir#" test.cfg
+
+    # Test against MONGO 2.6
+    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD26#" test.cfg
     - cat test.cfg
     - ant test
 
-#after_success:
-#  - mv test/.coverage .
-#  - coveralls
+    # Test against MONGO 3.0
+    #- sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD30#" test.cfg
+    #- cat test.cfg
+    #- ant test
+

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Requirements
 ------------
 Java 8 (OpenJDK OK)  
 Apache Ant (http://ant.apache.org/)  
-MongoDB 2.4+ (https://www.mongodb.com/)  
+MongoDB 2.6+ (https://www.mongodb.com/)  
 Jetty 9.3+ (http://www.eclipse.org/jetty/download.html)
     (see jetty-config.md for version used for testing)  
 This repo (git clone https://github.com/kbase/auth2)  

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
@@ -53,7 +53,7 @@ public class AuthenticationCreateRootTest {
 	 */
 	
 	/* The pwd hash is checked by regenerating from the provided salt.
-	 * The created date is checked to be within 200 ms of the current time.
+	 * The created date is checked to be within 500 ms of the current time.
 	 */
 	private class RootUserAnswerMatcher implements Answer<Void> {
 
@@ -86,8 +86,8 @@ public class AuthenticationCreateRootTest {
 			f.set(exp, user.getCreated().getTime());
 			assertThat("local user does not match. Created date was not checked.", user, is(exp));
 			// may want to consider mocking date generation
-			assertThat("creation date not within 200ms",
-					TestCommon.dateWithin(user.getCreated(), 200), is(true));
+			assertThat("creation date not within 500ms",
+					TestCommon.dateWithin(user.getCreated(), 500), is(true));
 			return null;
 		}
 		


### PR DESCRIPTION
Sets up testing against multiple versions of mongo, extend test time window to 500ms for local user account creation which is needed occasionally when travis is under load.