### PR TITLE
Ignore root & disabled users when verifiying users via list

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
       Build file for the second KBase Authentication Service 
   </description>
 	
-  <!-- TODO BUILD switch to gradle or at least ivy -->
+  <!-- TODO ZLATER BUILD switch to gradle or at least ivy -->
 
   <!-- set global properties for this build -->
   <property name="package" value="KBase authentication service"/>

--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -29,8 +29,6 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	//TODO JAVADOC
 	//TODO TEST unittests
 	
-	//TODO DOCs document deploy.cfg.example
-	
 	private static final String KB_DEP = "KB_DEPLOYMENT_CONFIG";
 	private static final String CFG_LOC ="authserv2";
 	private static final String DEFAULT_LOG_NAME = "KBaseAuthService2";

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -796,7 +796,7 @@ public class Authentication {
 	}
 
 	/** Look up display names for a set of user names. A maximum of 10000 users may be looked up
-	 * at once.
+	 * at once. Never returns the root user name or disabled users.
 	 * @param token a token for the user requesting the lookup.
 	 * @param usernames the user names to look up.
 	 * @return the display names for each user name. Any non-existent user names will be missing.
@@ -809,8 +809,6 @@ public class Authentication {
 			final IncomingToken token,
 			final Set<UserName> usernames)
 			throws InvalidTokenException, AuthStorageException, IllegalParameterException {
-		//TODO DISABLED don't return disabled users in user search (do return in search from admin)
-		//TODO SEARCH never include root user
 		getToken(token); // just check the token is valid
 		if (usernames.size() > MAX_RETURNED_USERS) {
 			throw new IllegalParameterException(
@@ -819,7 +817,10 @@ public class Authentication {
 		if (usernames.isEmpty()) {
 			return new HashMap<>();
 		}
-		return storage.getUserDisplayNames(usernames);
+		
+		final Map<UserName, DisplayName> displayNames = storage.getUserDisplayNames(usernames);
+		displayNames.remove(UserName.ROOT);
+		return displayNames;
 	}
 	
 	/** Look up display names based on a search specification. A maximum of 10000 users will be

--- a/src/us/kbase/auth2/lib/UserSearchSpec.java
+++ b/src/us/kbase/auth2/lib/UserSearchSpec.java
@@ -28,6 +28,8 @@ public class UserSearchSpec {
 	private final Set<Role> searchRoles = new HashSet<>();
 	private final Set<String> searchCustomRoles = new HashSet<>();
 	private boolean isRegex = false;
+	private boolean includeRoot = false;
+	private boolean includeDisabled = false;
 	
 	private UserSearchSpec() {}
 
@@ -102,6 +104,20 @@ public class UserSearchSpec {
 	 */
 	public Set<String> getSearchCustomRoles() {
 		return Collections.unmodifiableSet(searchCustomRoles);
+	}
+	
+	/** Returns true if the root user should be included in the search results if warranted.
+	 * @return true if the root user should be included.
+	 */
+	public boolean isRootIncluded() {
+		return includeRoot;
+	}
+	
+	/** Returns true if disabled users should be included in the search results if warranted.
+	 * @return true if disabled users should be included.
+	 */
+	public boolean isDisabledIncluded() {
+		return includeDisabled;
 	}
 	
 	/** Returns the field by which users should be ordered when applying a limit.
@@ -248,6 +264,24 @@ public class UserSearchSpec {
 						"Custom role cannot be null or the empty string");
 			}
 			uss.searchCustomRoles.add(customRole);
+			return this;
+		}
+		
+		/** Include the root user in the search results, if warranted.
+		 * @param include true to include the root user.
+		 * @return this builder.
+		 */
+		public Builder withIncludeRoot(final boolean include) {
+			uss.includeRoot = include;
+			return this;
+		}
+		
+		/** Include disabled users in the search results, if warranted.
+		 * @param include true to include disabled users.
+		 * @return this builder.
+		 */
+		public Builder withIncludeDisabled(final boolean include) {
+			uss.includeDisabled = include;
 			return this;
 		}
 		

