### PR TITLE
Add Name superclass and partial Authentication.java token tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -207,6 +207,7 @@
       <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
+      <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
       <test name="us.kbase.test.auth2.lib.AuthUserTest"/>
       <test name="us.kbase.test.auth2.lib.CollectingExternalConfigTest"/>
       <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>

--- a/build.xml
+++ b/build.xml
@@ -219,10 +219,11 @@
       <test name="us.kbase.test.auth2.lib.LocalUserTest"/>
       <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
       <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
+      <test name="us.kbase.test.auth2.lib.NameTest"/>
       <test name="us.kbase.test.auth2.lib.NewUserTest"/>
       <test name="us.kbase.test.auth2.lib.PasswordTest"/>
       <test name="us.kbase.test.auth2.lib.RoleTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
+      <test name="us.kbase.test.auth2.lib.TokenNameTest"/>
       <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
       <test name="us.kbase.test.auth2.lib.UserNameTest"/>
       <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
@@ -245,6 +246,7 @@
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
+      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -640,7 +640,7 @@ public class Authentication {
 			final boolean serverToken)
 			throws AuthStorageException, MissingParameterException,
 			InvalidTokenException, UnauthorizedException {
-		checkString(tokenName, "token name"); //TODO CODE max token name size 100, make a Name class that handles the checking, removes control chars, etc and UserName & other classes inherit from
+		checkString(tokenName, "token name");
 		final HashedToken t = getToken(token);
 		if (!t.getTokenType().equals(TokenType.LOGIN)) {
 			throw new UnauthorizedException(ErrorType.UNAUTHORIZED,

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1,6 +1,5 @@
 package us.kbase.auth2.lib;
 
-import static us.kbase.auth2.lib.Utils.checkString;
 import static us.kbase.auth2.lib.Utils.clear;
 import static us.kbase.auth2.lib.Utils.nonNull;
 import static us.kbase.auth2.lib.Utils.noNulls;
@@ -636,11 +635,11 @@ public class Authentication {
 	 */
 	public NewToken createToken(
 			final IncomingToken token,
-			final String tokenName,
+			final TokenName tokenName,
 			final boolean serverToken)
 			throws AuthStorageException, MissingParameterException,
 			InvalidTokenException, UnauthorizedException {
-		checkString(tokenName, "token name");
+		nonNull(tokenName, "tokenName");
 		final HashedToken t = getToken(token);
 		if (!t.getTokenType().equals(TokenType.LOGIN)) {
 			throw new UnauthorizedException(ErrorType.UNAUTHORIZED,

--- a/src/us/kbase/auth2/lib/CustomRole.java
+++ b/src/us/kbase/auth2/lib/CustomRole.java
@@ -1,9 +1,9 @@
 package us.kbase.auth2.lib;
 
+import static us.kbase.auth2.lib.Utils.checkString;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static us.kbase.auth2.lib.Utils.checkString;
 
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -44,7 +44,7 @@ public class CustomRole {
 	
 	public static void checkValidRoleID(final String id)
 			throws MissingParameterException, IllegalParameterException {
-		checkString(id, "custom role id", MAX_ROLE_LENGTH);
+		Name.checkValidName(id, "custom role id", MAX_ROLE_LENGTH);
 		final Matcher m = INVALID_CHARS.matcher(id);
 		if (m.find()) {
 			throw new IllegalParameterException(String.format(

--- a/src/us/kbase/auth2/lib/DisplayName.java
+++ b/src/us/kbase/auth2/lib/DisplayName.java
@@ -1,7 +1,5 @@
 package us.kbase.auth2.lib;
 
-import static us.kbase.auth2.lib.Utils.checkString;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -13,30 +11,20 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  * @author gaprice@lbl.gov
  *
  */
-public class DisplayName {
+public class DisplayName extends Name {
 
 	private final static int MAX_NAME_LENGTH = 100;
 	
 	/* What's ok for a display name? for now just a non-empty string < 100 chars, trimmed. */
 	
-	private final String name;
-	
 	/** Create a display name.
 	 * @param name the name.
 	 * @throws MissingParameterException if the name is null or the empty string.
-	 * @throws IllegalParameterException if the name is too long.
+	 * @throws IllegalParameterException if the name is too long or contains control characters.
 	 */
 	public DisplayName(final String name)
 			throws MissingParameterException, IllegalParameterException {
-		checkString(name, "display name", MAX_NAME_LENGTH);
-		this.name = name.trim().replaceAll("\\p{Cntrl}", "");;
-	}
-	
-	/** Get the display name.
-	 * @return the display name.
-	 */
-	public String getName() {
-		return name;
+		super(name, "display name", MAX_NAME_LENGTH);
 	}
 	
 	/** Get the canonical display name for this name. Returns a list of the whitespace separated
@@ -45,45 +33,15 @@ public class DisplayName {
 	 */
 	public List<String> getCanonicalDisplayName() {
 		//TODO SEARCH remove punctuation on the outside of tokens, needs to handle unicode
-		return Arrays.asList(name.toLowerCase().split("\\s+"));
+		return Arrays.asList(getName().toLowerCase().split("\\s+"));
 	}
 	
 	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("DisplayName [name=");
-		builder.append(name);
+		builder.append("DisplayName [getName()=");
+		builder.append(getName());
 		builder.append("]");
 		return builder.toString();
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((name == null) ? 0 : name.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		DisplayName other = (DisplayName) obj;
-		if (name == null) {
-			if (other.name != null) {
-				return false;
-			}
-		} else if (!name.equals(other.name)) {
-			return false;
-		}
-		return true;
 	}
 }

--- a/src/us/kbase/auth2/lib/Name.java
+++ b/src/us/kbase/auth2/lib/Name.java
@@ -1,0 +1,103 @@
+package us.kbase.auth2.lib;
+
+import static us.kbase.auth2.lib.Utils.checkString;
+import static us.kbase.auth2.lib.Utils.checkStringNoCheckedException;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+/** The base class for objects that are names.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class Name {
+	
+	private final String name;
+	
+	/** Create a new name.
+	 * 
+	 * Prior to any operations .trim() is called on the name.
+	 * 
+	 * @param name the name to create.
+	 * @param type the type of the name. This string is included in exceptions but is otherwise
+	 * unused.
+	 * @param maxCodePoints the maximum number of code points in the name. Values less than 1
+	 * are ignored.
+	 * @throws MissingParameterException if the name is null or the empty string.
+	 * @throws IllegalParameterException if the name is too long or if the name contains
+	 * control characters.
+	 */
+	public Name(final String name, final String type, final int maxCodePoints)
+			throws MissingParameterException, IllegalParameterException {
+		this.name = checkValidName(name, type, maxCodePoints);
+	}
+	
+	/** Check that a name is valid.
+	 * 
+	 * Prior to any operations .trim() is called on the name.
+	 * 
+	 * @param name the name.
+	 * @param type the type of the name. This string is included in exceptions but is otherwise
+	 * unused.
+	 * @param maxCodePoints the maximum number of code points in the name. Values less than 1
+	 * are ignored.
+	 * @return the trimmed name.
+	 * @throws MissingParameterException if the name is null or the empty string.
+	 * @throws IllegalParameterException if the name is too long or if the name contains
+	 * control characters.
+	 */
+	public static String checkValidName(
+			String name,
+			final String type,
+			final int maxCodePoints)
+			throws MissingParameterException, IllegalParameterException {
+		checkStringNoCheckedException(type, "type");
+		checkString(name, type, maxCodePoints);
+		name = name.trim();
+		final boolean[] containsControlChars = {false};
+		name.codePoints().forEach(i -> {
+			containsControlChars[0] = containsControlChars[0] || Character.isISOControl(i);
+		});
+		if (containsControlChars[0]) {
+			throw new IllegalParameterException(type + " contains control characters");
+		}
+		return name;
+	}
+	
+	/** Get the name.
+	 * @return the name.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		Name other = (Name) obj;
+		if (name == null) {
+			if (other.name != null) {
+				return false;
+			}
+		} else if (!name.equals(other.name)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/us/kbase/auth2/lib/TokenName.java
+++ b/src/us/kbase/auth2/lib/TokenName.java
@@ -1,0 +1,23 @@
+package us.kbase.auth2.lib;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+public class TokenName extends Name {
+	
+	//TODO NOW use this in named tokens
+	
+	public TokenName(final String name)
+			throws MissingParameterException, IllegalParameterException {
+		super(name, "token name", 30);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("TokenName [getName()=");
+		builder.append(getName());
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/src/us/kbase/auth2/lib/TokenName.java
+++ b/src/us/kbase/auth2/lib/TokenName.java
@@ -5,8 +5,6 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
 
 public class TokenName extends Name {
 	
-	//TODO NOW use this in named tokens
-	
 	public TokenName(final String name)
 			throws MissingParameterException, IllegalParameterException {
 		super(name, "token name", 30);

--- a/src/us/kbase/auth2/lib/UserName.java
+++ b/src/us/kbase/auth2/lib/UserName.java
@@ -1,7 +1,5 @@
 package us.kbase.auth2.lib;
 
-import static us.kbase.auth2.lib.Utils.checkString;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,7 +16,7 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  * @author gaprice@lbl.gov
  *
  */
-public class UserName {
+public class UserName extends Name{
 
 	// this must never be a valid username 
 	private final static String ROOT_NAME = "***ROOT***";
@@ -38,8 +36,6 @@ public class UserName {
 	private final static Pattern INVALID_CHARS = Pattern.compile(INVALID_CHARS_REGEX);
 	public final static int MAX_NAME_LENGTH = 100;
 	
-	private final String name;
-
 	/** Create a new user name.
 	 * @param name the user name.
 	 * @throws MissingParameterException if the name supplied is null or empty.
@@ -48,10 +44,8 @@ public class UserName {
 	 */
 	public UserName(final String name)
 			throws MissingParameterException, IllegalParameterException {
-		checkString(name, "user name", MAX_NAME_LENGTH);
-		if (name.trim().equals(ROOT_NAME)) {
-			this.name = ROOT_NAME;
-		} else {
+		super(name, "user name", MAX_NAME_LENGTH);
+		if (!name.trim().equals(ROOT_NAME)) {
 			final Matcher m = INVALID_CHARS.matcher(name);
 			if (m.find()) {
 				throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, String.format(
@@ -61,7 +55,6 @@ public class UserName {
 				throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME,
 						"Username must start with a letter");
 			}
-			this.name = name;
 		}
 	}
 	
@@ -69,16 +62,9 @@ public class UserName {
 	 * @return true if this user name represents the root user.
 	 */
 	public boolean isRoot() {
-		return name.equals(ROOT_NAME);
+		return getName().equals(ROOT_NAME);
 	}
 
-	/** Returns the user name as a string.
-	 * @return the user name.
-	 */
-	public String getName() {
-		return name;
-	}
-	
 	// returns the null if the name contains no lowercase letters.
 	/** Given a string, returns a new name based on that string that is a legal user name. If
 	 * it is not possible construct a valid user name, null is returned.
@@ -96,39 +82,11 @@ public class UserName {
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + name.hashCode();
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		final UserName other = (UserName) obj;
-		if (!name.equals(other.name)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
 	public String toString() {
 		StringBuilder builder = new StringBuilder();
-		builder.append("UserName [name=");
-		builder.append(name);
+		builder.append("UserName [getName()=");
+		builder.append(getName());
 		builder.append("]");
 		return builder.toString();
 	}
-	
-	
 }

--- a/src/us/kbase/auth2/lib/Utils.java
+++ b/src/us/kbase/auth2/lib/Utils.java
@@ -28,7 +28,7 @@ public class Utils {
 	}
 	
 	/** Check that a string is non-null, has at least one non-whitespace character, and is below
-	 * a specified length.
+	 * a specified length (not including surrounding whitespace).
 	 * @param s the string to check.
 	 * @param name the name of the string to use in any error messages.
 	 * @param max the maximum number of code points in the string. If 0 or less, the length is not
@@ -46,7 +46,7 @@ public class Utils {
 			throw new MissingParameterException(name);
 		}
 		
-		if (max > 0 && codePoints(s) > max) {
+		if (max > 0 && codePoints(s.trim()) > max) {
 			throw new IllegalParameterException(
 					name + " size greater than limit " + max);
 		}

--- a/src/us/kbase/auth2/lib/token/HashedToken.java
+++ b/src/us/kbase/auth2/lib/token/HashedToken.java
@@ -10,6 +10,9 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
 
+import com.google.common.base.Optional;
+
+import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.UserName;
 
 /** A hashed token associated with a user.
@@ -21,7 +24,7 @@ public class HashedToken {
 
 	private final TokenType type;
 	private final UUID id;
-	private final String tokenName;
+	private final Optional<TokenName> tokenName;
 	private final String tokenHash;
 	private final UserName userName;
 	private final Instant expirationDate;
@@ -38,7 +41,7 @@ public class HashedToken {
 	 */
 	public HashedToken(
 			final TokenType type,
-			final String tokenName,
+			final Optional<TokenName> tokenName,
 			final UUID id,
 			final String tokenHash,
 			final UserName userName,
@@ -54,7 +57,7 @@ public class HashedToken {
 			throw new IllegalArgumentException("expirationDate must be > creationDate");
 		}
 		this.type = type;
-		this.tokenName = tokenName; // null ok
+		this.tokenName = tokenName == null ? Optional.absent() : tokenName;
 		this.tokenHash = tokenHash;
 		this.userName = userName;
 		this.expirationDate = expirationDate;
@@ -76,10 +79,10 @@ public class HashedToken {
 		return id;
 	}
 	
-	/** Get the name of the token, or null if it is unnamed.
+	/** Get the name of the token, or absent if it is unnamed.
 	 * @return the name of the token.
 	 */
-	public String getTokenName() {
+	public Optional<TokenName> getTokenName() {
 		return tokenName;
 	}
 

--- a/src/us/kbase/auth2/lib/token/NewToken.java
+++ b/src/us/kbase/auth2/lib/token/NewToken.java
@@ -7,6 +7,9 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.google.common.base.Optional;
+
+import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.UserName;
 
 /** A new token associated with a user.
@@ -16,7 +19,7 @@ import us.kbase.auth2.lib.UserName;
 public class NewToken {
 
 	private final TokenType type;
-	private final String tokenName;
+	private final Optional<TokenName> tokenName;
 	private final String token;
 	private final UserName userName;
 	private final Instant expirationDate;
@@ -48,7 +51,7 @@ public class NewToken {
 		}
 		this.id = id;
 		this.type = type;
-		this.tokenName = null;
+		this.tokenName = Optional.absent();
 		this.token = token;
 		this.userName = userName;
 		this.creationDate = creation;
@@ -68,14 +71,14 @@ public class NewToken {
 	public NewToken(
 			final UUID id,
 			final TokenType type,
-			final String tokenName,
+			final TokenName tokenName,
 			final String token,
 			final UserName userName,
 			final Instant creation,
 			final long lifetimeInMS) {
 		nonNull(id, "id");
 		checkStringNoCheckedException(token, "token");
-		checkStringNoCheckedException(tokenName, "tokenName");
+		nonNull(tokenName, "tokenName");
 		nonNull(type, "type");
 		nonNull(userName, "userName");
 		nonNull(creation, "creation");
@@ -84,7 +87,7 @@ public class NewToken {
 		}
 		this.id = id;
 		this.type = type;
-		this.tokenName = tokenName;
+		this.tokenName = Optional.of(tokenName);
 		this.token = token;
 		this.userName = userName;
 		this.creationDate = creation;
@@ -99,10 +102,10 @@ public class NewToken {
 		return type;
 	}
 	
-	/** Get the token's name, or null if the token is not named.
+	/** Get the token's name, or absent if the token is not named.
 	 * @return the token's name.
 	 */
-	public String getTokenName() {
+	public Optional<TokenName> getTokenName() {
 		return tokenName;
 	}
 

--- a/src/us/kbase/auth2/lib/token/TokenSet.java
+++ b/src/us/kbase/auth2/lib/token/TokenSet.java
@@ -56,4 +56,44 @@ public class TokenSet {
 	public Set<HashedToken> getTokens() {
 		return tokens;
 	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((currentToken == null) ? 0 : currentToken.hashCode());
+		result = prime * result + ((tokens == null) ? 0 : tokens.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		TokenSet other = (TokenSet) obj;
+		if (currentToken == null) {
+			if (other.currentToken != null) {
+				return false;
+			}
+		} else if (!currentToken.equals(other.currentToken)) {
+			return false;
+		}
+		if (tokens == null) {
+			if (other.tokens != null) {
+				return false;
+			}
+		} else if (!tokens.equals(other.tokens)) {
+			return false;
+		}
+		return true;
+	}
+	
+	
 }

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
@@ -98,7 +99,7 @@ public class Tokens {
 			@FormParam("tokentype") final String tokenType)
 			throws AuthStorageException, MissingParameterException,
 			NoTokenProvidedException, InvalidTokenException,
-			UnauthorizedException {
+			UnauthorizedException, IllegalParameterException {
 		return createtoken(tokenName, tokenType,
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
 	}
@@ -179,8 +180,9 @@ public class Tokens {
 			final IncomingToken userToken)
 			throws AuthStorageException, MissingParameterException,
 			NoTokenProvidedException, InvalidTokenException,
-			UnauthorizedException {
-		return new UINewToken(auth.createToken(userToken, tokenName, "server".equals(tokenType)));
+			UnauthorizedException, IllegalParameterException {
+		return new UINewToken(auth.createToken(userToken, new TokenName(tokenName),
+				"server".equals(tokenType)));
 	}
 
 	private Map<String, Object> getTokens(final IncomingToken token)

--- a/src/us/kbase/auth2/service/ui/UIToken.java
+++ b/src/us/kbase/auth2/service/ui/UIToken.java
@@ -3,6 +3,9 @@ package us.kbase.auth2.service.ui;
 import java.time.Instant;
 import java.util.UUID;
 
+import com.google.common.base.Optional;
+
+import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.TokenType;
@@ -27,14 +30,14 @@ public class UIToken {
 
 	UIToken(
 			final TokenType type,
-			final String tokenName,
+			final Optional<TokenName> tokenName,
 			final UUID id,
 			final UserName userName,
 			final Instant creationDate,
 			final Instant expirationDate) {
 		this.type = type.getDescription();
 		this.id = id.toString();
-		this.name = tokenName;
+		this.name = tokenName.isPresent() ? tokenName.get().getName() : null;
 		this.user = userName.getName();
 		this.expires = expirationDate.toEpochMilli();
 		this.created = creationDate.toEpochMilli();

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -1,0 +1,94 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import static us.kbase.test.auth2.TestCommon.assertClear;
+import static us.kbase.test.auth2.TestCommon.set;
+import static us.kbase.test.auth2.lib.AuthenticationTester.initTestAuth;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import us.kbase.auth2.cryptutils.RandomDataGenerator;
+import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
+import us.kbase.auth2.lib.storage.AuthStorage;
+import us.kbase.auth2.lib.token.HashedToken;
+import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.lib.AuthenticationTester.TestAuth;
+
+public class AuthenticationTokenTest {
+	
+	
+	/* tests token get, create, revoke, and getBare. */
+	
+	@Test
+	public void getToken() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobar");
+		
+		final Instant now = Instant.now();
+		final UUID id = UUID.randomUUID();
+		
+		final HashedToken expected = new HashedToken(TokenType.LOGIN, null, id,
+				"whee", new UserName("foo"), now, now);
+		
+		when(storage.getToken(t.getHashedToken())).thenReturn(expected);
+		
+		final HashedToken ht = auth.getToken(t);
+		assertThat("incorrect token", ht, is(new HashedToken(TokenType.LOGIN, null,
+				id, "whee", new UserName("foo"), now, now)));
+	}
+	
+	@Test
+	public void getTokenFailNull() throws Exception {
+		final Authentication auth = initTestAuth().auth;
+		failGetToken(auth, null, new NullPointerException("token"));
+	}
+
+	
+	@Test
+	public void getTokenFailNoSuchToken() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobar");
+		
+		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
+		
+		failGetToken(auth, t, new InvalidTokenException());
+	}
+
+	private void failGetToken(
+			final Authentication auth,
+			final IncomingToken t,
+			final Exception e) {
+		try {
+			auth.getToken(t);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+}

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -17,17 +17,31 @@ import static us.kbase.test.auth2.lib.AuthenticationTester.initTestAuth;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import us.kbase.auth2.cryptutils.RandomDataGenerator;
+import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
+import us.kbase.auth2.lib.exceptions.ErrorType;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
+import us.kbase.auth2.lib.exceptions.NoSuchUserException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.AuthStorage;
+import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.lib.token.TokenSet;
@@ -155,6 +169,138 @@ public class AuthenticationTokenTest {
 			final Exception e) {
 		try {
 			auth.getToken(t);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void getTokensUser() throws Exception {
+		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
+				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
+				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+		getTokensUser(admin);
+	}
+	
+	@Test
+	public void getTokensUserFailNonAdmin() throws Exception {
+		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
+				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
+	}
+	
+	@Test
+	public void getTokensUserFailCreate() throws Exception {
+		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
+				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
+				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
+	}
+	
+	@Test
+	public void getTokensUserFailRoot() throws Exception {
+		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
+				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
+				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
+	}
+	
+	@Test
+	public void getTokensUserFailDisabled() throws Exception {
+		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
+				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), null,
+				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
+		failGetTokensUser(admin, new DisabledUserException());
+	}
+	
+	@Test
+	public void getTokensUserFailNulls() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final Authentication auth = testauth.auth;
+		
+		failGetTokensUser(auth, null, new UserName("foo"), new NullPointerException("token"));
+		failGetTokensUser(auth, new IncomingToken("foo"), null,
+				new NullPointerException("userName"));
+	}
+	
+	@Test
+	public void getTokensUserFailInvalidToken() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobarbaz");
+		
+		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
+		
+		failGetTokensUser(auth, t, new UserName("bar"), new InvalidTokenException());
+	}
+	
+	@Test
+	public void forceResetAllPasswordsFailCatastrophicNoUser() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobarbaz");
+		
+		final HashedToken token = new HashedToken(TokenType.LOGIN, null, UUID.randomUUID(),
+				"wubba", new UserName("admin"), Instant.now(), Instant.now());
+		
+		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
+		
+		when(storage.getUser(new UserName("admin"))).thenThrow(new NoSuchUserException("admin"));
+		
+		failGetTokensUser(auth, t, new UserName("bar"), new RuntimeException(
+				"There seems to be an error in the storage system. Token was valid, but no user"));
+	}
+
+	private void getTokensUser(final AuthUser admin) throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobarbaz");
+		
+		final HashedToken token = new HashedToken(TokenType.LOGIN, null, UUID.randomUUID(),
+				"wubba", admin.getUserName(), Instant.now(), Instant.now());
+		
+		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
+		
+		when(storage.getUser(admin.getUserName())).thenReturn(admin, (AuthUser) null);
+		
+		when(storage.getTokens(new UserName("foo"))).thenReturn(set(TOKEN1, TOKEN2));
+		
+		try {
+			final Set<HashedToken> tokens = auth.getTokens(t, new UserName("foo"));
+			assertThat("incorrect tokens", tokens, is(set(TOKEN1, TOKEN2)));
+		} catch (Throwable th) {
+			if (admin.isDisabled()) {
+				verify(storage).deleteTokens(admin.getUserName());
+			}
+			throw th;
+		}
+	}
+	
+	private void failGetTokensUser(final AuthUser admin, final Exception e) {
+		try {
+			getTokensUser(admin);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private void failGetTokensUser(
+			final Authentication auth,
+			final IncomingToken token,
+			final UserName name,
+			final Exception e) {
+		try {
+			auth.getTokens(token, name);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -24,12 +24,15 @@ import java.util.UUID;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import com.google.common.base.Optional;
+
 import us.kbase.auth2.cryptutils.RandomDataGenerator;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
@@ -57,10 +60,10 @@ public class AuthenticationTokenTest {
 	private static final HashedToken TOKEN2;
 	static {
 		try {
-		TOKEN1 = new HashedToken(TokenType.LOGIN, null,
+		TOKEN1 = new HashedToken(TokenType.LOGIN, Optional.absent(),
 				UUID.randomUUID(), "whee", new UserName("foo"), Instant.ofEpochMilli(3000),
 				Instant.ofEpochMilli(4000));
-		TOKEN2 = new HashedToken(TokenType.EXTENDED_LIFETIME, "baz",
+		TOKEN2 = new HashedToken(TokenType.EXTENDED_LIFETIME, Optional.of(new TokenName("baz")),
 				UUID.randomUUID(), "whee1", new UserName("foo"), Instant.ofEpochMilli(5000),
 				Instant.ofEpochMilli(6000));
 		} catch (Exception e) {
@@ -79,13 +82,13 @@ public class AuthenticationTokenTest {
 		final Instant now = Instant.now();
 		final UUID id = UUID.randomUUID();
 		
-		final HashedToken expected = new HashedToken(TokenType.LOGIN, null, id,
+		final HashedToken expected = new HashedToken(TokenType.LOGIN, Optional.absent(), id,
 				"whee", new UserName("foo"), now, now);
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(expected);
 		
 		final HashedToken ht = auth.getToken(t);
-		assertThat("incorrect token", ht, is(new HashedToken(TokenType.LOGIN, null,
+		assertThat("incorrect token", ht, is(new HashedToken(TokenType.LOGIN, Optional.absent(),
 				id, "whee", new UserName("foo"), now, now)));
 	}
 	
@@ -247,8 +250,8 @@ public class AuthenticationTokenTest {
 		
 		final IncomingToken t = new IncomingToken("foobarbaz");
 		
-		final HashedToken token = new HashedToken(TokenType.LOGIN, null, UUID.randomUUID(),
-				"wubba", new UserName("admin"), Instant.now(), Instant.now());
+		final HashedToken token = new HashedToken(TokenType.LOGIN, Optional.absent(),
+				UUID.randomUUID(), "wubba", new UserName("admin"), Instant.now(), Instant.now());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
 		
@@ -265,8 +268,8 @@ public class AuthenticationTokenTest {
 		
 		final IncomingToken t = new IncomingToken("foobarbaz");
 		
-		final HashedToken token = new HashedToken(TokenType.LOGIN, null, UUID.randomUUID(),
-				"wubba", admin.getUserName(), Instant.now(), Instant.now());
+		final HashedToken token = new HashedToken(TokenType.LOGIN, Optional.absent(),
+				UUID.randomUUID(), "wubba", admin.getUserName(), Instant.now(), Instant.now());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
 		
@@ -317,4 +320,7 @@ public class AuthenticationTokenTest {
 		
 		assertThat("incorrect token", auth.getBareToken(), is("foobar"));
 	}
+	
+	//TODO NOW TEST create & revoke
+	
 }

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -30,14 +30,29 @@ import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
 import us.kbase.auth2.lib.storage.AuthStorage;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.TokenSet;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.test.auth2.TestCommon;
 import us.kbase.test.auth2.lib.AuthenticationTester.TestAuth;
 
 public class AuthenticationTokenTest {
 	
-	
 	/* tests token get, create, revoke, and getBare. */
+	
+	private static final HashedToken TOKEN1;
+	private static final HashedToken TOKEN2;
+	static {
+		try {
+		TOKEN1 = new HashedToken(TokenType.LOGIN, null,
+				UUID.randomUUID(), "whee", new UserName("foo"), Instant.ofEpochMilli(3000),
+				Instant.ofEpochMilli(4000));
+		TOKEN2 = new HashedToken(TokenType.EXTENDED_LIFETIME, "baz",
+				UUID.randomUUID(), "whee1", new UserName("foo"), Instant.ofEpochMilli(5000),
+				Instant.ofEpochMilli(6000));
+		} catch (Exception e) {
+			throw new RuntimeException("Fix yer tests newb", e);
+		}
+	}
 	
 	@Test
 	public void getToken() throws Exception {
@@ -81,6 +96,60 @@ public class AuthenticationTokenTest {
 	}
 
 	private void failGetToken(
+			final Authentication auth,
+			final IncomingToken t,
+			final Exception e) {
+		try {
+			auth.getToken(t);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void getTokens() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobar");
+		
+		final Instant now = Instant.now();
+		final UUID id = UUID.randomUUID();
+		
+		final HashedToken expected = new HashedToken(TokenType.LOGIN, null, id,
+				"whee", new UserName("foo"), now, now);
+		
+		when(storage.getToken(t.getHashedToken())).thenReturn(expected, (HashedToken) null);
+		
+		when(storage.getTokens(new UserName("foo"))).thenReturn(set(TOKEN1, TOKEN2));
+		
+		final TokenSet ts = auth.getTokens(t);
+		assertThat("incorrect token set", ts, is(new TokenSet(expected, set(TOKEN2, TOKEN1))));
+	}
+	
+	@Test
+	public void getTokensFailNull() throws Exception {
+		final Authentication auth = initTestAuth().auth;
+		failGetTokens(auth, null, new NullPointerException("token"));
+	}
+
+	
+	@Test
+	public void getTokensFailNoSuchToken() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken t = new IncomingToken("foobar");
+		
+		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
+		
+		failGetTokens(auth, t, new InvalidTokenException());
+	}
+	
+	private void failGetTokens(
 			final Authentication auth,
 			final IncomingToken t,
 			final Exception e) {

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -306,4 +306,15 @@ public class AuthenticationTokenTest {
 			TestCommon.assertExceptionCorrect(got, e);
 		}
 	}
+	
+	@Test
+	public void getBareToken() throws Exception {
+		final TestAuth testauth = initTestAuth();
+		final Authentication auth = testauth.auth;
+		final RandomDataGenerator rand = testauth.randGen;
+		
+		when(rand.getToken()).thenReturn("foobar");
+		
+		assertThat("incorrect token", auth.getBareToken(), is("foobar"));
+	}
 }

--- a/src/us/kbase/test/auth2/lib/CustomRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/CustomRoleTest.java
@@ -28,7 +28,8 @@ public class CustomRoleTest {
 		failConstruct(null, "foo", new MissingParameterException("custom role id"));
 		failConstruct("   \n  ", "foo", new MissingParameterException("custom role id"));
 		failConstruct("bar", null, new MissingParameterException("custom role description"));
-		failConstruct("bar", "   \t \n  ", new MissingParameterException("custom role description"));
+		failConstruct("bar", "   \t \n  ",
+				new MissingParameterException("custom role description"));
 		
 		failConstruct(TestCommon.LONG101, "foo", new IllegalParameterException(
 				ErrorType.ILLEGAL_PARAMETER,
@@ -84,5 +85,4 @@ public class CustomRoleTest {
 	public void equals() {
 		EqualsVerifier.forClass(CustomRole.class).usingGetClass().verify();
 	}
-	
 }

--- a/src/us/kbase/test/auth2/lib/DisplayNameTest.java
+++ b/src/us/kbase/test/auth2/lib/DisplayNameTest.java
@@ -19,10 +19,9 @@ public class DisplayNameTest {
 	
 	@Test
 	public void constructor() throws Exception {
-		//tests removing control characters
-		final DisplayName dn = new DisplayName("    fo\no\boΔ\n");
+		final DisplayName dn = new DisplayName("    foooΔ   ");
 		assertThat("incorrect displayname", dn.getName(), is("foooΔ"));
-		assertThat("incorrect toString", dn.toString(), is("DisplayName [name=foooΔ]"));
+		assertThat("incorrect toString", dn.toString(), is("DisplayName [getName()=foooΔ]"));
 	}
 	
 	@Test
@@ -34,6 +33,8 @@ public class DisplayNameTest {
 	public void constructFail() throws Exception {
 		failConstruct(null, new MissingParameterException("display name"));
 		failConstruct("   \n  ", new MissingParameterException("display name"));
+		failConstruct("    fo\no\boΔ\n", new IllegalParameterException(
+				"display name contains control characters"));
 		failConstruct(TestCommon.LONG101, new IllegalParameterException(
 				ErrorType.ILLEGAL_PARAMETER,
 				"display name size greater than limit 100"));
@@ -50,7 +51,7 @@ public class DisplayNameTest {
 	
 	@Test
 	public void canonical() throws Exception {
-		final DisplayName dn = new DisplayName("whEe      BA\nR  \n bleΔah   wuΞgga");
+		final DisplayName dn = new DisplayName("whEe      BAR   bleΔah   wuΞgga");
 		assertThat("incorrect canonical name", dn.getCanonicalDisplayName(),
 				is(Arrays.asList("whee", "bar", "bleδah", "wuξgga")));
 	}

--- a/src/us/kbase/test/auth2/lib/LocalLoginResultTest.java
+++ b/src/us/kbase/test/auth2/lib/LocalLoginResultTest.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
 import us.kbase.auth2.lib.LocalLoginResult;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.token.NewToken;
@@ -37,7 +39,7 @@ public class LocalLoginResultTest {
 				is(nt.getExpirationDate()));
 		assertThat("incorrect token id", llr.getToken().getId(), is(nt.getId()));
 		assertThat("incorrect token", llr.getToken().getToken(), is("foo"));
-		assertThat("incorrect token name", llr.getToken().getTokenName(), is((String) null));
+		assertThat("incorrect token name", llr.getToken().getTokenName(), is(Optional.absent()));
 		assertThat("incorrect token username", llr.getToken().getUserName(),
 				is(new UserName("bar")));
 		

--- a/src/us/kbase/test/auth2/lib/LocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/LocalUserTest.java
@@ -224,13 +224,14 @@ public class LocalUserTest {
 				"LocalUser [passwordHash=[102, 111, 111, 98, 97, 114, 98, 97, 122, 98], " +
 				"salt=[119, 104], forceReset=false, " +
 				"lastReset=Optional.of(1970-01-01T00:00:04Z), " +
-				"getDisplayName()=DisplayName [name=bar], " +
-				"getEmail()=EmailAddress [email=f@g.com], getUserName()=UserName [name=foo], " +
+				"getDisplayName()=DisplayName [getName()=bar], " +
+				"getEmail()=EmailAddress [email=f@g.com], " +
+				"getUserName()=UserName [getName()=foo], " +
 				"getRoles()=[CREATE_ADMIN], getCustomRoles()=[foobar], " +
 				"getCreated()=1970-01-01T00:00:01Z, " +
 				"getLastLogin()=Optional.of(1970-01-01T00:00:02Z), " +
 				"getDisabledState()=UserDisabledState [disabledReason=Optional.absent(), " +
-				"byAdmin=Optional.of(UserName [name=who])," +
+				"byAdmin=Optional.of(UserName [getName()=who])," +
 				" time=Optional.of(1970-01-01T00:00:03Z)]]"));
 		
 	}

--- a/src/us/kbase/test/auth2/lib/LoginTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginTokenTest.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LoginState;
@@ -56,7 +58,7 @@ public class LoginTokenTest {
 				is(nt.getExpirationDate()));
 		assertThat("incorrect token id", lt.getToken().getId(), is(nt.getId()));
 		assertThat("incorrect token", lt.getToken().getToken(), is("foo"));
-		assertThat("incorrect token name", lt.getToken().getTokenName(), is((String) null));
+		assertThat("incorrect token name", lt.getToken().getTokenName(), is(Optional.absent()));
 		assertThat("incorrect token username", lt.getToken().getUserName(),
 				is(new UserName("bar")));
 		assertThat("incorrect login state provider", lt.getLoginState().getProvider(), is("foo"));

--- a/src/us/kbase/test/auth2/lib/NameTest.java
+++ b/src/us/kbase/test/auth2/lib/NameTest.java
@@ -1,0 +1,93 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.auth2.lib.Name;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.test.auth2.TestCommon;
+
+public class NameTest {
+	
+	@Test
+	public void equals() throws Exception {
+		EqualsVerifier.forClass(Name.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void construct() throws Exception {
+		final Name n = new Name("     foo     ", "bar", 3);
+		assertThat("incorrect name", n.getName(), is("foo"));
+		
+		final Name n2 = new Name("     fo𐎣o     ", "bar", 4);
+		assertThat("incorrect name", n2.getName(), is("fo𐎣o"));
+		
+		final Name n3 = new Name("     foo     ", "bar", 0);
+		assertThat("incorrect name", n3.getName(), is("foo"));
+	}
+	
+	@Test
+	public void check() throws Exception {
+		assertThat("incorrect name", Name.checkValidName("     foo     ", "bar", 3), is("foo"));
+		assertThat("incorrect name", Name.checkValidName("     𐎣foo     ", "bar", 4), is("𐎣foo"));
+		assertThat("incorrect name", Name.checkValidName("     𐎣foo     ", "bar", 0), is("𐎣foo"));
+	}
+	
+	@Test
+	public void constructFail() {
+		failConstruct("foo", null, 3, new IllegalArgumentException("Missing argument: type"));
+		failConstruct("foo", "   \t \n    ", 3,
+				new IllegalArgumentException("Missing argument: type"));
+		failConstruct(null, "thing", 1, new MissingParameterException("thing"));
+		failConstruct("    \t    \n    ", "thing", 1, new MissingParameterException("thing"));
+		failConstruct("     fo𐎣o     ", "thing", 3,
+				new IllegalParameterException("thing size greater than limit 3"));
+		failConstruct("     fo\b𐎣o     ", "thing", 5,
+				new IllegalParameterException("thing contains control characters"));
+	}
+	
+	@Test
+	public void checkFail() {
+		failCheck("foo", null, 3, new IllegalArgumentException("Missing argument: type"));
+		failCheck("foo", "   \t \n    ", 3,
+				new IllegalArgumentException("Missing argument: type"));
+		failCheck(null, "thing", 1, new MissingParameterException("thing"));
+		failCheck("    \t    \n    ", "thing", 1, new MissingParameterException("thing"));
+		failCheck("     fo𐎣o     ", "thing", 3,
+				new IllegalParameterException("thing size greater than limit 3"));
+		failCheck("     fo\b𐎣o     ", "thing", 5,
+				new IllegalParameterException("thing contains control characters"));
+	}
+	
+	private void failConstruct(
+			final String name,
+			final String type,
+			final int maxCodePoints,
+			final Exception e) {
+		try {
+			new Name(name, type, maxCodePoints);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private void failCheck(
+			final String name,
+			final String type,
+			final int maxCodePoints,
+			final Exception e) {
+		try {
+			Name.checkValidName(name, type, maxCodePoints);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+
+}

--- a/src/us/kbase/test/auth2/lib/TokenNameTest.java
+++ b/src/us/kbase/test/auth2/lib/TokenNameTest.java
@@ -1,0 +1,42 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.TokenName;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.test.auth2.TestCommon;
+
+public class TokenNameTest {
+	
+	@Test
+	public void construct() throws Exception {
+		final TokenName tn = new TokenName("foo");
+		assertThat("incorrect name", tn.getName(), is("foo"));
+		assertThat("incorrect toString()", tn.toString(), is("TokenName [getName()=foo]"));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		failConstruct(null, new MissingParameterException("token name"));
+		failConstruct(TestCommon.LONG101.substring(0, 31),
+				new IllegalParameterException("token name size greater than limit 30"));
+	}
+	
+	private void failConstruct(
+			final String name,
+			final Exception e) {
+		try {
+			new TokenName(name);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+		
+	}
+
+}

--- a/src/us/kbase/test/auth2/lib/UserDisabledStateTest.java
+++ b/src/us/kbase/test/auth2/lib/UserDisabledStateTest.java
@@ -181,7 +181,7 @@ public class UserDisabledStateTest {
 		final UserDisabledState uds = new UserDisabledState("foo", new UserName("bar"), t);
 		assertThat("incorrect toString", uds.toString(), is(
 				"UserDisabledState [disabledReason=Optional.of(foo), " +
-				"byAdmin=Optional.of(UserName [name=bar]), " +
+				"byAdmin=Optional.of(UserName [getName()=bar]), " +
 				"time=Optional.of(1970-01-01T00:00:07Z)]"));
 	}
 }

--- a/src/us/kbase/test/auth2/lib/UserNameTest.java
+++ b/src/us/kbase/test/auth2/lib/UserNameTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
@@ -19,13 +20,13 @@ public class UserNameTest {
 		final UserName un = new UserName("***ROOT***");
 		assertThat("incorrect username", un.getName(), is("***ROOT***"));
 		assertThat("incorrect is root", un.isRoot(), is(true));
-		assertThat("incorrect toString", un.toString(), is("UserName [name=***ROOT***]"));
+		assertThat("incorrect toString", un.toString(), is("UserName [getName()=***ROOT***]"));
 		assertThat("incorrect hashCode" , un.hashCode(), is(-280622915));
 		
 		final UserName un2 = UserName.ROOT;
 		assertThat("incorrect username", un2.getName(), is("***ROOT***"));
 		assertThat("incorrect is root", un2.isRoot(), is(true));
-		assertThat("incorrect toString", un2.toString(), is("UserName [name=***ROOT***]"));
+		assertThat("incorrect toString", un2.toString(), is("UserName [getName()=***ROOT***]"));
 		assertThat("incorrect hashCode" , un2.hashCode(), is(-280622915));
 	}
 	
@@ -34,7 +35,7 @@ public class UserNameTest {
 		final UserName un = new UserName("a8nba9");
 		assertThat("incorrect username", un.getName(), is("a8nba9"));
 		assertThat("incorrect is root", un.isRoot(), is(false));
-		assertThat("incorrect toString", un.toString(), is("UserName [name=a8nba9]"));
+		assertThat("incorrect toString", un.toString(), is("UserName [getName()=a8nba9]"));
 		assertThat("incorrect hashCode" , un.hashCode(), is(-1462848190));
 	}
 	
@@ -68,12 +69,7 @@ public class UserNameTest {
 	
 	@Test
 	public void equals() throws Exception {
-		final UserName un1 = new UserName("foo");
-		assertThat("incorrect equality", un1.equals(un1), is(true));
-		assertThat("incorrect null", un1.equals(null), is(false));
-		assertThat("incorrect type", un1.equals("foo"), is(false));
-		assertThat("incorrect bad name", un1.equals(new UserName("bar")), is(false));
-		assertThat("incorrect good name", un1.equals(new UserName("foo")), is(true));
+		EqualsVerifier.forClass(UserName.class).usingGetClass().verify();
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/UtilsTest.java
+++ b/src/us/kbase/test/auth2/lib/UtilsTest.java
@@ -50,6 +50,7 @@ public class UtilsTest {
 		Utils.checkString(TestCommon.LONG1001, "name");
 		Utils.checkStringNoCheckedException(TestCommon.LONG1001, "name");
 		Utils.checkString("ok", "name", 2);
+		Utils.checkString(" \n  ok   \t", "name", 2);
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/token/TokenTest.java
+++ b/src/us/kbase/test/auth2/lib/token/TokenTest.java
@@ -51,6 +51,11 @@ public class TokenTest {
 	}
 	
 	@Test
+	public void equalsTokenSet() {
+		EqualsVerifier.forClass(TokenSet.class).usingGetClass().verify();
+	}
+	
+	@Test
 	public void tokenTypeGetType() throws Exception {
 		assertThat("failed to get login token type", TokenType.getType("Login"),
 				is(TokenType.LOGIN));


### PR DESCRIPTION
Added a Name superclass for UserName, DisplayName, and the new TokenName (see below) that handles common code - checking for nulls, whitespace only, control chars, and max code points, as well as trimming the name.

Added a TokenName class that does minimal checking on the token name (max length 30 code points, no control chars).

Used Optional rather than null for designating unnamed tokens.

Add tests for token related functionality in Authentication.java. Still need to test non-login based creation & revocation. Merging this now, however, as it's getting big.

