### PR TITLE
Update /link endpoints, remove JSON versions of /(login|link)/start

### DIFF
--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -105,55 +105,25 @@ public class Link {
 		return ret;
 	}
 	
+	/* this method intentionally does not check the user identity because UIs must use a browser
+	 * form submit rather than AJAX for the redirect to work correctly. Since it's a form submit
+	 * the UI cannot trap any errors, and an invalid token error would default to the built in
+	 * HTML UI. Hence, this method should only throw errors when the request absolutely cannot
+	 * continue.
+	 */
 	@POST
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Path(UIPaths.LINK_START)
 	public Response linkStart(
-			@Context final HttpHeaders headers,
 			@FormParam("provider") final String provider)
 			throws NoTokenProvidedException, NoSuchIdentityProviderException,
 			AuthStorageException, InvalidTokenException, DisabledUserException {
-		
-		final IncomingToken incToken = getTokenFromCookie(headers, cfg.getTokenCookieName());
-		return linkStart(provider, incToken);
-	}
-
-	private Response linkStart(final String provider, final IncomingToken incToken)
-			throws InvalidTokenException, AuthStorageException, DisabledUserException,
-			NoSuchIdentityProviderException {
-		auth.getUser(incToken); // ensures the token is valid
 		
 		final String state = auth.getBareToken();
 		final URI target = toURI(auth.getIdentityProviderURL(provider, state, true));
 		return Response.seeOther(target).cookie(getStateCookie(state)).build();
 	}
-	
-	private static class LinkStart extends IncomingJSON {
-		
-		public final String provider;
 
-		@JsonCreator
-		public LinkStart(@JsonProperty("provider") final String provider) {
-			this.provider = provider;
-		}
-	}
-	
-	@POST
-	@Consumes(MediaType.APPLICATION_JSON)
-	@Path(UIPaths.LINK_START)
-	public Response linkStart(
-			@HeaderParam(UIConstants.HEADER_TOKEN) final String token,
-			final LinkStart start)
-			throws NoTokenProvidedException, InvalidTokenException, DisabledUserException,
-				NoSuchIdentityProviderException, AuthStorageException, IllegalParameterException,
-				MissingParameterException {
-		if (start == null) {
-			throw new MissingParameterException("JSON body missing");
-		}
-		start.exceptOnAdditionalProperties();
-		return linkStart(start.provider, getToken(token));
-	}
-	
 	private NewCookie getStateCookie(final String state) {
 		return new NewCookie(new Cookie(LINK_STATE_COOKIE,
 				state == null ? "no state" : state, UIPaths.LINK_ROOT_COMPLETE, null),

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -118,61 +118,16 @@ public class Login {
 			throws IllegalParameterException, AuthStorageException,
 			NoSuchIdentityProviderException {
 		
-		return loginStart(provider, redirect, stayLoggedIn == null);
-	}
-
-	private Response loginStart(
-			final String provider,
-			final String redirect,
-			final boolean session)
-			throws AuthStorageException, IllegalParameterException,
-			NoSuchIdentityProviderException {
 		getRedirectURL(redirect); // check redirect url is ok
 		final String state = auth.getBareToken();
 		final URI target = toURI(auth.getIdentityProviderURL(provider, state, false));
-
+		
 		final ResponseBuilder r = Response.seeOther(target).cookie(getStateCookie(state))
-				.cookie(getSessionChoiceCookie(session));
+				.cookie(getSessionChoiceCookie(stayLoggedIn == null));
 		if (redirect != null && !redirect.trim().isEmpty()) {
 			r.cookie(getRedirectCookie(redirect));
 		}
 		return r.build();
-	}
-	
-	private static class LoginStart extends IncomingJSON {
-		
-		public String provider;
-		public String redirect;
-		private Object stayLoggedIn;
-		
-		@JsonCreator
-		public LoginStart(
-				@JsonProperty("provider") final String provider,
-				@JsonProperty("redirect") final String redirect,
-				@JsonProperty("stay_logged_in") final Object stayLoggedIn) {
-			super();
-			this.provider = provider;
-			this.redirect = redirect;
-			this.stayLoggedIn = stayLoggedIn;
-		}
-		
-		public boolean isStayLoggedIn() throws IllegalParameterException {
-			return getBoolean(stayLoggedIn, "stay_logged_in");
-		}
-	}
-	
-	@POST
-	@Consumes(MediaType.APPLICATION_JSON)
-	@Path(UIPaths.LOGIN_START)
-	public Response loginStart(final LoginStart login)
-			throws IllegalParameterException, AuthStorageException,
-			NoSuchIdentityProviderException, MissingParameterException {
-		if (login == null) {
-			throw new MissingParameterException("JSON body missing");
-		}
-		
-		login.exceptOnAdditionalProperties();
-		return loginStart(login.provider, login.redirect, !login.isStayLoggedIn());
 	}
 
 	private URL getRedirectURL(final String redirect)

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -177,8 +177,9 @@ public class Me {
 			throws NoTokenProvidedException, InvalidTokenException,
 			AuthStorageException, UnLinkFailedException, DisabledUserException {
 		// id can't be null
-		final IncomingToken token = getTokenFromCookie(headers, cfg.getTokenCookieName(), false);
-		auth.unlink(token == null ? getToken(headerToken) : token, id);
+		final Optional<IncomingToken> token = getTokenFromCookie(
+				headers, cfg.getTokenCookieName(), false);
+		auth.unlink(token.isPresent() ? token.get() : getToken(headerToken), id);
 	}
 	
 	@POST

--- a/src/us/kbase/auth2/service/ui/UIUtils.java
+++ b/src/us/kbase/auth2/service/ui/UIUtils.java
@@ -13,6 +13,8 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.UriInfo;
 
+import com.google.common.base.Optional;
+
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
@@ -113,11 +115,10 @@ public class UIUtils {
 			final HttpHeaders headers,
 			final String tokenCookieName)
 			throws NoTokenProvidedException {
-		return getTokenFromCookie(headers, tokenCookieName, true);
+		return getTokenFromCookie(headers, tokenCookieName, true).get();
 	}
 	
-	//TODO CODE use optional
-	public static IncomingToken getTokenFromCookie(
+	public static Optional<IncomingToken> getTokenFromCookie(
 			final HttpHeaders headers,
 			final String tokenCookieName,
 			final boolean throwException)
@@ -128,17 +129,17 @@ public class UIUtils {
 			if (throwException) {
 				throw new NoTokenProvidedException("No user token provided");
 			}
-			return null;
+			return Optional.absent();
 		}
 		final String val = c.getValue();
 		if (val == null || val.trim().isEmpty()) {
 			if (throwException) {
 				throw new NoTokenProvidedException("No user token provided");
 			}
-			return null;
+			return Optional.absent();
 		}
 		try {
-			return new IncomingToken(val.trim());
+			return Optional.of(new IncomingToken(val.trim()));
 		} catch (MissingParameterException e) {
 			throw new RuntimeException("This should be impossible", e);
 		}


### PR DESCRIPTION
/*/start are useless - there's no way to have the redirect work correctly with
json input, has to be a form submit from the browser. There's no way to
set headers for a form submit. Worse, there's no way to catch any errors
for the form submit, which means the raw auth2 server response will be
shown if the token is invalid.

For the latter reason, removed the token check from /link/start.

* [x] make /link/complete token optional, since non-built in UIs may submit tokens via headers vs. cookies. Hence /link/complete should not rely on a token to function, since the ui cannot submit a token.
