### PR TITLE
Associate policy IDs with user accounts

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -226,6 +226,7 @@
       <test name="us.kbase.test.auth2.lib.NameTest"/>
       <test name="us.kbase.test.auth2.lib.NewUserTest"/>
       <test name="us.kbase.test.auth2.lib.PasswordTest"/>
+      <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
       <test name="us.kbase.test.auth2.lib.RoleTest"/>
       <test name="us.kbase.test.auth2.lib.TokenNameTest"/>
       <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>

--- a/src/us/kbase/auth2/lib/AuthUser.java
+++ b/src/us/kbase/auth2/lib/AuthUser.java
@@ -31,9 +31,12 @@ public class AuthUser {
 	private final Set<Role> canGrantRoles;
 	private final Set<String> customRoles;
 	private final Set<RemoteIdentityWithLocalID> identities;
+	private final Set<PolicyID> policyIDs;
 	private final Instant created;
 	private final Optional<Instant> lastLogin;
 	private final UserDisabledState disabledState;
+	
+	//TODO ZLATER CODE should really consider a builder for this, although the constructor is only used in storage implementations and tests
 	
 	/** Create a new user.
 	 * @param userName the name of the user.
@@ -43,6 +46,7 @@ public class AuthUser {
 	 * users.
 	 * @param roles any roles the user possesses.
 	 * @param customRoles any custom roles the user possesses.
+	 * @param policyIDs the policy IDs associated with the user.
 	 * @param created the date the user account was created.
 	 * @param lastLogin the date of the user's last login. If this time is before the created
 	 * date it will be silently modified to match the creation date.
@@ -55,6 +59,7 @@ public class AuthUser {
 			Set<RemoteIdentityWithLocalID> identities,
 			Set<Role> roles,
 			Set<String> customRoles,
+			Set<PolicyID> policyIDs,
 			final Instant created,
 			final Optional<Instant> lastLogin,
 			final UserDisabledState disabledState) {
@@ -81,6 +86,11 @@ public class AuthUser {
 		}
 		Utils.noNulls(customRoles, "null item in customRoles");
 		this.customRoles = Collections.unmodifiableSet(new HashSet<>(customRoles));
+		if (policyIDs == null) {
+			policyIDs = new HashSet<>();
+		}
+		Utils.noNulls(policyIDs, "null item in policyIDs");
+		this.policyIDs = Collections.unmodifiableSet(new HashSet<>(policyIDs));
 		/* this is a little worrisome as there are two sources of truth for root. Maybe
 		 * automatically add the role for root? Or have a root user subclass?
 		 * This'll do for now
@@ -113,7 +123,7 @@ public class AuthUser {
 	 */
 	public AuthUser(final AuthUser user, final Set<RemoteIdentityWithLocalID> newIDs) {
 		this(user.getUserName(), user.getEmail(), user.getDisplayName(), newIDs, user.getRoles(),
-				user.getCustomRoles(), user.getCreated(), user.getLastLogin(),
+				user.getCustomRoles(), user.getPolicyIDs(), user.getCreated(), user.getLastLogin(),
 				user.getDisabledState());
 	}
 
@@ -186,6 +196,13 @@ public class AuthUser {
 	 */
 	public Set<RemoteIdentityWithLocalID> getIdentities() {
 		return identities;
+	}
+	
+	/** Get the set of policyIDs associated with this user.
+	 * @return the policy IDs.
+	 */
+	public Set<PolicyID> getPolicyIDs() {
+		return policyIDs;
 	}
 	
 	/** Get this user's creation date.
@@ -267,6 +284,7 @@ public class AuthUser {
 		result = prime * result + ((email == null) ? 0 : email.hashCode());
 		result = prime * result + ((identities == null) ? 0 : identities.hashCode());
 		result = prime * result + ((lastLogin == null) ? 0 : lastLogin.hashCode());
+		result = prime * result + ((policyIDs == null) ? 0 : policyIDs.hashCode());
 		result = prime * result + ((roles == null) ? 0 : roles.hashCode());
 		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
 		return result;
@@ -331,6 +349,13 @@ public class AuthUser {
 				return false;
 			}
 		} else if (!lastLogin.equals(other.lastLogin)) {
+			return false;
+		}
+		if (policyIDs == null) {
+			if (other.policyIDs != null) {
+				return false;
+			}
+		} else if (!policyIDs.equals(other.policyIDs)) {
 			return false;
 		}
 		if (roles == null) {

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1502,12 +1502,25 @@ public class Authentication {
 		if (u.get().isDisabled()) {
 			throw new DisabledUserException("This account is disabled");
 		}
+		addPolicyIDs(u.get().getUserName(), policyIDs);
 		if (linkAll) {
 			ids.remove(ri);
 			filterLinkCandidates(ids);
 			link(u.get().getUserName(), ids);
 		}
 		return login(u.get().getUserName());
+	}
+	
+	// assumes inputs have been checked and the user exists
+	private void addPolicyIDs(final UserName user, final Set<PolicyID> pids)
+			throws AuthStorageException {
+		try {
+			storage.addPolicyIDs(user, pids);
+		} catch (NoSuchUserException e) {
+			throw new AuthStorageException(
+					"Something is very broken. User should exist but doesn't: "
+							+ e.getMessage(), e);
+		}
 	}
 	
 	private Optional<RemoteIdentityWithLocalID> getIdentity(

--- a/src/us/kbase/auth2/lib/LocalUser.java
+++ b/src/us/kbase/auth2/lib/LocalUser.java
@@ -18,7 +18,7 @@ public class LocalUser extends AuthUser {
 	private final boolean forceReset;
 	private final Optional<Instant> lastReset;
 	
-	// should really consider a builder for these
+	//TODO ZLATER CODE should really consider a builder for this, although the constructor is only used in storage implementations and tests
 	
 	/** Create a new local user.
 	 * @param userName the name of the user.
@@ -26,6 +26,7 @@ public class LocalUser extends AuthUser {
 	 * @param displayName the display name of the user.
 	 * @param roles any roles the user possesses.
 	 * @param customRoles any custom roles the user possesses.
+	 * @param policyIDs the set of policy IDs associated with the user.
 	 * @param created the date the user account was created.
 	 * @param lastLogin the date of the user's last login.
 	 * @param disabledState whether the user account is disabled.
@@ -40,6 +41,7 @@ public class LocalUser extends AuthUser {
 			final DisplayName displayName,
 			final Set<Role> roles,
 			final Set<String> customRoles,
+			final Set<PolicyID> policyIDs,
 			final Instant created,
 			final Optional<Instant> lastLogin,
 			final UserDisabledState disabledState,
@@ -47,8 +49,8 @@ public class LocalUser extends AuthUser {
 			final byte[] salt,
 			final boolean forceReset,
 			final Optional<Instant> lastReset) {
-		super(userName, email, displayName, null, roles, customRoles, created, lastLogin,
-				disabledState);
+		super(userName, email, displayName, null, roles, customRoles, policyIDs, created,
+				lastLogin, disabledState);
 		// what's the right # here? Have to rely on user to some extent
 		if (passwordHash == null || passwordHash.length < 10) {
 			throw new IllegalArgumentException("passwordHash missing or too small");
@@ -131,37 +133,4 @@ public class LocalUser extends AuthUser {
 		}
 		return true;
 	}
-
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("LocalUser [passwordHash=");
-		builder.append(Arrays.toString(passwordHash));
-		builder.append(", salt=");
-		builder.append(Arrays.toString(salt));
-		builder.append(", forceReset=");
-		builder.append(forceReset);
-		builder.append(", lastReset=");
-		builder.append(lastReset);
-		builder.append(", getDisplayName()=");
-		builder.append(getDisplayName());
-		builder.append(", getEmail()=");
-		builder.append(getEmail());
-		builder.append(", getUserName()=");
-		builder.append(getUserName());
-		builder.append(", getRoles()=");
-		builder.append(getRoles());
-		builder.append(", getCustomRoles()=");
-		builder.append(getCustomRoles());
-		builder.append(", getCreated()=");
-		builder.append(getCreated());
-		builder.append(", getLastLogin()=");
-		builder.append(getLastLogin());
-		builder.append(", getDisabledState()=");
-		builder.append(getDisabledState());
-		builder.append("]");
-		return builder.toString();
-	}
-	
-	
 }

--- a/src/us/kbase/auth2/lib/NewLocalUser.java
+++ b/src/us/kbase/auth2/lib/NewLocalUser.java
@@ -1,6 +1,7 @@
 package us.kbase.auth2.lib;
 
 import java.time.Instant;
+import java.util.Set;
 
 /** A newly created local user.
  * @author gaprice@lbl.gov
@@ -12,6 +13,7 @@ public class NewLocalUser extends LocalUser {
 	 * @param userName the name of the user.
 	 * @param email the email address of the user.
 	 * @param displayName the display name of the user.
+	 * @param policyIDs the policy IDs associated with the user.
 	 * @param created the date the user was created.
 	 * @param passwordHash a salted, hashed password for the user.
 	 * @param salt the salt for the hashed password. 
@@ -21,11 +23,11 @@ public class NewLocalUser extends LocalUser {
 			final UserName userName,
 			final EmailAddress email,
 			final DisplayName displayName,
+			final Set<PolicyID> policyIDs,
 			final Instant created,
 			final byte[] passwordHash,
-			final byte[] salt,
-			final boolean forceReset) {
-		super(userName, email, displayName, null, null, created, null,
+			final byte[] salt, final boolean forceReset) {
+		super(userName, email, displayName, null, null, policyIDs, created, null,
 				new UserDisabledState(), passwordHash, salt, forceReset, null);
 	}
 }

--- a/src/us/kbase/auth2/lib/NewRootUser.java
+++ b/src/us/kbase/auth2/lib/NewRootUser.java
@@ -2,6 +2,7 @@ package us.kbase.auth2.lib;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 
 /** A newly created root user.
@@ -24,6 +25,7 @@ public class NewRootUser extends LocalUser {
 			final byte[] passwordHash,
 			final byte[] salt) {
 		super(UserName.ROOT, email, displayName, new HashSet<>(Arrays.asList(Role.ROOT)), null,
-				created, null, new UserDisabledState(), passwordHash, salt, false, null);
+				Collections.emptySet(), created, null, new UserDisabledState(), passwordHash, salt,
+				false, null);
 	}
 }

--- a/src/us/kbase/auth2/lib/NewUser.java
+++ b/src/us/kbase/auth2/lib/NewUser.java
@@ -23,6 +23,7 @@ public class NewUser extends AuthUser {
 	 * @param email the email address of the user.
 	 * @param displayName the display name of the user.
 	 * @param remoteIdentity the 3rd party identity associated with this user.
+	 * @param policyIDs the policy IDs associated with this user.
 	 * @param created the date the user was created.
 	 * @param lastLogin the date of the user's last login. If this time is before the created
 	 * date (e.g. the time this constructor is called) it will be silently modified to match
@@ -33,9 +34,10 @@ public class NewUser extends AuthUser {
 			final EmailAddress email,
 			final DisplayName displayName,
 			final RemoteIdentityWithLocalID remoteIdentity,
+			final Set<PolicyID> policyIDs,
 			final Instant created,
 			final Optional<Instant> lastLogin) {
-		super(userName, email, displayName, set(remoteIdentity), null, null,
+		super(userName, email, displayName, set(remoteIdentity), null, null, policyIDs,
 				created, lastLogin, new UserDisabledState());
 	}
 

--- a/src/us/kbase/auth2/lib/PolicyID.java
+++ b/src/us/kbase/auth2/lib/PolicyID.java
@@ -1,0 +1,22 @@
+package us.kbase.auth2.lib;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+/** The ID for a policy document to which the user has agreed.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class PolicyID extends Name {
+
+	/** Create a policy ID.
+	 * @param policyID the id.
+	 * @throws MissingParameterException if the policy ID is missing.
+	 * @throws IllegalParameterException if the policy ID is too long or contains control
+	 * characters.
+	 */
+	public PolicyID(final String policyID)
+			throws MissingParameterException, IllegalParameterException {
+		super(policyID, "policy id", 20);
+	}
+}

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -15,6 +15,7 @@ import us.kbase.auth2.lib.ExternalConfig;
 import us.kbase.auth2.lib.ExternalConfigMapper;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserSearchSpec;
@@ -169,8 +170,7 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	LocalUser getLocalUser(UserName userName)
-			throws AuthStorageException, NoSuchUserException;
+	LocalUser getLocalUser(UserName userName) throws AuthStorageException, NoSuchUserException;
 	
 	/** Update the display name and/or email address for a user.
 	 * @param userName the user to update.
@@ -190,6 +190,16 @@ public interface AuthStorage {
 	 * system occurs.
 	 */
 	void setLastLogin(UserName userName, Instant lastLogin)
+			throws NoSuchUserException, AuthStorageException;
+	
+	/** Add policy IDs to the set of policy IDs already associated with a user.
+	 * @param userName the name of the user to modify.
+	 * @param policyIDs the policy IDs to add to the user.
+	 * @throws NoSuchUserException if the user does not exist.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 */
+	void addPolicyIDs(UserName userName, Set<PolicyID> policyIDs)
 			throws NoSuchUserException, AuthStorageException;
 	
 	/** Store a token in the database. No checking is done on the validity

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -202,6 +202,13 @@ public interface AuthStorage {
 	void addPolicyIDs(UserName userName, Set<PolicyID> policyIDs)
 			throws NoSuchUserException, AuthStorageException;
 	
+	/** Remove a policy ID from all users in the database.
+	 * @param policyID the policy ID to remove.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 */
+	void removePolicyID(PolicyID policyID) throws AuthStorageException;
+	
 	/** Store a token in the database. No checking is done on the validity
 	 * of the token - passing in tokens with bad data is a programming error.
 	 * @param token the token to store.

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -35,6 +35,8 @@ public class Fields {
 	public static final String USER_ROLES = "roles";
 	/** The custom roles the user possesses. */
 	public static final String USER_CUSTOM_ROLES = "custrls";
+	/** Any policy IDs associated with the user. */
+	public static final String USER_POLICY_IDS = "policyids";
 	/** The date the user account was created. */
 	public static final String USER_CREATED = "create";
 	/** The date of the user's last login. */

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -1443,6 +1443,18 @@ public class MongoStorage implements AuthStorage {
 						policyIDs.stream().map(id -> id.getName()).collect(Collectors.toSet()))));
 		updateUserAnyUpdate(userName, update);
 	}