--- a/src/us/kbase/auth2/lib/UserSearchSpec.java
+++ b/src/us/kbase/auth2/lib/UserSearchSpec.java
@@ -20,7 +20,7 @@ import com.google.common.base.Optional;
  */
 public class UserSearchSpec {
 	
-	//TODO CODE don't expose regex externally. Not sure how best to do this without duplicating a lot of the class. For now setting regex is default access (package only).
+	//TODO ZLATER CODE don't expose regex externally. Not sure how best to do this without duplicating a lot of the class. For now setting regex is default access (package only).
 	
 	private Optional<String> prefix = Optional.absent();
 	private boolean searchUser = false;

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -136,7 +136,7 @@ public interface AuthStorage {
 	Optional<AuthUser> getUser(RemoteIdentity remoteID) throws AuthStorageException;
 	
 	/** Get the display names for a set of users. Any non-existent users are left out of the
-	 * returned map.
+	 * returned map. Disabled users are never returned.
 	 * @param usernames the usernames for which to get display names.
 	 * @return a mapping of username to display name.
 	 * @throws AuthStorageException if a problem connecting with the storage

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -145,7 +145,12 @@ public interface AuthStorage {
 	Map<UserName, DisplayName> getUserDisplayNames(Set<UserName> usernames)
 			throws AuthStorageException;
 	
-	/** Search for users based on a prefix of the user and display names and the user's roles.
+	//TODO ZLATER CODE could make a wrapper class for UserSearchSpec that doesn't include the root user stuff.
+	/** Search for users based on a search specification.
+	 * 
+	 * Note that auth storage implementations have no knowledge of root users and therefore
+	 * ignore the root user selection in the search specification.
+	 * 
 	 * @param spec the specification for the search.
 	 * @param maxReturnedUsers the maximum number of users to return.
 	 * @return a mapping of user name to display name for the discovered users.

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -787,6 +787,9 @@ public class MongoStorage implements AuthStorage {
 			query.put(Fields.USER_CUSTOM_ROLES, new Document("$all", crs.stream()
 					.map(d -> d.getObjectId(Fields.MONGO_ID)).collect(Collectors.toSet())));
 		}
+		if (!spec.isDisabledIncluded()) {
+			query.put(Fields.USER_DISABLED_REASON, null);
+		}
 		return getDisplayNames(query, SEARCHFIELD_TO_FIELD.get(spec.orderBy()), limit);
 	}
 

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -713,7 +713,8 @@ public class MongoStorage implements AuthStorage {
 		}
 		final List<String> queryusers = users.stream().map(u -> u.getName())
 				.collect(Collectors.toList());
-		final Document query = new Document(Fields.USER_NAME, new Document("$in", queryusers));
+		final Document query = new Document(Fields.USER_NAME, new Document("$in", queryusers))
+				.append(Fields.USER_DISABLED_REASON, null);
 		return getDisplayNames(query, Fields.USER_NAME, -1);
 	}
 

--- a/src/us/kbase/auth2/service/AuthBuilder.java
+++ b/src/us/kbase/auth2/service/AuthBuilder.java
@@ -57,7 +57,7 @@ public class AuthBuilder {
 	}
 	
 	private MongoClient buildMongo(final AuthStartupConfig c) throws StorageInitException {
-		//TODO ZLATER handle shards & replica sets
+		//TODO ZLATER MONGO handle shards & replica sets
 		try {
 			if (c.getMongoUser().isPresent()) {
 				final List<MongoCredential> creds = Arrays.asList(MongoCredential.createCredential(

--- a/src/us/kbase/auth2/service/AuthenticationService.java
+++ b/src/us/kbase/auth2/service/AuthenticationService.java
@@ -24,8 +24,6 @@ import us.kbase.auth2.service.exceptions.ExceptionHandler;
 import us.kbase.auth2.service.template.TemplateProcessor;
 import us.kbase.auth2.service.template.mustache.MustacheProcessor;
 
-//TODO WAIT accept json in text/plain and application/x-www-form-urlencoded or manually handle it
-
 public class AuthenticationService extends ResourceConfig {
 	
 	//TODO TEST
@@ -47,7 +45,7 @@ public class AuthenticationService extends ResourceConfig {
 			throw new IllegalStateException("Call setConfig() before " +
 					"starting the server ya daft numpty");
 		}
-		//TODO ZLATER Get the class name from environment if we need alternate config mechanism
+		//TODO ZLATER CONFIG Get the class name from environment if we need alternate config mechanism
 		final AuthStartupConfig cfg = ServiceCommon.loadClassWithInterface(
 				cfgClass, AuthStartupConfig.class);
 		

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -155,7 +155,8 @@ public class Admin {
 			throws InvalidTokenException, IllegalParameterException, NoTokenProvidedException,
 			AuthStorageException, UnauthorizedException {
 		final String prefix = form.getFirst("prefix");
-		final UserSearchSpec.Builder build = UserSearchSpec.getBuilder();
+		final UserSearchSpec.Builder build = UserSearchSpec.getBuilder().withIncludeDisabled(true)
+				.withIncludeRoot(true); // may want to include option to exclude disabled
 		final boolean hasPrefix;
 		if (prefix != null && !prefix.trim().isEmpty()) {
 			build.withSearchPrefix(prefix);

--- a/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
+++ b/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
@@ -30,6 +30,8 @@ public class UserSearchSpecTest {
 				.withSearchOnRole(Role.DEV_TOKEN)
 				.withSearchOnCustomRole("bar")
 				.withSearchOnCustomRole("baz")
+				.withIncludeRoot(true)
+				.withIncludeDisabled(true)
 				.build();
 		
 		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
@@ -43,6 +45,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(set("baz", "bar")));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(true));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(true));
 		
 	}
 	
@@ -59,6 +63,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -75,6 +81,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -92,6 +100,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -110,6 +120,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search roles", uss.getSearchRoles(), is(set(Role.SERV_TOKEN)));
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(), is(set("bar")));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.DISPLAYNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -126,6 +138,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search roles", uss.getSearchRoles(), is(set(Role.DEV_TOKEN)));
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(), is(set("foo")));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.CUSTOMROLE));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -142,6 +156,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.ROLE));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -158,6 +174,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -175,6 +193,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 
 	private void setRegex(final Builder b, final String regex) throws Exception {
@@ -199,6 +219,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test
@@ -216,6 +238,8 @@ public class UserSearchSpecTest {
 		assertThat("incorrect search custom roles", uss.getSearchCustomRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
+		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
+		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -432,6 +432,61 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	}
 	
 	@Test
+	public void searchWithDisabled() throws Exception {
+		createUsersForCanonicalSearch();
+		
+		when(mockClock.instant()).thenReturn(Instant.now());
+		
+		storage.disableAccount(new UserName("u3"), new UserName("foo"), "foo");
+		
+
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u3"), new DisplayName("al douglas"));
+		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withIncludeDisabled(true).build(), 10), is(expected));
+	}
+	
+	@Test
+	public void searchWithoutDisabled() throws Exception {
+		createUsersForCanonicalSearch();
+		
+		when(mockClock.instant()).thenReturn(Instant.now());
+		
+		storage.disableAccount(new UserName("u3"), new UserName("foo"), "foo");
+		
+
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withIncludeDisabled(false).build(), 10), is(expected));
+	}
+	
+	@Test
+	public void searchWithoutDisabledDefault() throws Exception {
+		createUsersForCanonicalSearch();
+		
+		when(mockClock.instant()).thenReturn(Instant.now());
+		
+		storage.disableAccount(new UserName("u3"), new UserName("foo"), "foo");
+		
+
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.build(), 10), is(expected));
+	}
+	
+	@Test
 	public void searchFail() throws Exception {
 		//only one way to actually cause an exception
 		try {

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -3,6 +3,7 @@ package us.kbase.test.auth2.lib.storage.mongo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
 
 import static us.kbase.test.auth2.TestCommon.set;
 
@@ -82,6 +83,27 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		assertThat("incorrect users found", storage.getUserDisplayNames(
 				Collections.emptySet()), is(expected));
+	}
+	
+	@Test
+	public void getNamesFromListWithDisabledUsers() throws Exception {
+		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("bar"), REMOTE1, NOW, null));
+		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
+				new DisplayName("whoo"), REMOTE2, NOW, null));
+		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
+				new DisplayName("wonk"), REMOTE3, NOW, null));
+		
+		when(mockClock.instant()).thenReturn(Instant.now());
+		
+		storage.disableAccount(new UserName("whee"), new UserName("admin"), "they suck");
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("bar"));
+		expected.put(new UserName("wugga"), new DisplayName("wonk"));
+		assertThat("incorrect users found", storage.getUserDisplayNames(set(
+				new UserName("foo"), new UserName("whee"), new UserName("wugga"))),
+				is(expected));
 	}
 	
 	@Test


### PR DESCRIPTION
* Ignore root & disabled users when verifiying users via list 
* Only include root & disabled users in search if requested & user is admin
* minor TODO cleanup
