### PR TITLE
user search tests + start application immediately

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -208,6 +208,7 @@
       <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
+      <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
       <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
       <test name="us.kbase.test.auth2.lib.AuthUserTest"/>

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -840,6 +840,10 @@ public class Authentication {
 			final UserSearchSpec spec)
 			throws InvalidTokenException, UnauthorizedException, AuthStorageException {
 		nonNull(spec, "spec");
+		if (spec.isRegex()) {
+			throw new UnauthorizedException(ErrorType.UNAUTHORIZED,
+					"Regex search is currently for internal use only");
+		}
 		final AuthUser user = getUser(token);
 		if (!Role.isAdmin(user.getRoles())) {
 			if (spec.isCustomRoleSearch() || spec.isRoleSearch()) {
@@ -854,10 +858,6 @@ public class Authentication {
 				throw new UnauthorizedException(ErrorType.UNAUTHORIZED,
 						"Only admins may search with root or disabled users included");
 			}
-		}
-		if (spec.isRegex()) {
-			throw new UnauthorizedException(ErrorType.UNAUTHORIZED,
-					"Regex search is currently for internal use only");
 		}
 		final Map<UserName, DisplayName> displayNames = storage.getUserDisplayNames(
 				spec, MAX_RETURNED_USERS);

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -797,7 +797,7 @@ public class Authentication {
 	/** Look up display names for a set of user names. A maximum of 10000 users may be looked up
 	 * at once. Never returns the root user name or disabled users.
 	 * @param token a token for the user requesting the lookup.
-	 * @param usernames the user names to look up.
+	 * @param userNames the user names to look up.
 	 * @return the display names for each user name. Any non-existent user names will be missing.
 	 * @throws InvalidTokenException if the token is invalid.
 	 * @throws AuthStorageException if an error occurred accessing the storage system.
@@ -806,18 +806,20 @@ public class Authentication {
 	 */
 	public Map<UserName, DisplayName> getUserDisplayNames(
 			final IncomingToken token,
-			final Set<UserName> usernames)
+			final Set<UserName> userNames)
 			throws InvalidTokenException, AuthStorageException, IllegalParameterException {
+		nonNull(userNames, "userNames");
+		noNulls(userNames, "Null name in userNames");
 		getToken(token); // just check the token is valid
-		if (usernames.size() > MAX_RETURNED_USERS) {
+		if (userNames.isEmpty()) {
+			return new HashMap<>();
+		}
+		if (userNames.size() > MAX_RETURNED_USERS) {
 			throw new IllegalParameterException(
 					"User count exceeds maximum of " + MAX_RETURNED_USERS);
 		}
-		if (usernames.isEmpty()) {
-			return new HashMap<>();
-		}
 		
-		final Map<UserName, DisplayName> displayNames = storage.getUserDisplayNames(usernames);
+		final Map<UserName, DisplayName> displayNames = storage.getUserDisplayNames(userNames);
 		displayNames.remove(UserName.ROOT);
 		return displayNames;
 	}

--- a/src/us/kbase/auth2/lib/CollectingExternalConfig.java
+++ b/src/us/kbase/auth2/lib/CollectingExternalConfig.java
@@ -1,5 +1,7 @@
 package us.kbase.auth2.lib;
 
+import static us.kbase.auth2.lib.Utils.nonNull;
+
 import java.util.Map;
 
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
@@ -17,7 +19,7 @@ public class CollectingExternalConfig implements ExternalConfig {
 	 * @param map the map defining the configuration.
 	 */
 	public CollectingExternalConfig(final Map<String, String> map) {
-		//TODO CODE should probably check for null here
+		nonNull(map, "map");
 		cfg = map;
 	}
 	

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
@@ -1,0 +1,141 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+import static us.kbase.test.auth2.TestCommon.set;
+import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
+import us.kbase.auth2.lib.storage.AuthStorage;
+import us.kbase.auth2.lib.token.HashedToken;
+import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
+
+public class AuthenticationGetUserDisplayNamesTest {
+
+	@Test
+	public void getDisplayNamesSet() throws Exception {
+		// includes test of removing root user
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("dfoo"));
+		expected.put(new UserName("bar"), new DisplayName("dbar"));
+
+		when(storage.getToken(token.getHashedToken()))
+				.thenReturn(new HashedToken(UUID.randomUUID(), TokenType.LOGIN, null, "foobarhash",
+						new UserName("foo"), Instant.now(), Instant.now()));
+		
+		when(storage.getUserDisplayNames(
+				set(new UserName("foo"), new UserName("bar"), new UserName("***ROOT***"))))
+			.thenReturn(expected);
+				
+		
+		final Map<UserName, DisplayName> disp = auth.getUserDisplayNames(
+				token, set(new UserName("foo"), new UserName("bar"), new UserName("***ROOT***")));
+		
+		assertThat("incorrect display names", disp, is(expected));
+	}
+	
+	@Test
+	public void getDisplayNamesEmptySet() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken()))
+				.thenReturn(new HashedToken(UUID.randomUUID(), TokenType.LOGIN, null, "foobarhash",
+						new UserName("foo"), Instant.now(), Instant.now()));
+		
+		final Map<UserName, DisplayName> disp = auth.getUserDisplayNames(
+				token, Collections.emptySet());
+		
+		assertThat("incorrect display names", disp, is(new HashMap<>()));
+	}
+	
+	@Test
+	public void getDisplayNamesSetFailNulls() throws Exception {
+		final Authentication auth = initTestMocks().auth;
+		
+		failGetDisplayNamesSet(auth, null, Collections.emptySet(),
+				new NullPointerException("token"));
+		failGetDisplayNamesSet(auth, new IncomingToken("token"), null,
+				new NullPointerException("userNames"));
+		failGetDisplayNamesSet(auth, new IncomingToken("token"), set(new UserName("foo"), null),
+				new NullPointerException("Null name in userNames"));
+	}
+	
+	@Test
+	public void getDisplayNamesSetFailBadToken() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
+		
+		failGetDisplayNamesSet(auth, token, Collections.emptySet(), new InvalidTokenException());
+	}
+	
+	@Test
+	public void getDisplayNamesSetFailTooManyUsers() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		final Set<UserName> users = new HashSet<>();
+		for (int i = 0; i < 10001; i++) {
+			users.add(new UserName("u" + i));
+		}
+		
+		when(storage.getToken(token.getHashedToken()))
+				.thenReturn(new HashedToken(UUID.randomUUID(), TokenType.LOGIN, null, "foobarhash",
+						new UserName("foo"), Instant.now(), Instant.now()));
+		
+		failGetDisplayNamesSet(auth, token, users,
+				new IllegalParameterException("User count exceeds maximum of 10000"));
+	}
+	
+	private void failGetDisplayNamesSet(
+			final Authentication auth,
+			final IncomingToken token,
+			final Set<UserName> names,
+			final Exception e) {
+		try {
+			auth.getUserDisplayNames(token, names);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+}

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
@@ -4,11 +4,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 
 import static us.kbase.test.auth2.TestCommon.set;
 import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
 
+import java.lang.reflect.Field;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,12 +22,23 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
+import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.UserSearchSpec;
+import us.kbase.auth2.lib.exceptions.DisabledUserException;
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
+import us.kbase.auth2.lib.exceptions.NoSuchUserException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.AuthStorage;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.IncomingToken;
@@ -136,6 +151,311 @@ public class AuthenticationGetUserDisplayNamesTest {
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
 		}
+	}
+	
+	@Test
+	public void getDisplayNamesSpec() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("dfoo"));
+		expected.put(new UserName("bar"), new DisplayName("dbar"));
+
+		getDisplayNamesSpec(user, spec, expected);
+	}
+	
+	@Test
+	public void getDisplayNamesSpecWithRootAsAdmin() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withIncludeRoot(true).build();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("dfoo"));
+		expected.put(new UserName("bar"), new DisplayName("dbar"));
+		expected.put(new UserName("***ROOT***"), new DisplayName("root"));
+
+		getDisplayNamesSpec(user, spec, expected);
+	}
+	
+	@Test
+	public void getDisplayNamesSpecWithRootAsCreate() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.CREATE_ADMIN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withIncludeRoot(true).build();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("dfoo"));
+		expected.put(new UserName("bar"), new DisplayName("dbar"));
+		expected.put(new UserName("***ROOT***"), new DisplayName("root"));
+
+		getDisplayNamesSpec(user, spec, expected);
+	}
+	
+	@Test
+	public void getDisplayNamesSpecWithRootAsRoot() throws Exception {
+		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.ROOT),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withIncludeRoot(true).build();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("foo"), new DisplayName("dfoo"));
+		expected.put(new UserName("bar"), new DisplayName("dbar"));
+		expected.put(new UserName("***ROOT***"), new DisplayName("root"));
+
+		getDisplayNamesSpec(user, spec, expected);
+	}
+	
+	@Test
+	public void getDisplayNamesSpecAllowedPermissions() throws Exception {
+		final UserSearchSpec noprefix = UserSearchSpec.getBuilder().build();
+		final UserSearchSpec custom = UserSearchSpec.getBuilder()
+				.withSearchOnCustomRole("foo").build();
+		final UserSearchSpec role = UserSearchSpec.getBuilder()
+				.withSearchOnRole(Role.ADMIN).build();
+		final UserSearchSpec disabled = UserSearchSpec.getBuilder()
+				.withIncludeDisabled(true).build();
+		
+		for (final UserSearchSpec spec: Arrays.asList(noprefix, custom, role, disabled)) {
+			for (final Role r: Arrays.asList(Role.ROOT, Role.CREATE_ADMIN, Role.ADMIN)) {
+				final AuthUser user = new AuthUser(
+						r == Role.ROOT ? UserName.ROOT : new UserName("foo"),
+								new EmailAddress("f@g.com"),
+						new DisplayName("foo"), Collections.emptySet(), set(r),
+						Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+						new UserDisabledState());
+				
+				final Map<UserName, DisplayName> expected = new HashMap<>();
+				expected.put(new UserName("foo"), new DisplayName("dfoo"));
+				expected.put(new UserName("bar"), new DisplayName("dbar"));
+				
+				getDisplayNamesSpec(user, spec, expected);
+				
+			}
+		}
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailNulls() throws Exception {
+		final Authentication auth = initTestMocks().auth;
+		
+		failGetDisplayNamesSpec(auth, null, UserSearchSpec.getBuilder().build(),
+				new NullPointerException("token"));
+		
+		failGetDisplayNamesSpec(auth, new IncomingToken("foo"),
+				null, new NullPointerException("spec"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailRegex() throws Exception {
+		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.ROOT),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
+		final Field m = spec.getClass().getDeclaredField("isRegex");
+		m.setAccessible(true);
+		m.set(spec, true);
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Regex search is currently for internal use only"));
+	}
+	
+	@Test
+	public void getDisplayNamesFailBadToken() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+
+		when(storage.getToken(token.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
+		
+		failGetDisplayNamesSpec(auth, token, UserSearchSpec.getBuilder().build(),
+				new InvalidTokenException());
+	}
+	
+	@Test
+	public void getDisplayNamesFailCatastrophic() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+
+		when(storage.getToken(token.getHashedToken()))
+				.thenReturn(new HashedToken(UUID.randomUUID(), TokenType.LOGIN, null, "foobarhash",
+						new UserName("foo"), Instant.now(), Instant.now()));
+		
+		when(storage.getUser(new UserName("foo"))).thenThrow(new NoSuchUserException("foo"));
+		
+		failGetDisplayNamesSpec(auth, token, UserSearchSpec.getBuilder().build(),
+				new RuntimeException("There seems to be an error " +
+						"in the storage system. Token was valid, but no user"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailDisabled() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
+		
+		failGetDisplayNamesSpec(user, spec, new DisabledUserException());
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailStdUserCustomRole() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withSearchOnCustomRole("foobar").build();
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Only admins may search on roles"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailStdUserRole() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withSearchOnRole(Role.ADMIN).build();
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Only admins may search on roles"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailStdUserNoPrefix() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().build();
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Only admins may search without a prefix"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailStdUserIncludeRoot() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withIncludeRoot(true).build();
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Only admins may search with root or disabled users included"));
+	}
+	
+	@Test
+	public void getDisplayNamesSpecFailStdUserIncludeDisabled() throws Exception {
+		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
+				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
+				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				new UserDisabledState());
+		
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
+				.withIncludeDisabled(true).build();
+		
+		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Only admins may search with root or disabled users included"));
+	}
+	
+	private void getDisplayNamesSpec(
+			final AuthUser user,
+			final UserSearchSpec spec,
+			final Map<UserName, DisplayName> expected)
+			throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final Map<UserName, DisplayName> ret = new HashMap<>();
+		ret.put(new UserName("foo"), new DisplayName("dfoo"));
+		ret.put(new UserName("bar"), new DisplayName("dbar"));
+		ret.put(new UserName("***ROOT***"), new DisplayName("root"));
+
+		final IncomingToken token = new IncomingToken("foobar");
+
+		when(storage.getToken(token.getHashedToken()))
+				.thenReturn(new HashedToken(UUID.randomUUID(), TokenType.LOGIN, null, "foobarhash",
+						user.getUserName(), Instant.now(), Instant.now()));
+		
+		when(storage.getUser(user.getUserName())).thenReturn(user);
+		
+		when(storage.getUserDisplayNames(spec, 10000)).thenReturn(ret);
+		
+		try {
+			final Map<UserName, DisplayName> got = auth.getUserDisplayNames(token, spec);
+		
+			assertThat("incorrect display names", got, is(expected));
+		} catch (Throwable th) {
+			if (user.isDisabled()) {
+				verify(storage).deleteTokens(user.getUserName());
+			} else {
+				verify(storage, never()).deleteTokens(user.getUserName());
+			}
+			throw th;
+		}
+	}
+	
+	private void failGetDisplayNamesSpec(
+			final AuthUser user,
+			final UserSearchSpec spec,
+			final Exception e) {
+		try {
+			getDisplayNamesSpec(user, spec, null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+
+	private void failGetDisplayNamesSpec(
+			final Authentication auth,
+			final IncomingToken token,
+			final UserSearchSpec spec,
+			final Exception e) {
+		try {
+			auth.getUserDisplayNames(token, spec);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+		// TODO Auto-generated method stub
+		
 	}
 	
 }

--- a/src/us/kbase/test/auth2/lib/CollectingExternalConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/CollectingExternalConfigTest.java
@@ -2,8 +2,7 @@ package us.kbase.test.auth2.lib;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-
-import java.util.Map;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -13,6 +12,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.CollectingExternalConfig;
 import us.kbase.auth2.lib.CollectingExternalConfig.CollectingExternalConfigMapper;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
+import us.kbase.test.auth2.TestCommon;
 
 public class CollectingExternalConfigTest {
 
@@ -26,9 +26,6 @@ public class CollectingExternalConfigTest {
 		final CollectingExternalConfig cfg = new CollectingExternalConfig(
 				ImmutableMap.of("foo", "bar"));
 		assertThat("incorrect config", cfg.toMap(), is(ImmutableMap.of("foo", "bar")));
-		
-		final CollectingExternalConfig cfg2 = new CollectingExternalConfig(null);
-		assertThat("incorrect config", cfg2.toMap(), is((Map<String, String>) null));
 	}
 	
 	@Test
@@ -36,6 +33,16 @@ public class CollectingExternalConfigTest {
 		final CollectingExternalConfig cfg = new CollectingExternalConfigMapper().fromMap(
 				ImmutableMap.of("baz", "bat"));
 		assertThat("incorrect config", cfg.toMap(), is(ImmutableMap.of("baz", "bat")));
+	}
+	
+	@Test
+	public void failConstruct() {
+		try {
+			new CollectingExternalConfig(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("map"));
+		}
 	}
 	
 }

--- a/war/web.xml
+++ b/war/web.xml
@@ -8,6 +8,7 @@
     <servlet>
         <servlet-name>Auth</servlet-name>
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+        <load-on-startup>1</load-on-startup>
         <init-param>
             <param-name>javax.ws.rs.Application</param-name>
             <param-value>us.kbase.auth2.service.AuthenticationService</param-value>


### PR DESCRIPTION
* Add tests for the getUserDisplayNames methods
* Make the application load in Jetty immediately rather than on the first request