+	
+	@Override
+	public void removePolicyID(final PolicyID policyID) throws AuthStorageException {
+		nonNull(policyID, "policyID");
+		try {
+			db.getCollection(COL_USERS).updateMany(new Document(), new Document("$pull",
+					new Document(Fields.USER_POLICY_IDS, policyID.getName())));
+			// don't care if nothing happened, just means no one had the role
+		} catch (MongoException e) {
+			throw new AuthStorageException("Connection to database failed: " + e.getMessage(), e);
+		}
+	}
 
 	private void updateConfig(
 			final String collection,

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -50,6 +50,7 @@ import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.Password;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserSearchSpec;
@@ -96,13 +97,15 @@ public class Admin {
 			@Context final HttpHeaders headers)
 			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
 			AuthStorageException {
-		return ImmutableMap.of(
-				"reseturl", relativize(uriInfo, UIPaths.ADMIN_ROOT_FORCE_RESET_PWD),
-				"revokeurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_REVOKE_ALL),
-				"tokenurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_TOKEN),
-				"searchurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_SEARCH),
-				"croles", auth.getCustomRoles(getTokenFromCookie(
+		final Map<String, Object> ret = new HashMap<>();
+		ret.put("reseturl", relativize(uriInfo, UIPaths.ADMIN_ROOT_FORCE_RESET_PWD));
+		ret.put("revokeurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_REVOKE_ALL));
+		ret.put("tokenurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_TOKEN));
+		ret.put("policyurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_POLICY_ID));
+		ret.put("searchurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_SEARCH));
+		ret.put("croles", auth.getCustomRoles(getTokenFromCookie(
 						headers, cfg.getTokenCookieName()), true));
+		return ret;
 	}
 	
 	@POST
@@ -128,8 +131,7 @@ public class Admin {
 	public Map<String, Object> getUserToken(
 			@Context final UriInfo uriInfo,
 			@FormParam("token") final String token)
-			throws NoTokenProvidedException, MissingParameterException, InvalidTokenException,
-			NoSuchTokenException, UnauthorizedException, AuthStorageException {
+			throws MissingParameterException, InvalidTokenException, AuthStorageException {
 		final IncomingToken t;
 		try {
 			t = getToken(token);
@@ -143,6 +145,17 @@ public class Admin {
 				ht.getUserName().getName() + SEP + UIPaths.ADMIN_TOKENS + SEP +
 				UIPaths.ADMIN_USER_TOKENS_REVOKE + SEP + ht.getId().toString()));
 		return ret;
+	}
+	
+	@POST
+	@Path(UIPaths.ADMIN_POLICY_ID)
+	public void removePolicyID(
+			@Context final HttpHeaders headers,
+			@FormParam("policy_id") final String policyID)
+			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
+				MissingParameterException, IllegalParameterException, AuthStorageException {
+		auth.removePolicyID(getTokenFromCookie(headers, cfg.getTokenCookieName()),
+				new PolicyID(policyID));
 	}
 	
 	@POST

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -9,11 +9,15 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -45,6 +49,7 @@ import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
@@ -396,6 +401,8 @@ public class Login {
 			l.put("disabled", user.isDisabled());
 			l.put("adminonly", loginRestricted);
 			l.put("id", loginState.getIdentities(userName).iterator().next().getID());
+			l.put("policy_ids", user.getPolicyIDs().stream().map(id -> id.getName())
+					.collect(Collectors.toSet()));
 			final List<String> remoteIDs = new LinkedList<>();
 			for (final RemoteIdentityWithLocalID id: loginState.getIdentities(userName)) {
 				remoteIDs.add(id.getDetails().getUsername());
@@ -425,32 +432,63 @@ public class Login {
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
 			@CookieParam(SESSION_CHOICE_COOKIE) final String session,
 			@FormParam("id") final UUID identityID,
+			@FormParam("policy_ids") final String policyIDs,
 			@FormParam("linkall") final String linkAll)
 			throws NoTokenProvidedException, AuthenticationException,
 			AuthStorageException, UnauthorizedException, IllegalParameterException,
-			LinkFailedException {
+			LinkFailedException, MissingParameterException {
 		
-		final NewToken newtoken = auth.login(
-				getLoginInProcessToken(token), identityID, linkAll != null);
+		final NewToken newtoken = auth.login(getLoginInProcessToken(token), identityID,
+				PickChoice.getPolicyIDs(policyIDs), linkAll != null);
 		return createLoginResponse(redirect, newtoken, !FALSE.equals(session));
 	}
 	
 	private static class PickChoice extends IncomingJSON {
 		
 		private final String id;
+		private final List<String> policyIDs;
 		private final Object linkAll;
-
+		
 		// don't throw error from constructor, doesn't get picked up by the custom error handler 
 		@JsonCreator
 		public PickChoice(
 				@JsonProperty("id") final String id,
+				@JsonProperty("policy_ids") final List<String> policyIDs,
 				@JsonProperty("linkall") final Object linkAll) {
 			this.id = id;
+			this.policyIDs = policyIDs;
 			this.linkAll = linkAll;
 		}
 		
 		public UUID getID() throws IllegalParameterException, MissingParameterException {
 			return getUUID(id, "id");
+		}
+		
+		public Set<PolicyID> getPolicyIDs()
+				throws MissingParameterException, IllegalParameterException {
+			return getPolicyIDs(policyIDs);
+		}
+		
+		public static Set<PolicyID> getPolicyIDs(final String policyIDlist)
+				throws MissingParameterException, IllegalParameterException {
+			final Set<PolicyID> ids = new HashSet<>();
+			if (policyIDlist == null) {
+				return ids;
+			}
+			return getPolicyIDs(Arrays.asList(policyIDlist.split(",")));
+			
+		}
+		
+		private static Set<PolicyID> getPolicyIDs(final List<String> policyIDs)
+				throws MissingParameterException, IllegalParameterException {
+			final Set<PolicyID> ret = new HashSet<>(); 
+			if (policyIDs == null || policyIDs.isEmpty()) {
+				return ret;
+			}
+			for (final String id: policyIDs) {
+				ret.add(new PolicyID(id));
+			}
+			return ret;
 		}
 		
 		public boolean isLinkAll() throws IllegalParameterException {
@@ -474,8 +512,8 @@ public class Login {
 		}
 		
 		pick.exceptOnAdditionalProperties();
-		final NewToken newtoken = auth.login(
-				getLoginInProcessToken(token), pick.getID(), pick.isLinkAll());
+		final NewToken newtoken = auth.login(getLoginInProcessToken(token),
+				pick.getID(), pick.getPolicyIDs(), pick.isLinkAll());
 		return createLoginResponseJSON(Response.Status.OK, redirect, newtoken);
 	}
 
@@ -490,6 +528,7 @@ public class Login {
 			@FormParam("user") final String userName,
 			@FormParam("display") final String displayName,
 			@FormParam("email") final String email,
+			@FormParam("policy_ids") final String policyIDs,
 			@FormParam("linkall") final String linkAll)
 			throws AuthenticationException, AuthStorageException,
 				UserExistsException, NoTokenProvidedException,
@@ -505,6 +544,7 @@ public class Login {
 				new UserName(userName),
 				new DisplayName(displayName),
 				new EmailAddress(email),
+				CreateChoice.getPolicyIDs(policyIDs),
 				linkAll != null);
 		return createLoginResponse(redirect, newtoken, !FALSE.equals(session));
 	}
@@ -522,8 +562,9 @@ public class Login {
 				@JsonProperty("user") final String userName,
 				@JsonProperty("display") final String displayName,
 				@JsonProperty("email") final String email,
+				@JsonProperty("policy_ids") final List<String> policyIDs,
 				@JsonProperty("linkall") final Object linkAll) {
-			super(id, linkAll);
+			super(id, policyIDs, linkAll);
 			this.user = userName;
 			this.displayName = displayName;
 			this.email = email;
@@ -554,6 +595,7 @@ public class Login {
 				new UserName(create.user),
 				new DisplayName(create.displayName),
 				new EmailAddress(create.email),
+				create.getPolicyIDs(),
 				create.isLinkAll());
 		return createLoginResponseJSON(Response.Status.CREATED, redirect, newtoken);
 	}

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -57,6 +57,9 @@ public class UIPaths {
 	public static final String ADMIN_REVOKE_ALL = REVOKE_ALL;
 	public static final String ADMIN_ROOT_REVOKE_ALL = ADMIN_ROOT + ADMIN_REVOKE_ALL;
 	
+	public static final String ADMIN_POLICY_ID = "policyid";
+	public static final String ADMIN_ROOT_POLICY_ID = ADMIN_ROOT + ADMIN_POLICY_ID;
+	
 	public static final String ADMIN_SEARCH = "search";
 	public static final String ADMIN_ROOT_SEARCH = ADMIN_ROOT + ADMIN_SEARCH;
 	

--- a/src/us/kbase/test/auth2/lib/AuthUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthUserTest.java
@@ -19,6 +19,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -31,6 +32,8 @@ import us.kbase.test.auth2.TestCommon;
 public class AuthUserTest {
 	
 	private static final Instant NOW = Instant.now();
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
@@ -47,7 +50,7 @@ public class AuthUserTest {
 	public void constructMinimal() throws Exception {
 		final AuthUser u = new AuthUser(new UserName("foo"),
 				new EmailAddress("f@g.com"), new DisplayName("bar"), null,
-				null, null, NOW, null, new UserDisabledState());
+				null, null, null, NOW, null, new UserDisabledState());
 		
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.absent()));
@@ -59,6 +62,7 @@ public class AuthUserTest {
 		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.absent()));
 		assertThat("incorrect grantable roles", u.getGrantableRoles(), is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -75,7 +79,7 @@ public class AuthUserTest {
 		
 		final AuthUser u = new AuthUser(UserName.ROOT,
 				new EmailAddress("f@g1.com"), new DisplayName("bar1"), null,
-				set(Role.ROOT), set("foo", "bar"), NOW, ll, new UserDisabledState(
+				set(Role.ROOT), set("foo", "bar"), MTPID, NOW, ll, new UserDisabledState(
 						"reason", new UserName("whee"), d));
 		
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
@@ -89,6 +93,7 @@ public class AuthUserTest {
 		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.of(d)));
 		assertThat("incorrect grantable roles", u.getGrantableRoles(), is(set(Role.CREATE_ADMIN)));
 		assertThat("incorrect identities", u.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(ll));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(),
 				is(Optional.of("reason")));
@@ -106,8 +111,9 @@ public class AuthUserTest {
 		
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				set(Role.DEV_TOKEN, Role.SERV_TOKEN), set("foo1"), NOW, ll, new UserDisabledState(
-						new UserName("whee1"), d));
+				set(Role.DEV_TOKEN, Role.SERV_TOKEN), set("foo1"),
+				set(new PolicyID("foo"), new PolicyID("bar")), NOW, ll,
+				new UserDisabledState(new UserName("whee1"), d));
 		
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.of(new UserName("whee1"))));
@@ -120,6 +126,8 @@ public class AuthUserTest {
 		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.of(d)));
 		assertThat("incorrect grantable roles", u.getGrantableRoles(), is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE)));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(),
+				is(set(new PolicyID("bar"), new PolicyID("foo"))));
 		assertThat("incorrect last login", u.getLastLogin(), is(ll));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(set(Role.SERV_TOKEN, Role.DEV_TOKEN)));
@@ -136,8 +144,8 @@ public class AuthUserTest {
 		
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				set(Role.DEV_TOKEN, Role.SERV_TOKEN), set("foo1"), NOW, ll, new UserDisabledState(
-						new UserName("whee1"), d));
+				set(Role.DEV_TOKEN, Role.SERV_TOKEN), set("foo1"), MTPID, NOW, ll,
+				new UserDisabledState(new UserName("whee1"), d));
 		
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.of(new UserName("whee1"))));
@@ -150,6 +158,7 @@ public class AuthUserTest {
 		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.of(d)));
 		assertThat("incorrect grantable roles", u.getGrantableRoles(), is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE)));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(set(Role.SERV_TOKEN, Role.DEV_TOKEN)));
@@ -163,7 +172,7 @@ public class AuthUserTest {
 	public void newRoles() throws Exception {
 		final AuthUser pre = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				null, null, NOW, null, new UserDisabledState());
+				null, null, MTPID, NOW, null, new UserDisabledState());
 		
 		final RemoteIdentityWithLocalID ri2 = new RemoteIdentityWithLocalID(
 				UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56714d8"),
@@ -182,6 +191,7 @@ public class AuthUserTest {
 		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.absent()));
 		assertThat("incorrect grantable roles", u.getGrantableRoles(), is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(ri2)));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -195,7 +205,7 @@ public class AuthUserTest {
 	public void roleMethods() throws Exception {
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), null, 
-				set(Role.ADMIN, Role.DEV_TOKEN), null, NOW, null,
+				set(Role.ADMIN, Role.DEV_TOKEN), null, MTPID, NOW, null,
 				new UserDisabledState());
 		
 		assertThat("incorrect has role", u.hasRole(Role.ROOT), is(false));
@@ -217,7 +227,7 @@ public class AuthUserTest {
 		
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE, ri2),
-				null, null, NOW, null, new UserDisabledState());
+				null, null, MTPID, NOW, null, new UserDisabledState());
 		
 		final RemoteIdentity target = new RemoteIdentity(
 				new RemoteIdentityID("prov2", "bar2"),
@@ -245,7 +255,7 @@ public class AuthUserTest {
 		final Instant c = ll.get().plusMillis(1000);
 		final AuthUser u = new AuthUser(new UserName("foo"),
 				new EmailAddress("f@g.com"), new DisplayName("bar"), null,
-				null, null, c, ll, new UserDisabledState());
+				null, null, MTPID, c, ll, new UserDisabledState());
 		assertThat("last login not updated correctly", u.getLastLogin(), is(Optional.of(c)));
 	}
 	
@@ -257,34 +267,38 @@ public class AuthUserTest {
 		final Set<RemoteIdentityWithLocalID> ids = set(REMOTE);
 		final Set<Role> roles = Collections.emptySet();
 		final Set<String> croles = Collections.emptySet();
+		final Set<PolicyID> pids = Collections.emptySet();
 		final Instant created = Instant.now();
 		final UserDisabledState ds = new UserDisabledState();
-		failConstruct(null, email, dn, ids, roles, croles, created, ds,
+		failConstruct(null, email, dn, ids, roles, croles, pids, created, ds,
 				new NullPointerException("userName"));
-		failConstruct(un, null, dn, ids, roles, croles, created, ds,
+		failConstruct(un, null, dn, ids, roles, croles, pids, created, ds,
 				new NullPointerException("email"));
-		failConstruct(un, email, null, ids, roles, croles, created, ds,
+		failConstruct(un, email, null, ids, roles, croles, pids, created, ds,
 				new NullPointerException("displayName"));
-		failConstruct(un, email, dn, ids, roles, croles, null, ds,
+		failConstruct(un, email, dn, ids, roles, croles, pids, null, ds,
 				new NullPointerException("created"));
-		failConstruct(un, email, dn, ids, roles, croles, created, null,
+		failConstruct(un, email, dn, ids, roles, croles, pids, created, null,
 				new NullPointerException("disabledState"));
-		failConstruct(UserName.ROOT, email, dn, null, roles, croles, created, ds,
+		failConstruct(UserName.ROOT, email, dn, null, roles, croles, pids, created, ds,
 				new IllegalStateException("Root username must only have the ROOT role"));
-		failConstruct(UserName.ROOT, email, dn, null, set(Role.ADMIN), croles, created, ds,
+		failConstruct(UserName.ROOT, email, dn, null, set(Role.ADMIN), croles, pids, created, ds,
 				new IllegalStateException("Root username must only have the ROOT role"));
-		failConstruct(UserName.ROOT, email, dn, null, set(Role.ADMIN, Role.ROOT), croles, created,
-				ds, new IllegalStateException("Root username must only have the ROOT role"));
-		failConstruct(UserName.ROOT, email, dn, ids, set(Role.ROOT), croles, created, ds,
+		failConstruct(UserName.ROOT, email, dn, null, set(Role.ADMIN, Role.ROOT), croles, pids,
+				created, ds,
+				new IllegalStateException("Root username must only have the ROOT role"));
+		failConstruct(UserName.ROOT, email, dn, ids, set(Role.ROOT), croles, pids, created, ds,
 				new IllegalStateException("Root user cannot have identities"));
-		failConstruct(un, email, dn, ids, set(Role.ADMIN, Role.ROOT), croles, created, ds,
+		failConstruct(un, email, dn, ids, set(Role.ADMIN, Role.ROOT), croles, pids, created, ds,
 				new IllegalStateException("Non-root username with root role"));
-		failConstruct(un, email, dn, set(REMOTE, null), roles, croles, created, ds,
+		failConstruct(un, email, dn, set(REMOTE, null), roles, croles, pids, created, ds,
 				new NullPointerException("null item in identities"));
-		failConstruct(un, email, dn, ids, set(Role.ADMIN, null), croles, created, ds,
+		failConstruct(un, email, dn, ids, set(Role.ADMIN, null), croles, pids, created, ds,
 				new NullPointerException("null item in roles"));
-		failConstruct(un, email, dn, ids, roles, set("foo", null), created, ds,
+		failConstruct(un, email, dn, ids, roles, set("foo", null), pids, created, ds,
 				new NullPointerException("null item in customRoles"));
+		failConstruct(un, email, dn, ids, roles, croles, set(new PolicyID("foo"), null), created,
+				ds, new NullPointerException("null item in policyIDs"));
 	}
 	
 	private void failConstruct(
@@ -294,12 +308,13 @@ public class AuthUserTest {
 			final Set<RemoteIdentityWithLocalID> identities,
 			final Set<Role> roles,
 			final Set<String> customRoles,
+			final Set<PolicyID> policyIDs,
 			final Instant created,
 			final UserDisabledState disabledState,
 			final Exception e) {
 		try {
 			new AuthUser(userName, email, displayName, identities, roles,
-					customRoles, created, null, disabledState);
+					customRoles, policyIDs, created, null, disabledState);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
@@ -311,7 +326,7 @@ public class AuthUserTest {
 		final Set<RemoteIdentityWithLocalID> ids = set(REMOTE);
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), ids,
-				null, null, NOW, null, new UserDisabledState());
+				null, null, MTPID, NOW, null, new UserDisabledState());
 		final RemoteIdentityWithLocalID ri = new RemoteIdentityWithLocalID(
 				UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56714d8"),
 				new RemoteIdentityID("prov2", "bar2"),
@@ -333,7 +348,7 @@ public class AuthUserTest {
 		final Set<Role> roles = set(Role.DEV_TOKEN);
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				roles, null, NOW, null, new UserDisabledState());
+				roles, null, MTPID, NOW, null, new UserDisabledState());
 		
 		try {
 			u.getRoles().add(Role.ADMIN);
@@ -351,7 +366,7 @@ public class AuthUserTest {
 		final Set<String> croles = set("foo");
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				null, croles, NOW, null, new UserDisabledState());
+				null, croles, MTPID, NOW, null, new UserDisabledState());
 		
 		try {
 			u.getCustomRoles().add("bar");
@@ -368,7 +383,7 @@ public class AuthUserTest {
 	public void immutableGrantableRoles() throws Exception {
 		final AuthUser u = new AuthUser(new UserName("whoo"),
 				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
-				null, null, NOW, null, new UserDisabledState());
+				null, null, MTPID, NOW, null, new UserDisabledState());
 		
 		try {
 			u.getGrantableRoles().add(Role.ADMIN);
@@ -376,5 +391,23 @@ public class AuthUserTest {
 		} catch (UnsupportedOperationException e) {
 			// test passed
 		}
+	}
+	
+	@Test
+	public void immutablePolicyIDs() throws Exception {
+		final Set<PolicyID> pids = set(new PolicyID("foo"));
+		final AuthUser u = new AuthUser(new UserName("whoo"),
+				new EmailAddress("f@g2.com"), new DisplayName("bar3"), set(REMOTE),
+				null, null, pids, NOW, null, new UserDisabledState());
+		
+		try {
+			u.getPolicyIDs().add(new PolicyID("bar"));
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			// test passed
+		}
+		
+		pids.add(new PolicyID("baz"));
+		assertThat("incorrect roles", u.getPolicyIDs(), is(set(new PolicyID("foo"))));
 	}
 }

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
@@ -16,6 +16,7 @@ import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -30,6 +31,7 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.NewLocalUser;
 import us.kbase.auth2.lib.Password;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -59,12 +61,13 @@ public class AuthenticationCreateLocalUserTest {
 	
 	private final static Instant NOW = Instant.now();
 	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	@Test
 	public void createWithAdminUser() throws Exception {
 		final Instant now = Instant.now();
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), now, Optional.of(now), new UserDisabledState());
+				Collections.emptySet(), MTPID, now, Optional.of(now), new UserDisabledState());
 		
 		create(admin);
 	}
@@ -74,7 +77,7 @@ public class AuthenticationCreateLocalUserTest {
 		final Instant now = Instant.now();
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), now, Optional.of(now), new UserDisabledState());
+				Collections.emptySet(), MTPID, now, Optional.of(now), new UserDisabledState());
 		
 		create(admin);
 	}
@@ -84,7 +87,7 @@ public class AuthenticationCreateLocalUserTest {
 		final Instant now = Instant.now();
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), now, Optional.of(now), new UserDisabledState());
+				Collections.emptySet(), MTPID, now, Optional.of(now), new UserDisabledState());
 		
 		create(admin);
 	}
@@ -94,7 +97,7 @@ public class AuthenticationCreateLocalUserTest {
 		final Instant now = Instant.now();
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), now, Optional.of(now), new UserDisabledState());
+				Collections.emptySet(), MTPID, now, Optional.of(now), new UserDisabledState());
 		createFail(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
 	
@@ -134,7 +137,8 @@ public class AuthenticationCreateLocalUserTest {
 		when(clock.instant()).thenReturn(create);
 		
 		final NewLocalUser expected = new NewLocalUser(new UserName("foo"),
-				new EmailAddress("f@g.com"), new DisplayName("bar"), create, hash, salt, true);
+				new EmailAddress("f@g.com"), new DisplayName("bar"), MTPID,
+				create, hash, salt, true);
 		
 		final LocalUserAnswerMatcher<NewLocalUser> matcher =
 				new LocalUserAnswerMatcher<>(expected);
@@ -174,7 +178,7 @@ public class AuthenticationCreateLocalUserTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState());
 		
 		when(storage.getUser(new UserName("admin"))).thenReturn(admin);
@@ -208,7 +212,7 @@ public class AuthenticationCreateLocalUserTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState());
 		
 		when(storage.getUser(new UserName("admin"))).thenReturn(admin);
@@ -233,7 +237,7 @@ public class AuthenticationCreateLocalUserTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("disabled", new UserName("foo"), Instant.now()));
 		
 		when(storage.getUser(new UserName("admin"))).thenReturn(admin);

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
@@ -193,6 +193,7 @@ public class AuthenticationCreateRootTest {
 		
 		final LocalUser disabled = new LocalUser(UserName.ROOT, EmailAddress.UNKNOWN,
 				new DisplayName("root"), set(Role.ROOT), Collections.emptySet(),
+				Collections.emptySet(),
 				Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState("foo", UserName.ROOT, Instant.now()),
 				new byte[10], new byte[8], false, null);

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
@@ -28,6 +28,7 @@ import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -47,6 +48,8 @@ import us.kbase.test.auth2.TestCommon;
 import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 
 public class AuthenticationGetUserDisplayNamesTest {
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 
 	@Test
 	public void getDisplayNamesSet() throws Exception {
@@ -157,7 +160,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpec() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
@@ -173,7 +176,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecWithRootAsAdmin() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -191,7 +194,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecWithRootAsCreate() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -209,7 +212,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecWithRootAsRoot() throws Exception {
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -239,7 +242,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 						r == Role.ROOT ? UserName.ROOT : new UserName("foo"),
 								new EmailAddress("f@g.com"),
 						new DisplayName("foo"), Collections.emptySet(), set(r),
-						Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+						Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 						new UserDisabledState());
 				
 				final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -267,7 +270,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailRegex() throws Exception {
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
@@ -316,7 +319,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailDisabled() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
@@ -328,7 +331,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailStdUserCustomRole() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -342,7 +345,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailStdUserRole() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -356,7 +359,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailStdUserNoPrefix() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().build();
@@ -369,7 +372,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailStdUserIncludeRoot() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -383,7 +386,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	public void getDisplayNamesSpecFailStdUserIncludeDisabled() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo")
@@ -454,8 +457,5 @@ public class AuthenticationGetUserDisplayNamesTest {
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
 		}
-		// TODO Auto-generated method stub
-		
 	}
-	
 }

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
@@ -12,6 +12,7 @@ import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -22,6 +23,7 @@ import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -41,12 +43,14 @@ import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 
 public class AuthenticationGetUserTest {
 	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
+	
 	@Test
 	public void getUser() throws Exception {
 		
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		getUser(user);
@@ -56,7 +60,7 @@ public class AuthenticationGetUserTest {
 	public void getUserFailDisabled() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 		
 		failGetUser(user, new DisabledUserException());
@@ -152,7 +156,7 @@ public class AuthenticationGetUserTest {
 	public void getOtherUserSameUser() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		getOtherUser(user, new UserName("admin"), true);
@@ -162,7 +166,7 @@ public class AuthenticationGetUserTest {
 	public void getOtherUserDiffUser() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo1"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState());
 		
 		getOtherUser(user, new UserName("foo"), false);
@@ -172,7 +176,7 @@ public class AuthenticationGetUserTest {
 	public void getOtherUserFailDisabledSameUser() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo1"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
 		
 		failGetOtherUser(user, new UserName("admin"), new NoSuchUserException("admin"));
@@ -182,7 +186,7 @@ public class AuthenticationGetUserTest {
 	public void getOtherUserFailDisabledDiffUser() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("foo1"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), Optional.of(Instant.now()),
+				Collections.emptySet(), MTPID, Instant.now(), Optional.of(Instant.now()),
 				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
 		
 		failGetOtherUser(user, new UserName("foo"), new NoSuchUserException("admin"));
@@ -289,11 +293,11 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		getUserAsAdmin(admin, user);
 	}
@@ -302,11 +306,11 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdminSelf() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		getUserAsAdmin(admin, user);
 	}
@@ -316,11 +320,11 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdminCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		getUserAsAdmin(admin, user);
 	}
@@ -329,11 +333,11 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdminRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		getUserAsAdmin(admin, user);
 	}
@@ -342,11 +346,11 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdminFailNotAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		failGetUserAsAdmin(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -355,12 +359,12 @@ public class AuthenticationGetUserTest {
 	public void getUserAsAdminFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("baz", new UserName("whee"), Instant.now()));
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		failGetUserAsAdmin(admin, user, new DisabledUserException());
 	}
@@ -420,7 +424,7 @@ public class AuthenticationGetUserTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
@@ -39,6 +39,7 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LocalLoginResult;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.Password;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -71,6 +72,8 @@ public class AuthenticationPasswordLoginTest {
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
 			new RemoteIdentityID("prov", "bar1"),
 			new RemoteIdentityDetails("user1", "full1", "email1"));
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 
 	@Test
 	public void loginStdUser() throws Exception {
@@ -102,7 +105,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				roles, Collections.emptySet(),
+				roles, Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -145,7 +148,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, true, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -203,7 +206,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		failLogin(auth, new UserName("foo"), p,
@@ -227,7 +230,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -254,7 +257,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null,
 				new UserDisabledState("foo", new UserName("foo"), Instant.now()),
 				hash, salt, false, null));
@@ -286,7 +289,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID, 
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -357,7 +360,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				roles, Collections.emptySet(),
+				roles, Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hashold, saltold, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -443,7 +446,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		failChangePassword(auth, new UserName("foo"), po, pn, new AuthenticationException(
@@ -467,7 +470,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		failChangePassword(auth, new UserName("foo"), po, pn, new IllegalPasswordException(
@@ -491,7 +494,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		failChangePassword(auth, new UserName("foo"), po, pn, new IllegalPasswordException(
@@ -516,7 +519,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hash, salt, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -545,7 +548,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null,
 				new UserDisabledState("foo", new UserName("foo"), Instant.now()),
 				hash, salt, false, null));
@@ -581,7 +584,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(new LocalUser(
 				new UserName("foo"), new EmailAddress("f@g.com"), new DisplayName("foo"),
-				Collections.emptySet(), Collections.emptySet(),
+				Collections.emptySet(), Collections.emptySet(), MTPID,
 				Instant.now(), null, new UserDisabledState(), hashold, saltold, false, null));
 		
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
@@ -617,11 +620,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordAdminOnStd() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		resetPassword(admin, user);
 	}
@@ -630,11 +633,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordSelf() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		resetPassword(admin, user);
 	}
@@ -643,11 +646,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordRootOnCreate() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		resetPassword(admin, user);
 	}
@@ -656,11 +659,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordRootOnSelf() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		resetPassword(admin, user);
 	}
@@ -669,11 +672,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordCreateOnAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		resetPassword(admin, user);
 	}
@@ -682,11 +685,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordFailLocalUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), set(REMOTE1), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new NoSuchUserException(
 				"foo is not a local user and has no password"));
@@ -697,11 +700,11 @@ public class AuthenticationPasswordLoginTest {
 		// shouldn't be able to reset own pwd, can use change pwd for that
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), set(REMOTE1), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -710,11 +713,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordFailCreateOnRoot() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Only root can reset root password"));
@@ -724,11 +727,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordFailCreateOnCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Cannot reset password of user with create administrator role"));
@@ -738,11 +741,11 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordFailAdminOnAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Cannot reset password of user with administrator role"));
@@ -752,12 +755,12 @@ public class AuthenticationPasswordLoginTest {
 	public void resetPasswordFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("admin2"), Instant.now()));
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failResetPassword(admin, user, new DisabledUserException());
 	}
@@ -817,7 +820,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
 		
@@ -833,11 +836,11 @@ public class AuthenticationPasswordLoginTest {
 		// clearing occurred
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
@@ -866,11 +869,11 @@ public class AuthenticationPasswordLoginTest {
 		// clearing occurred
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
@@ -988,10 +991,10 @@ public class AuthenticationPasswordLoginTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		forceResetPassword(admin, user);
 	}
@@ -1000,11 +1003,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordSelf() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		forceResetPassword(admin, user);
 	}
@@ -1013,11 +1016,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordRootOnCreate() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		forceResetPassword(admin, user);
 	}
@@ -1026,11 +1029,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordRootOnSelf() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		forceResetPassword(admin, user);
 	}
@@ -1039,11 +1042,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordCreateOnAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		forceResetPassword(admin, user);
 	}
@@ -1052,11 +1055,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordFailLocalUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), set(REMOTE1), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new NoSuchUserException(
 				"foo is not a local user and has no password"));
@@ -1067,11 +1070,11 @@ public class AuthenticationPasswordLoginTest {
 		// shouldn't be able to reset own pwd, can use change pwd for that
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), set(REMOTE1), Collections.emptySet(),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -1080,11 +1083,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordFailCreateOnRoot() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(UserName.ROOT, new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Only root can reset root password"));
@@ -1094,11 +1097,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordFailCreateOnCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Cannot reset password of user with create administrator role"));
@@ -1108,11 +1111,11 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordFailAdminOnAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Cannot reset password of user with administrator role"));
@@ -1122,12 +1125,12 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetPasswordFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("admin2"), Instant.now()));
 		
 		final AuthUser user = new AuthUser(new UserName("bar"), new EmailAddress("f@goo.com"),
 				new DisplayName("baz"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failForceResetPassword(admin, user, new DisabledUserException());
 	}
@@ -1187,7 +1190,7 @@ public class AuthenticationPasswordLoginTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(token, (HashedToken) null);
 		
@@ -1256,7 +1259,7 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetAllPasswordsCreateAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		forceResetAllPasswords(admin);
 	}
 	
@@ -1264,7 +1267,7 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetAllPasswordsRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		forceResetAllPasswords(admin);
 	}
 	
@@ -1272,7 +1275,7 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetAllPasswordsFailStdAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		failForceResetAllPasswords(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
 	
@@ -1280,7 +1283,7 @@ public class AuthenticationPasswordLoginTest {
 	public void forceResetAllPasswordsFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 		failForceResetAllPasswords(admin, new DisabledUserException());
 	}

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -32,6 +32,7 @@ import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.CollectingExternalConfig;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.TokenName;
 import us.kbase.auth2.lib.UserDisabledState;
@@ -70,6 +71,8 @@ public class AuthenticationTokenTest {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
 	}
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	@Test
 	public void getToken() throws Exception {
@@ -182,7 +185,7 @@ public class AuthenticationTokenTest {
 	public void getTokensUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		getTokensUser(admin);
 	}
 	
@@ -190,7 +193,7 @@ public class AuthenticationTokenTest {
 	public void getTokensUserFailNonAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
 	
@@ -198,7 +201,7 @@ public class AuthenticationTokenTest {
 	public void getTokensUserFailCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
 	
@@ -206,7 +209,7 @@ public class AuthenticationTokenTest {
 	public void getTokensUserFailRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		failGetTokensUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
 	
@@ -214,7 +217,7 @@ public class AuthenticationTokenTest {
 	public void getTokensUserFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
 		failGetTokensUser(admin, new DisabledUserException());
 	}
@@ -448,7 +451,7 @@ public class AuthenticationTokenTest {
 	public void revokeTokenAdmin() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		revokeTokenAdmin(admin);
 	}
@@ -457,7 +460,7 @@ public class AuthenticationTokenTest {
 	public void revokeTokenAdminFailStdUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeTokenAdmin(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -466,7 +469,7 @@ public class AuthenticationTokenTest {
 	public void revokeTokenAdminFailCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeTokenAdmin(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -475,7 +478,7 @@ public class AuthenticationTokenTest {
 	public void revokeTokenAdminFailRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeTokenAdmin(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -484,7 +487,7 @@ public class AuthenticationTokenTest {
 	public void revokeTokenAdminFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 
 		failRevokeTokenAdmin(admin, new DisabledUserException());
@@ -551,7 +554,7 @@ public class AuthenticationTokenTest {
 		
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(ht, (HashedToken) null);
 		
@@ -670,7 +673,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminAll() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		revokeAllTokensAdminAll(admin);
 	}
@@ -679,7 +682,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminAllFailStdUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminAll(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -688,7 +691,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminAllFailCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminAll(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -697,7 +700,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminAllFailRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminAll(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -706,7 +709,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminAllFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 
 		failRevokeAllTokensAdminAll(admin, new DisabledUserException());
@@ -804,7 +807,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		revokeAllTokensAdminUser(admin);
 	}
@@ -813,7 +816,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminUserFailStdUser() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -822,7 +825,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminUserFailCreate() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -831,7 +834,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminUserFailRoot() throws Exception {
 		final AuthUser admin = new AuthUser(UserName.ROOT, new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ROOT),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 
 		failRevokeAllTokensAdminUser(admin, new UnauthorizedException(ErrorType.UNAUTHORIZED));
 	}
@@ -840,7 +843,7 @@ public class AuthenticationTokenTest {
 	public void revokeAllTokensAdminUserFailDisabled() throws Exception {
 		final AuthUser admin = new AuthUser(new UserName("admin"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("bar"), Instant.now()));
 
 		failRevokeAllTokensAdminUser(admin, new DisabledUserException());
@@ -942,7 +945,7 @@ public class AuthenticationTokenTest {
 	public void createDevToken() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, false);
 	}
@@ -951,7 +954,7 @@ public class AuthenticationTokenTest {
 	public void createDevTokenAltLifetime() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
 		lifetimes.put(TokenLifetimeType.DEV, 42 * 24 * 3600 * 1000L);
@@ -962,7 +965,7 @@ public class AuthenticationTokenTest {
 	public void createDevTokenWithServRole() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, false);
 	}
@@ -971,7 +974,7 @@ public class AuthenticationTokenTest {
 	public void createServToken() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, true);
 	}
@@ -980,7 +983,7 @@ public class AuthenticationTokenTest {
 	public void createServTokenWithAdminRole() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, true);
 	}
@@ -989,7 +992,7 @@ public class AuthenticationTokenTest {
 	public void createServTokenWithAltLifetime() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
 		lifetimes.put(TokenLifetimeType.SERV, 24 * 24 * 3600 * 1000L);
@@ -1000,7 +1003,7 @@ public class AuthenticationTokenTest {
 	public void createTokenFailDisabledUser() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
 		
 		failCreateToken(user, false, new DisabledUserException());
@@ -1010,7 +1013,7 @@ public class AuthenticationTokenTest {
 	public void createTokenFailNoDevRole() throws Exception {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.CREATE_ADMIN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		failCreateToken(user, false, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"User foo is not authorized to create this token type."));
@@ -1021,7 +1024,7 @@ public class AuthenticationTokenTest {
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(),
 				set(Role.CREATE_ADMIN, Role.DEV_TOKEN),
-				Collections.emptySet(), Instant.now(), null, new UserDisabledState());
+				Collections.emptySet(), MTPID, Instant.now(), null, new UserDisabledState());
 		
 		failCreateToken(user, true, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"User foo is not authorized to create this token type."));
@@ -1075,7 +1078,7 @@ public class AuthenticationTokenTest {
 		
 		final AuthUser user = new AuthUser(new UserName("foo"), new EmailAddress("f@g.com"),
 				new DisplayName("bar"), Collections.emptySet(), set(Role.SERV_TOKEN),
-				Collections.emptySet(), Instant.now(), null,
+				Collections.emptySet(), MTPID, Instant.now(), null,
 				new UserDisabledState("foo", new UserName("baz"), Instant.now()));
 		
 		final IncomingToken t = new IncomingToken("foobar");

--- a/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -41,7 +42,7 @@ public class LinkIdentitiesTest {
 	static {
 		try {
 			AUTH_USER = new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-					new DisplayName("bar"), REMOTE1, Instant.now(), null);
+					new DisplayName("bar"), REMOTE1, Collections.emptySet(), Instant.now(), null);
 		} catch (Exception e) {
 			throw new RuntimeException("fix yer tests newb", e);
 		}

--- a/src/us/kbase/test/auth2/lib/LinkTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkTokenTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class LinkTokenTest {
 	static {
 		try {
 			AUTH_USER = new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-					new DisplayName("bar"), REMOTE1, Instant.now(), null);
+					new DisplayName("bar"), REMOTE1, Collections.emptySet(), Instant.now(), null);
 		} catch (Exception e) {
 			throw new RuntimeException("fix yer tests newb", e);
 		}

--- a/src/us/kbase/test/auth2/lib/LocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/LocalUserTest.java
@@ -21,12 +21,15 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.NewLocalUser;
 import us.kbase.auth2.lib.NewRootUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.test.auth2.TestCommon;
 
 public class LocalUserTest {
+
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	@Test
 	public void equals() {
@@ -41,6 +44,7 @@ public class LocalUserTest {
 		final DisplayName dn = new DisplayName("bar");
 		final Set<Role> r = set(Role.CREATE_ADMIN);
 		final Set<String> cr = set("foobar");
+		final Set<PolicyID> pids = set(new PolicyID("foo"));
 		final Instant d = Instant.ofEpochMilli(5);
 		final Optional<Instant> ll = Optional.of(Instant.ofEpochMilli(6));
 		final Instant dis = Instant.now();
@@ -48,7 +52,7 @@ public class LocalUserTest {
 		final byte[] pwd = "foobarbazb".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wh".getBytes(StandardCharsets.UTF_8);
 		
-		final LocalUser lu = new LocalUser(un, e, dn, r, cr, d, ll, uds,
+		final LocalUser lu = new LocalUser(un, e, dn, r, cr, pids, d, ll, uds,
 				pwd, salt, false, null);
 		assertThat("incorrect password hash",
 				new String(lu.getPasswordHash(), StandardCharsets.UTF_8), is("foobarbazb"));
@@ -69,6 +73,7 @@ public class LocalUserTest {
 		assertThat("incorrect enable toggle date", lu.getEnableToggleDate(), is(Optional.of(dis)));
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(), is(set(Role.ADMIN)));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy IDs", lu.getPolicyIDs(), is(set(new PolicyID("foo"))));
 		assertThat("incorrect last login", lu.getLastLogin(), is(ll));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(set(Role.CREATE_ADMIN)));
@@ -91,7 +96,7 @@ public class LocalUserTest {
 		final byte[] pwd = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "we".getBytes(StandardCharsets.UTF_8);
 		
-		final LocalUser lu = new LocalUser(un, e, dn, r, cr, create, null, uds,
+		final LocalUser lu = new LocalUser(un, e, dn, r, cr, MTPID, create, null, uds,
 				pwd, salt, true, dis);
 		assertThat("incorrect password hash",
 				new String(lu.getPasswordHash(), StandardCharsets.UTF_8), is("foobarbaz1"));
@@ -122,7 +127,7 @@ public class LocalUserTest {
 			final Exception e) {
 		try {
 			new LocalUser(new UserName("foo"), new EmailAddress("e@g.com"),
-					new DisplayName("bar"), Collections.emptySet(), Collections.emptySet(),
+					new DisplayName("bar"), Collections.emptySet(), Collections.emptySet(), MTPID,
 					Instant.now(), null, new UserDisabledState(), passwordHash, salt, false, null);
 			fail("excpected exception");
 		} catch (Exception got) {
@@ -136,7 +141,7 @@ public class LocalUserTest {
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		final Instant create = Instant.now();
 		final NewLocalUser lu = new NewLocalUser(new UserName("foo"), new EmailAddress("e@g.com"),
-				new DisplayName("bar"), create, pwd, salt, false);
+				new DisplayName("bar"), set(new PolicyID("foo")), create, pwd, salt, false);
 		
 		assertThat("incorrect password hash",
 				new String(lu.getPasswordHash(), StandardCharsets.UTF_8), is("foobarbaz8"));
@@ -157,6 +162,7 @@ public class LocalUserTest {
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy IDs", lu.getPolicyIDs(), is(set(new PolicyID("foo"))));
 		assertThat("incorrect last login", lu.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(Collections.emptySet()));
@@ -193,6 +199,7 @@ public class LocalUserTest {
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(),
 				is(set(Role.CREATE_ADMIN)));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy IDs", lu.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", lu.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(set(Role.ROOT)));
@@ -201,39 +208,4 @@ public class LocalUserTest {
 		assertThat("incorrect is local", lu.isLocal(), is(true));
 		assertThat("incorrect is root", lu.isRoot(), is(true));
 	}
-	
-	@Test
-	public void localUserToString() throws Exception {
-		final UserName un = new UserName("foo");
-		final EmailAddress e = new EmailAddress("f@g.com");
-		final DisplayName dn = new DisplayName("bar");
-		final Set<Role> r = set(Role.CREATE_ADMIN);
-		final Set<String> cr = set("foobar");
-		final Instant d = Instant.ofEpochMilli(1000);
-		final Optional<Instant> ll = Optional.of(Instant.ofEpochMilli(2000));
-		final Instant dis = Instant.ofEpochMilli(3000);
-		final Optional<Instant> lastReset = Optional.of(Instant.ofEpochMilli(4000));
-		final UserDisabledState uds = new UserDisabledState(new UserName("who"), dis);
-		final byte[] pwd = "foobarbazb".getBytes(StandardCharsets.UTF_8);
-		final byte[] salt = "wh".getBytes(StandardCharsets.UTF_8);
-		
-		final LocalUser lu = new LocalUser(un, e, dn, r, cr, d, ll, uds,
-				pwd, salt, false, lastReset);
-		
-		assertThat("incorrect toString", lu.toString(), is(
-				"LocalUser [passwordHash=[102, 111, 111, 98, 97, 114, 98, 97, 122, 98], " +
-				"salt=[119, 104], forceReset=false, " +
-				"lastReset=Optional.of(1970-01-01T00:00:04Z), " +
-				"getDisplayName()=DisplayName [getName()=bar], " +
-				"getEmail()=EmailAddress [email=f@g.com], " +
-				"getUserName()=UserName [getName()=foo], " +
-				"getRoles()=[CREATE_ADMIN], getCustomRoles()=[foobar], " +
-				"getCreated()=1970-01-01T00:00:01Z, " +
-				"getLastLogin()=Optional.of(1970-01-01T00:00:02Z), " +
-				"getDisabledState()=UserDisabledState [disabledReason=Optional.absent(), " +
-				"byAdmin=Optional.of(UserName [getName()=who])," +
-				" time=Optional.of(1970-01-01T00:00:03Z)]]"));
-		
-	}
-
 }

--- a/src/us/kbase/test/auth2/lib/LoginStateTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginStateTest.java
@@ -47,11 +47,11 @@ public class LoginStateTest {
 	static {
 		try {
 			AUTH_USER1 = new NewUser(new UserName("foo4"), new EmailAddress("f@g.com"),
-					new DisplayName("bar4"), REMOTE1, Instant.now(), null);
+					new DisplayName("bar4"), REMOTE1, Collections.emptySet(), Instant.now(), null);
 			AUTH_USER2 = new AuthUser(new UserName("foo5"),
 					new EmailAddress("f@g5.com"), new DisplayName("bar5"), set(REMOTE2, REMOTE3),
-					set(Role.ADMIN), Collections.emptySet(), Instant.now(), null,
-					new UserDisabledState());
+					set(Role.ADMIN), Collections.emptySet(), Collections.emptySet(),
+					Instant.now(), null, new UserDisabledState());
 		} catch (Exception e) {
 			throw new RuntimeException("fix yer tests newb", e);
 		}

--- a/src/us/kbase/test/auth2/lib/LoginTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginTokenTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -36,9 +37,9 @@ public class LoginTokenTest {
 	static {
 		try {
 			LOGIN_STATE = new LoginState.Builder("foo", false)
-					.withUser(new NewUser(new UserName("foo"),
-							new EmailAddress("f@g.com"),
-							new DisplayName("bar"), REMOTE, Instant.now(), null), REMOTE).build();
+					.withUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
+							new DisplayName("bar"), REMOTE, Collections.emptySet(),
+							Instant.now(), null), REMOTE).build();
 		} catch (Exception e) {
 			throw new RuntimeException("Fix yer tests nub", e);
 		}

--- a/src/us/kbase/test/auth2/lib/NewUserTest.java
+++ b/src/us/kbase/test/auth2/lib/NewUserTest.java
@@ -17,6 +17,7 @@ import com.google.common.base.Optional;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
@@ -34,7 +35,7 @@ public class NewUserTest {
 	public void constructorNoLastLogin() throws Exception {
 		final Instant now = Instant.now();
 		final NewUser u = new NewUser(new UserName("foo"), new EmailAddress("e@g.com"),
-				new DisplayName("bar"), REMOTE, now, null);
+				new DisplayName("bar"), REMOTE, set(new PolicyID("foo")), now, null);
 		
 		//check that super() is called correctly
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
@@ -49,6 +50,7 @@ public class NewUserTest {
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE)));
 		assertThat("incorrect identity", u.getIdentity(), is(REMOTE));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(set(new PolicyID("foo"))));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -63,7 +65,7 @@ public class NewUserTest {
 		final Instant create = Instant.ofEpochMilli(4000);
 		final Optional<Instant> ll = Optional.of(Instant.ofEpochMilli(6000));
 		final NewUser u = new NewUser(new UserName("foo"), new EmailAddress("e@g.com"),
-				new DisplayName("bar"), REMOTE, create, ll);
+				new DisplayName("bar"), REMOTE, Collections.emptySet(), create, ll);
 		
 		//check that super() is called correctly
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
@@ -78,6 +80,7 @@ public class NewUserTest {
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE)));
 		assertThat("incorrect identity", u.getIdentity(), is(REMOTE));
+		assertThat("incorrect policy IDs", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(ll));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -91,7 +94,7 @@ public class NewUserTest {
 	public void constructorFail() throws Exception {
 		try {
 			new NewUser(new UserName("foo"), new EmailAddress("e@g.com"),
-					new DisplayName("bar"), null, Instant.now(), null);
+					new DisplayName("bar"), null, Collections.emptySet(), Instant.now(), null);
 			fail("expected exception");
 		} catch (NullPointerException e) {
 			assertThat("incorrect exception message", e.getMessage(), is("remoteIdentity"));

--- a/src/us/kbase/test/auth2/lib/PolicyIDTest.java
+++ b/src/us/kbase/test/auth2/lib/PolicyIDTest.java
@@ -1,0 +1,39 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.PolicyID;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.test.auth2.TestCommon;
+
+public class PolicyIDTest {
+
+	@Test
+	public void construct() throws Exception {
+		final PolicyID pid = new PolicyID(TestCommon.LONG101.substring(0, 20));
+		assertThat("incorrect pid", pid.getName(), is(TestCommon.LONG101.substring(0, 20)));
+	}
+	
+	@Test
+	public void constructFail() {
+		failConstruct(null, new MissingParameterException("policy id"));
+		failConstruct("           ", new MissingParameterException("policy id"));
+		failConstruct(TestCommon.LONG101.substring(0, 31), new IllegalParameterException(
+				"policy id size greater than limit 20"));
+	}
+	
+	public void failConstruct(final String pid, final Exception e) {
+		try {
+			new PolicyID(pid);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+}

--- a/src/us/kbase/test/auth2/lib/ViewableUserTest.java
+++ b/src/us/kbase/test/auth2/lib/ViewableUserTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class ViewableUserTest {
 	@Test
 	public void constructWithoutEmail() throws Exception {
 		final AuthUser u = new NewUser(new UserName("foo"), new EmailAddress("e@f.com"),
-				new DisplayName("bar"), REMOTE, Instant.now(), null);
+				new DisplayName("bar"), REMOTE, Collections.emptySet(), Instant.now(), null);
 		
 		final ViewableUser vu = new ViewableUser(u, false);
 		assertThat("incorrect username", vu.getUserName(), is(new UserName("foo")));
@@ -48,7 +49,7 @@ public class ViewableUserTest {
 	@Test
 	public void constructWithEmail() throws Exception {
 		final AuthUser u = new NewUser(new UserName("foo"), new EmailAddress("e@f.com"),
-				new DisplayName("bar"), REMOTE, Instant.now(), null);
+				new DisplayName("bar"), REMOTE, Collections.emptySet(), Instant.now(), null);
 		
 		final ViewableUser vu = new ViewableUser(u, true);
 		assertThat("incorrect username", vu.getUserName(), is(new UserName("foo")));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageCustomRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageCustomRoleTest.java
@@ -18,6 +18,7 @@ import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -32,6 +33,8 @@ import us.kbase.test.auth2.TestCommon;
 public class MongoStorageCustomRoleTest extends MongoStorageTester {
 
 	private static final Instant NOW = Instant.now();
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
@@ -131,7 +134,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -150,7 +153,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -163,7 +166,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void removeRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -177,7 +180,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void removeNonExistentRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -191,7 +194,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveSameRole() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -204,7 +207,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void noop() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		
@@ -226,7 +229,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 		 * deleted.
 		 */
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -267,7 +270,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void updateFailNoSuchRole() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		failUpdateRoles(new UserName("foo"), set("foo"), set("bar"),
 				new NoSuchRoleException("bar"));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageDisableAccountTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageDisableAccountTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -15,6 +17,7 @@ import com.google.common.base.Optional;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -24,6 +27,8 @@ import us.kbase.auth2.lib.identity.RemoteIdentityWithLocalID;
 import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageDisableAccountTest extends MongoStorageTester {
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	private static final Instant NOW = Instant.now();
 
@@ -35,7 +40,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void disableAccountTwice() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),
@@ -106,7 +111,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void enableAccountTwice() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),
@@ -164,7 +169,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void disableEnableDisable() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -21,6 +21,7 @@ import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserSearchSpec;
@@ -33,6 +34,8 @@ import us.kbase.test.auth2.TestCommon;
 public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	
 	private static final Instant NOW = Instant.now();
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 
 	private static final RemoteIdentityWithLocalID REMOTE1 = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
@@ -57,11 +60,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromList() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE1, NOW, null));
+				new DisplayName("bar"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE2, NOW, null));
+				new DisplayName("whoo"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("bar"));
@@ -74,11 +77,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromEmptyList() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE1, NOW, null));
+				new DisplayName("bar"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE2, NOW, null));
+				new DisplayName("whoo"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		assertThat("incorrect users found", storage.getUserDisplayNames(
@@ -88,11 +91,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromListWithDisabledUsers() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE1, NOW, null));
+				new DisplayName("bar"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE2, NOW, null));
+				new DisplayName("whoo"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		when(mockClock.instant()).thenReturn(Instant.now());
 		
@@ -129,11 +132,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserName() throws Exception {
 		storage.createUser(new NewUser(new UserName("foow"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("whee"), new DisplayName("bar"));
@@ -147,11 +150,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchDisplayName() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("barw"), REMOTE2, NOW, null));
+				new DisplayName("barw"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -165,13 +168,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchBothNames() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -186,13 +189,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchBothNamesEmpty() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -206,13 +209,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchNoResults() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		
@@ -223,13 +226,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllResults() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -244,11 +247,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserRegex() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("baz"), REMOTE1, NOW, null));
+				new DisplayName("baz"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whoo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("baz"));
@@ -267,11 +270,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchWithRegexInPrefix() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("baz"), REMOTE1, NOW, null));
+				new DisplayName("baz"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whoo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		
@@ -283,13 +286,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserLimit() throws Exception {
 		storage.createUser(new NewUser(new UserName("wfoo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE2, NOW, null));
+				new DisplayName("bar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("wfoo"), new DisplayName("whoo"));
@@ -302,13 +305,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchDisplayLimit() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -322,13 +325,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("whee"), set(Role.ADMIN, Role.DEV_TOKEN),
 				Collections.emptySet());
@@ -351,13 +354,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchMultipleRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("whee"), set(Role.ADMIN, Role.DEV_TOKEN),
 				Collections.emptySet());
@@ -375,13 +378,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchCustomRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
 		storage.setCustomRole(new CustomRole("bat", "bleah"));
@@ -407,13 +410,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchMultipleCustomRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("thewrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
 		storage.setCustomRole(new CustomRole("bat", "bleah"));
@@ -500,13 +503,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllFields() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("whoo"), REMOTE1, NOW, null));
+				new DisplayName("whoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
 		storage.setCustomRole(new CustomRole("bat", "bleah"));
@@ -538,13 +541,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllFieldsWithLimit() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("fwhoo"), REMOTE1, NOW, null));
+				new DisplayName("fwhoo"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("whee"), new EmailAddress("f@g.com"),
-				new DisplayName("wbar"), REMOTE2, NOW, null));
+				new DisplayName("wbar"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wugga"), new EmailAddress("f@g.com"),
-				new DisplayName("wonk"), REMOTE3, NOW, null));
+				new DisplayName("wonk"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("wrock"), new EmailAddress("f@g.com"),
-				new DisplayName("smellywcooking"), REMOTE4, NOW, null));
+				new DisplayName("smellywcooking"), REMOTE4, MTPID, NOW, null));
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
 		storage.setCustomRole(new CustomRole("bat", "bleah"));
@@ -629,12 +632,12 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 
 	private void createUsersForCanonicalSearch() throws Exception {
 		storage.createUser(new NewUser(new UserName("u1"), new EmailAddress("f@g.com"),
-				new DisplayName("Douglas J Adams"), REMOTE1, NOW, null));
+				new DisplayName("Douglas J Adams"), REMOTE1, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("u2"), new EmailAddress("f@g.com"),
-				new DisplayName("Herbert Dougie Howser"), REMOTE2, NOW, null));
+				new DisplayName("Herbert Dougie Howser"), REMOTE2, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("u3"), new EmailAddress("f@g.com"),
-				new DisplayName("al douglas"), REMOTE3, NOW, null));
+				new DisplayName("al douglas"), REMOTE3, MTPID, NOW, null));
 		storage.createUser(new NewUser(new UserName("u4"), new EmailAddress("f@g.com"),
-				new DisplayName("Albert HevensyDouglas"), REMOTE4, NOW, null));
+				new DisplayName("Albert HevensyDouglas"), REMOTE4, MTPID, NOW, null));
 	}
 }

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStoragePasswordTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStoragePasswordTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.bson.Document;
@@ -19,6 +21,7 @@ import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.NewLocalUser;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.NoSuchLocalUserException;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -29,6 +32,8 @@ import us.kbase.auth2.lib.storage.mongo.Fields;
 import us.kbase.test.auth2.TestCommon;
 
 public class MongoStoragePasswordTest extends MongoStorageTester {
+	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
 	private static final Instant NOW = Instant.now();
 
@@ -42,7 +47,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(new NewLocalUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), NOW, passwordHash, salt, false));
+				new DisplayName("bar"), MTPID, NOW, passwordHash, salt, false));
 		storage.forcePasswordReset(new UserName("foo"));
 		
 		assertThat("expected forced password reset",
@@ -52,7 +57,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 	@Test
 	public void resetFailNoLocalUser() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		failReset(new UserName("foo"), new NoSuchLocalUserException("foo"));
 	}
 	
@@ -76,11 +81,11 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(new NewLocalUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), NOW, passwordHash, salt, false));
+				new DisplayName("bar"), MTPID, NOW, passwordHash, salt, false));
 		storage.createLocalUser(new NewLocalUser(new UserName("foo2"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), NOW, passwordHash, salt, false));
+				new DisplayName("bar"), MTPID, NOW, passwordHash, salt, false));
 		storage.createUser(new NewUser(new UserName("foo3"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.forcePasswordReset();
 		final Document stduser = db.getCollection("users")
@@ -97,7 +102,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(new NewLocalUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), NOW, passwordHash, salt, false));
+				new DisplayName("bar"), MTPID, NOW, passwordHash, salt, false));
 		final LocalUser user = storage.getLocalUser(new UserName("foo"));
 		assertThat("incorrect last reset date", user.getLastPwdReset(), is(Optional.absent()));
 		
@@ -122,7 +127,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(new NewLocalUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), NOW, passwordHash, salt, false));
+				new DisplayName("bar"), MTPID, NOW, passwordHash, salt, false));
 		final LocalUser user = storage.getLocalUser(new UserName("foo"));
 		assertThat("incorrect last reset date", user.getLastPwdReset(), is(Optional.absent()));
 		
@@ -174,7 +179,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 	@Test
 	public void changePasswordFailNoLocalUser() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		final byte[] pwd = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		failChangePassword(new UserName("foo"), pwd, salt, new NoSuchLocalUserException("foo"));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageRolesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageRolesTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -28,6 +29,8 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 
 	private static final Instant NOW = Instant.now();
 	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
+	
 	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
 			new RemoteIdentityID("prov", "bar1"),
@@ -36,7 +39,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN, Role.ADMIN), set(Role.SERV_TOKEN));
@@ -52,7 +55,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		storage.updateRoles(new UserName("foo"), set(Role.DEV_TOKEN, Role.ADMIN),
 				Collections.emptySet());
 		assertThat("incorrect roles", storage.getUser(new UserName("foo")).getRoles(),
@@ -62,7 +65,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void removeRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN), Collections.emptySet());
@@ -75,7 +78,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void removeNonExistentRoles() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("foo"), Collections.emptySet(),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN));
@@ -86,7 +89,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveSameRole() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN), set(Role.DEV_TOKEN));
@@ -97,7 +100,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void noop() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE, NOW, null));
+				new DisplayName("bar"), REMOTE, MTPID, NOW, null));
 		storage.updateRoles(new UserName("foo"), set(Role.DEV_TOKEN), Collections.emptySet());
 		
 		storage.updateRoles(new UserName("foo"), Collections.emptySet(), Collections.emptySet());

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
@@ -35,15 +35,20 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	
 	private static final Set<PolicyID> MTPID = Collections.emptySet();
 	
-	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
+	private static final RemoteIdentityWithLocalID REMOTE1 = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
 			new RemoteIdentityID("prov", "bar1"),
 			new RemoteIdentityDetails("user1", "full1", "email1"));
 	
+	private static final RemoteIdentityWithLocalID REMOTE2 = new RemoteIdentityWithLocalID(
+			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d9"),
+			new RemoteIdentityID("prov", "bar2"),
+			new RemoteIdentityDetails("user2", "full2", "email2"));
+	
 	@Test
 	public void updateNoop() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"), new UserUpdate());
 		final AuthUser au = storage.getUser(new UserName("user1"));
@@ -55,7 +60,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateDisplay() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withDisplayName(new DisplayName("whee")));
@@ -68,7 +73,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateEmail() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withEmail(new EmailAddress("foobar@baz.com")));
@@ -81,7 +86,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateBoth() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withEmail(new EmailAddress("foobar@baz.com"))
@@ -117,7 +122,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void lastLogin() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		final Instant d = NOW.plus(Duration.ofHours(2));
 		storage.setLastLogin(new UserName("user1"), d);
@@ -148,7 +153,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsEmpty() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.addPolicyIDs(new UserName("user1"), Collections.emptySet());
 		assertThat("incorrect policyIDs", storage.getUser(new UserName("user1")).getPolicyIDs(),
@@ -158,7 +163,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDs() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.addPolicyIDs(new UserName("user1"), set(new PolicyID("foo"), new PolicyID("bar")));
 		assertThat("incorrect policyIDs", storage.getUser(new UserName("user1")).getPolicyIDs(),
@@ -168,7 +173,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsOverwrite() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.addPolicyIDs(new UserName("user1"), set(new PolicyID("foo"), new PolicyID("bar")));
 		storage.addPolicyIDs(new UserName("user1"), set(new PolicyID("bar"), new PolicyID("baz")));
@@ -179,7 +184,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsOverwriteEmpty() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.addPolicyIDs(new UserName("user1"), set(new PolicyID("foo"), new PolicyID("bar")));
 		storage.addPolicyIDs(new UserName("user1"), Collections.emptySet());
@@ -210,6 +215,54 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void removePolicyID() throws Exception {
+		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
+				new DisplayName("bar1"), REMOTE1, set(new PolicyID("foo"), new PolicyID("bar")),
+				NOW, null);
+		storage.createUser(nu);
+		final NewUser nu2 = new NewUser(new UserName("user2"), new EmailAddress("e@g1.com"),
+				new DisplayName("bar1"), REMOTE2, set(new PolicyID("foo"), new PolicyID("baz")),
+				NOW, null);
+		storage.createUser(nu2);
+		
+		storage.removePolicyID(new PolicyID("foo"));
+
+		assertThat("incorrect policyIDs", storage.getUser(new UserName("user1")).getPolicyIDs(),
+				is(set(new PolicyID("bar"))));
+		assertThat("incorrect policyIDs", storage.getUser(new UserName("user2")).getPolicyIDs(),
+				is(set(new PolicyID("baz"))));
+	}
+	
+	@Test
+	public void removeUnusedPolicyID() throws Exception {
+		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
+				new DisplayName("bar1"), REMOTE1, set(new PolicyID("foo"), new PolicyID("bar")),
+				NOW, null);
+		storage.createUser(nu);
+		final NewUser nu2 = new NewUser(new UserName("user2"), new EmailAddress("e@g1.com"),
+				new DisplayName("bar1"), REMOTE2, set(new PolicyID("foo"), new PolicyID("baz")),
+				NOW, null);
+		storage.createUser(nu2);
+		
+		storage.removePolicyID(new PolicyID("bat"));
+
+		assertThat("incorrect policyIDs", storage.getUser(new UserName("user1")).getPolicyIDs(),
+				is(set(new PolicyID("bar"), new PolicyID("foo"))));
+		assertThat("incorrect policyIDs", storage.getUser(new UserName("user2")).getPolicyIDs(),
+				is(set(new PolicyID("baz"), new PolicyID("foo"))));
+	}
+	
+	@Test
+	public void failRemovePolicyID() throws Exception {
+		try {
+			storage.removePolicyID(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("policyID"));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.fail;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -16,6 +18,7 @@ import us.kbase.auth2.lib.AuthUser;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserUpdate;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -28,6 +31,8 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 
 	private static final Instant NOW = Instant.now();
 	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
+	
 	private static final RemoteIdentityWithLocalID REMOTE = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
 			new RemoteIdentityID("prov", "bar1"),
@@ -36,7 +41,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateNoop() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, NOW, null);
+				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"), new UserUpdate());
 		final AuthUser au = storage.getUser(new UserName("user1"));
@@ -48,7 +53,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateDisplay() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, NOW, null);
+				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withDisplayName(new DisplayName("whee")));
@@ -61,7 +66,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateEmail() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, NOW, null);
+				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withEmail(new EmailAddress("foobar@baz.com")));
@@ -74,7 +79,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateBoth() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, NOW, null);
+				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
 				new UserUpdate().withEmail(new EmailAddress("foobar@baz.com"))
@@ -110,7 +115,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void lastLogin() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE, NOW, null);
+				new DisplayName("bar1"), REMOTE, MTPID, NOW, null);
 		storage.createUser(nu);
 		final Instant d = NOW.plus(Duration.ofHours(2));
 		storage.setLastLogin(new UserName("user1"), d);

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 
 import org.junit.Test;
@@ -22,6 +23,7 @@ import us.kbase.auth2.lib.LocalUser;
 import us.kbase.auth2.lib.NewLocalUser;
 import us.kbase.auth2.lib.NewRootUser;
 import us.kbase.auth2.lib.NewUser;
+import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserDisabledState;
 import us.kbase.auth2.lib.UserName;
@@ -42,6 +44,8 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	
 	private static final Instant NOW = Instant.now();
 	
+	private static final Set<PolicyID> MTPID = Collections.emptySet();
+	
 	private static final RemoteIdentityWithLocalID REMOTE1 = new RemoteIdentityWithLocalID(
 			UUID.fromString("ec8a91d3-5923-4639-8d12-0891c56715d8"),
 			new RemoteIdentityID("prov", "bar1"),
@@ -58,7 +62,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
 		final NewLocalUser nlu = new NewLocalUser(
 				new UserName("local"), new EmailAddress("e@g.com"), new DisplayName("bar"),
-				NOW, pwd, salt, false);
+				set(new PolicyID("foo"), new PolicyID("bar")), NOW, pwd, salt, false);
 				
 		storage.createLocalUser(nlu);
 		
@@ -81,6 +85,8 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy ids", lu.getPolicyIDs(),
+				is(set(new PolicyID("bar"), new PolicyID("foo"))));
 		assertThat("incorrect last login", lu.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(Collections.emptySet()));
@@ -98,7 +104,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		final Instant create = Instant.now();
 		final NewLocalUser nlu = new NewLocalUser(
 				new UserName("baz"), EmailAddress.UNKNOWN, new DisplayName("bang"),
-				create, pwd, salt, true);
+				MTPID, create, pwd, salt, true);
 				
 		storage.createLocalUser(nlu);
 		
@@ -121,6 +127,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy ids", lu.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", lu.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(Collections.emptySet()));
@@ -160,6 +167,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", lu.getGrantableRoles(),
 				is(set(Role.CREATE_ADMIN)));
 		assertThat("incorrect identities", lu.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy ids", lu.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", lu.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", lu.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", lu.getRoles(), is(set(Role.ROOT)));
@@ -180,7 +188,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		final byte[] salt = "whoo".getBytes(StandardCharsets.UTF_8);
 		final NewLocalUser nlu = new NewLocalUser(
 				new UserName("baz"), new EmailAddress("f@g.com"), new DisplayName("bang"),
-				NOW, pwd, salt, true);
+				MTPID, NOW, pwd, salt, true);
 				
 		storage.createLocalUser(nlu);
 		
@@ -208,7 +216,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		final byte[] salt = "whoo".getBytes(StandardCharsets.UTF_8);
 		final NewLocalUser nlu = new NewLocalUser(
 				new UserName("baz"), new EmailAddress("f@g.com"), new DisplayName("bang"),
-				NOW, pwd, salt, true);
+				MTPID, NOW, pwd, salt, true);
 				
 		storage.createLocalUser(nlu);
 		failGetLocalUser(new UserName("bar"), new NoSuchUserException("bar"));
@@ -217,7 +225,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getStdUserAsLocal() throws Exception {
 		storage.createUser(new NewUser(new UserName("foo"), new EmailAddress("f@g.com"),
-				new DisplayName("bar"), REMOTE1, NOW, null));
+				new DisplayName("bar"), REMOTE1, MTPID, NOW, null));
 		failGetLocalUser(new UserName("foo"), new NoSuchLocalUserException("foo"));
 	}
 	
@@ -237,7 +245,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		final Instant create = Instant.ofEpochMilli(1000);
 		final NewLocalUser nlu = new NewLocalUser(
 				new UserName("baz"), new EmailAddress("f@g.com"), new DisplayName("bang"),
-				create, pwd, salt, true);
+				set(new PolicyID("baz")), create, pwd, salt, true);
 				
 		storage.createLocalUser(nlu);
 		
@@ -254,6 +262,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", u.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(Collections.emptySet()));
+		assertThat("incorrect policy ids", u.getPolicyIDs(), is(set(new PolicyID("baz"))));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -268,7 +277,8 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		// ensure last login is after creation date
 		final Instant ll = NOW.plusMillis(1000);
 		final NewUser nu = new NewUser(new UserName("user"), new EmailAddress("e@g.com"),
-				new DisplayName("bar"), REMOTE1, NOW, Optional.of(ll));
+				new DisplayName("bar"), REMOTE1, set(new PolicyID("foo"), new PolicyID("bar")),
+				NOW, Optional.of(ll));
 				
 		storage.createUser(nu);
 		
@@ -285,6 +295,8 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", u.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE1)));
+		assertThat("incorrect policy ids", u.getPolicyIDs(),
+				is(set(new PolicyID("bar"), new PolicyID("foo"))));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.of(ll)));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -298,7 +310,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	public void getStdUserNullLastLogin() throws Exception {
 		final Instant create = Instant.ofEpochMilli(6000);
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, create, null);
+				new DisplayName("bar1"), REMOTE1, null, create, null);
 				
 		storage.createUser(nu);
 		
@@ -315,6 +327,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect grantable roles", u.getGrantableRoles(),
 				is(Collections.emptySet()));
 		assertThat("incorrect identities", u.getIdentities(), is(set(REMOTE1)));
+		assertThat("incorrect policy ids", u.getPolicyIDs(), is(Collections.emptySet()));
 		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
 		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
 		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
@@ -332,7 +345,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getNoSuchUser() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 				
 		storage.createUser(nu);
 		failGetLocalUser(new UserName("user2"), new NoSuchUserException("user2"));
@@ -355,7 +368,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void createExistingUser() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 				
 		storage.createUser(nu);
 		
@@ -365,7 +378,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 				new RemoteIdentityDetails("user1", "full1", "email1"));
 		
 		final NewUser nu2 = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), ri, NOW, null);
+				new DisplayName("bar1"), ri, MTPID, NOW, null);
 		
 		failCreateUser(nu2, new UserExistsException("user1"));
 	}
@@ -373,7 +386,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void createUserWithExistingRemoteID() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 				
 		storage.createUser(nu);
 		
@@ -383,7 +396,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 				new RemoteIdentityDetails("user1", "full1", "email1"));
 		
 		final NewUser nu2 = new NewUser(new UserName("user2"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), ri, NOW, null);
+				new DisplayName("bar1"), ri, MTPID, NOW, null);
 		
 		failCreateUser(nu2, new IdentityLinkedException("prov : bar1"));
 	}
@@ -391,7 +404,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void createUserWithExistingIdentityLocalID() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 				
 		storage.createUser(nu);
 		
@@ -401,7 +414,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 				new RemoteIdentityDetails("user1", "full1", "email1"));
 		
 		final NewUser nu2 = new NewUser(new UserName("user2"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), ri, NOW, null);
+				new DisplayName("bar1"), ri, MTPID, NOW, null);
 		
 		failCreateUser(nu2, new IdentityLinkedException("prov2 : bar1"));
 	}
@@ -418,7 +431,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getUserByRemoteId() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		final AuthUser au = storage.getUser(REMOTE1).get();
 		assertThat("incorrect username", au.getUserName(), is(new UserName("user1")));
@@ -431,7 +444,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getUserByRemoteId2() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.link(new UserName("user1"), REMOTE2);
 		final AuthUser au = storage.getUser(REMOTE2).get();
@@ -445,7 +458,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getNonExistentUserByRemoteId() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		assertThat("incorrect user", storage.getUser(REMOTE2), is(Optional.absent()));
 	}
@@ -455,7 +468,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 	@Test
 	public void getUserAndUpdateRemoteId() throws Exception {
 		final NewUser nu = new NewUser(new UserName("user1"), new EmailAddress("e@g1.com"),
-				new DisplayName("bar1"), REMOTE1, NOW, null);
+				new DisplayName("bar1"), REMOTE1, MTPID, NOW, null);
 		storage.createUser(nu);
 		storage.link(new UserName("user1"), REMOTE2);
 		

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -83,8 +83,10 @@ provider, e.g. a choice of accounts is required.
 Select this option if a custom UI is setting its own login cookies but is not intercepting the 
 3rd party identity provider redirect. The server will then always
 redirect to the UI prior to logging in a user (but after processing the return from the identity
-provider), so the UI can then use JSON endpoints that don't
-set a cookie with a login token.
+provider), so the UI can then use JSON endpoints that don't set a cookie with a login token.</br>
+
+Also set this option if users must agree to policy documents prior to login and the IDs of the
+policy documents should be stored in the auth server.
 </p>
 <input type="reset" value="Reset"/>
 <input type="submit" value="Update"/>

--- a/templates/admingeneral.mustache
+++ b/templates/admingeneral.mustache
@@ -12,6 +12,11 @@
 	<input type="submit" value="Submit" />
 </form>
 
+<form action="{{policyurl}}" method="post">
+	Remove policy ID: <input type="text" name="policy_id" /><br/>
+	<input type="submit" value="Submit" />
+</form>
+
 <h3>Search for users</h3>
 <form action="{{searchurl}}" method="post">
 	User name or display name prefix: <input type="text" name="prefix" /><br/>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -15,6 +15,7 @@ Policy IDs: {{policy_ids}}<br/>
 {{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
+	Add policy IDs: <input type="text" name="policy_ids"/><br>
 	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="submit" value="Login"/>
 </form>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -11,6 +11,7 @@ accounts:</p>
 {{#login}}
 Username: {{username}} {{#disabled}}DISABLED{{/disabled}} {{#adminonly}}***Currently only admin accounts can log in***{{/adminonly}}<br/>
 Provider usernames: {{prov_usernames}}<br/>
+Policy IDs: {{policy_ids}}<br/>
 {{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
@@ -34,7 +35,8 @@ Email is only visible to you, software acting on your behalf, and system adminis
 <form action="{{createurl}}" method="post">
 	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
 	Display name: <input type="text" name="display" value="{{prov_fullname}}"/><br/>
-	Email: <input type="text" name="email" value="{{prov_email}}"/></br/>
+	Email: <input type="text" name="email" value="{{prov_email}}"/><br/>
+	Policy IDs: <input type="text" name="policy_ids"/><br>
 	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Create"/>


### PR DESCRIPTION
TODO:
* [x] store policy IDs on account creation and return on /login/choice page
* [x] add policy IDs to set on /login/pick
* [x] add admin function to remove a policy ID from all users

Local accounts will not support policy ID associations for now.