### PR TITLE
Create agent tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ username -> display name. At most 10,000 names are returned.
 GET /api/V2/token  
 Introspect a token.
 
+POST /api/V2/token  
+Create an agent token. Takes form or JSON encoded data with the key `tokenname`. Use the
+`Content-Type` header to specify input type.
+
 #### Legacy
 
 Endpoints (mostly) identical to the original Globus and KBase auth endpoints are provided for

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -703,7 +703,8 @@ public class Authentication {
 		} else {
 			life = c.getTokenLifetimeMS(TokenLifetimeType.DEV);
 		}
-		final NewToken nt = new NewToken(randGen.randomUUID(), TokenType.EXTENDED_LIFETIME,
+		final NewToken nt = new NewToken(randGen.randomUUID(),
+				serverToken ? TokenType.SERV : TokenType.DEV,
 				tokenName, randGen.getToken(), au.getUserName(), clock.instant(), life);
 		storage.storeToken(nt.getHashedToken());
 		return nt;

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -680,7 +680,6 @@ public class Authentication {
 	 * other than via logging in.
 	 * @return the new token.
 	 * @throws AuthStorageException if an error occurred accessing the storage system.
-	 * @throws MissingParameterException If the name is missing.
 	 * @throws InvalidTokenException if the provided token is not valid.
 	 * @throws UnauthorizedException if the provided token is not a login token or the user does
 	 * not have the role required to create the token type.
@@ -689,8 +688,7 @@ public class Authentication {
 			final IncomingToken token,
 			final TokenName tokenName,
 			final TokenType tokenType)
-			throws AuthStorageException, MissingParameterException,
-			InvalidTokenException, UnauthorizedException {
+			throws AuthStorageException, InvalidTokenException, UnauthorizedException {
 		nonNull(tokenName, "tokenName");
 		nonNull(tokenType, "tokenType");
 		if (TokenType.LOGIN.equals(tokenType)) {

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth2.cryptutils.PasswordCrypt;
 import us.kbase.auth2.cryptutils.RandomDataGenerator;
@@ -129,6 +130,12 @@ public class Authentication {
 			throw new RuntimeException("this should be impossible", e);
 		}
 	}
+	
+	private static final Map<TokenType, TokenLifetimeType> TOKEN_LIFE_TYPE = ImmutableMap.of(
+			TokenType.LOGIN, TokenLifetimeType.LOGIN,
+			TokenType.AGENT, TokenLifetimeType.AGENT,
+			TokenType.DEV, TokenLifetimeType.DEV,
+			TokenType.SERV, TokenLifetimeType.SERV);
 
 	private final AuthStorage storage;
 	// DO NOT modify this after construction, not thread safe
@@ -666,10 +673,11 @@ public class Authentication {
 		}
 	}
 
-	/** Create a new developer or service token.
+	/** Create a new agent, developer or service token.
 	 * @param token a token for the user that wishes to create a new token.
 	 * @param tokenName a name for the token.
-	 * @param serverToken whether the token should be a developer or server token.
+	 * @param tokenType the type of token to create. Note that login tokens may not be created
+	 * other than via logging in.
 	 * @return the new token.
 	 * @throws AuthStorageException if an error occurred accessing the storage system.
 	 * @throws MissingParameterException If the name is missing.
@@ -680,32 +688,33 @@ public class Authentication {
 	public NewToken createToken(
 			final IncomingToken token,
 			final TokenName tokenName,
-			final boolean serverToken)
+			final TokenType tokenType)
 			throws AuthStorageException, MissingParameterException,
 			InvalidTokenException, UnauthorizedException {
 		nonNull(tokenName, "tokenName");
+		nonNull(tokenType, "tokenType");
+		if (TokenType.LOGIN.equals(tokenType)) {
+			throw new IllegalArgumentException("Cannot create a login token without logging in");
+		}
 		final HashedToken t = getToken(token);
 		if (!t.getTokenType().equals(TokenType.LOGIN)) {
 			throw new UnauthorizedException(ErrorType.UNAUTHORIZED,
 					"Only login tokens may be used to create a token");
 		}
-		final AuthUser au = getUser(t);
-		final Role reqRole = serverToken ? Role.SERV_TOKEN : Role.DEV_TOKEN;
-		if (!reqRole.isSatisfiedBy(au.getRoles())) {
-			throw new UnauthorizedException(ErrorType.UNAUTHORIZED, String.format(
-					"User %s is not authorized to create this token type.",
-					au.getUserName().getName()));
+		final AuthUser au = getUser(t); // check for disabled user for AGENT tokens as well
+		if (!TokenType.AGENT.equals(tokenType)) {
+			final Role reqRole = TokenType.SERV.equals(tokenType) ?
+					Role.SERV_TOKEN : Role.DEV_TOKEN;
+			if (!reqRole.isSatisfiedBy(au.getRoles())) {
+				throw new UnauthorizedException(ErrorType.UNAUTHORIZED, String.format(
+						"User %s is not authorized to create this token type.",
+						au.getUserName().getName()));
+			}
 		}
-		final long life;
 		final AuthConfig c = cfg.getAppConfig();
-		if (serverToken) {
-			life = c.getTokenLifetimeMS(TokenLifetimeType.SERV);
-		} else {
-			life = c.getTokenLifetimeMS(TokenLifetimeType.DEV);
-		}
-		final NewToken nt = new NewToken(randGen.randomUUID(),
-				serverToken ? TokenType.SERV : TokenType.DEV,
-				tokenName, randGen.getToken(), au.getUserName(), clock.instant(), life);
+		final long life = c.getTokenLifetimeMS(TOKEN_LIFE_TYPE.get(tokenType));
+		final NewToken nt = new NewToken(randGen.randomUUID(), tokenType,
+				tokenName, randGen.getToken(), t.getUserName(), clock.instant(), life);
 		storage.storeToken(nt.getHashedToken());
 		return nt;
 	}

--- a/src/us/kbase/auth2/lib/config/AuthConfig.java
+++ b/src/us/kbase/auth2/lib/config/AuthConfig.java
@@ -34,6 +34,7 @@ public class AuthConfig {
 	static {
 		final Map<TokenLifetimeType, Long> m = new HashMap<>();
 		m.put(TokenLifetimeType.EXT_CACHE,			   5 * 60 * 1000L);
+		m.put(TokenLifetimeType.AGENT,		 7 * 24 * 60 * 60 * 1000L);
 		m.put(TokenLifetimeType.LOGIN,		14 * 24 * 60 * 60 * 1000L);
 		m.put(TokenLifetimeType.DEV,		90 * 24 * 60 * 60 * 1000L);
 		// this is set so absurdly low because some other, lesser languages can't represent
@@ -50,6 +51,8 @@ public class AuthConfig {
 		
 		/** Lifetime type for a login token. */
 		LOGIN,
+		/** Lifetime type for an agent token. */
+		AGENT,
 		/** Lifetime type for a developer token. */
 		DEV,
 		/** Lifetime type for a server token. */

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -181,6 +181,8 @@ public class Fields {
 	public static final String CONFIG_APP_TOKEN_LIFE_CACHE = "tokenlifecache";
 	/** The lifetime of a login token. */
 	public static final String CONFIG_APP_TOKEN_LIFE_LOGIN = "tokenlifelogin";
+	/** The lifetime of an agent token. */
+	public static final String CONFIG_APP_TOKEN_LIFE_AGENT = "tokenlifeagent";
 	/** The lifetime of a developer token. */
 	public static final String CONFIG_APP_TOKEN_LIFE_DEV = "tokenlifedev";
 	/** The lifetime of a server token. */

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -125,6 +125,7 @@ public class MongoStorage implements AuthStorage {
 		final Map<TokenLifetimeType, String> m = new HashMap<>();
 		m.put(TokenLifetimeType.EXT_CACHE, Fields.CONFIG_APP_TOKEN_LIFE_CACHE);
 		m.put(TokenLifetimeType.LOGIN, Fields.CONFIG_APP_TOKEN_LIFE_LOGIN);
+		m.put(TokenLifetimeType.AGENT, Fields.CONFIG_APP_TOKEN_LIFE_AGENT);
 		m.put(TokenLifetimeType.DEV, Fields.CONFIG_APP_TOKEN_LIFE_DEV);
 		m.put(TokenLifetimeType.SERV, Fields.CONFIG_APP_TOKEN_LIFE_SERV);
 		TOKEN_LIFETIME_FIELD_MAP = Collections.unmodifiableMap(m);

--- a/src/us/kbase/auth2/lib/token/TokenType.java
+++ b/src/us/kbase/auth2/lib/token/TokenType.java
@@ -3,8 +3,7 @@ package us.kbase.auth2.lib.token;
 import java.util.HashMap;
 import java.util.Map;
 
-/** An enumeration representing the type of the token, either a standard login token or an 
- * extended lifetime token.
+/** An enumeration representing the type of a token.
  * 
  * @author gaprice@lbl.gov
  *
@@ -16,8 +15,12 @@ public enum TokenType {
 	 */
 	/** A standard login token. */
 	LOGIN				("Login", "Login"),
-	/** An extended lifetype token. */
-	EXTENDED_LIFETIME	("ExtLife", "Extended lifetime");
+	/** An agent token. */
+	AGENT				("Agent", "Agent"),
+	/** A developer token. */
+	DEV					("Dev", "Developer"),
+	/** A service token. */
+	SERV	("Serv", "Service");
 	
 	private static final Map<String, TokenType> TYPE_MAP = new HashMap<>();
 	static {

--- a/src/us/kbase/auth2/service/api/Token.java
+++ b/src/us/kbase/auth2/service/api/Token.java
@@ -6,17 +6,30 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.TokenName;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.HashedToken;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.auth2.service.common.IncomingJSON;
+import us.kbase.auth2.service.ui.UINewToken;
 
 @Path(APIPaths.API_V2_TOKEN)
 public class Token {
@@ -42,5 +55,42 @@ public class Token {
 		ret.put("name", ht.getTokenName().isPresent() ? ht.getTokenName().get().getName() : null);
 		ret.put("id", ht.getId().toString());
 		return ret;
+	}
+	
+	@POST
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+	@Produces(MediaType.APPLICATION_JSON)
+	public UINewToken createAgentTokenForm(
+			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
+			@FormParam("tokenname") final String name)
+			throws InvalidTokenException, MissingParameterException, UnauthorizedException,
+			NoTokenProvidedException, IllegalParameterException, AuthStorageException {
+		
+		//TODO NOW move ui token into common area
+		return new UINewToken(auth.createToken(
+				getToken(token), new TokenName(name), TokenType.AGENT));
+	}
+	
+	private static class CreateToken extends IncomingJSON {
+		
+		public final String tokenname;
+
+		@JsonCreator
+		public CreateToken(@JsonProperty("tokenname") final String name) {
+			this.tokenname = name;
+		}
+	}
+	
+	@POST
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	public UINewToken createAgentTokenJSON(
+			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
+			final CreateToken create)
+			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
+			MissingParameterException, IllegalParameterException, AuthStorageException {
+		create.exceptOnAdditionalProperties();
+		return new UINewToken(auth.createToken(
+				getToken(token), new TokenName(create.tokenname), TokenType.AGENT));
 	}
 }

--- a/src/us/kbase/auth2/service/api/Token.java
+++ b/src/us/kbase/auth2/service/api/Token.java
@@ -29,7 +29,7 @@ import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.service.common.IncomingJSON;
-import us.kbase.auth2.service.ui.UINewToken;
+import us.kbase.auth2.service.common.NewExternalToken;
 
 @Path(APIPaths.API_V2_TOKEN)
 public class Token {
@@ -60,14 +60,14 @@ public class Token {
 	@POST
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces(MediaType.APPLICATION_JSON)
-	public UINewToken createAgentTokenForm(
+	public NewExternalToken createAgentTokenForm(
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
 			@FormParam("tokenname") final String name)
 			throws InvalidTokenException, MissingParameterException, UnauthorizedException,
 			NoTokenProvidedException, IllegalParameterException, AuthStorageException {
 		
 		//TODO NOW move ui token into common area
-		return new UINewToken(auth.createToken(
+		return new NewExternalToken(auth.createToken(
 				getToken(token), new TokenName(name), TokenType.AGENT));
 	}
 	
@@ -84,13 +84,13 @@ public class Token {
 	@POST
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public UINewToken createAgentTokenJSON(
+	public NewExternalToken createAgentTokenJSON(
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
 			final CreateToken create)
 			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
 			MissingParameterException, IllegalParameterException, AuthStorageException {
 		create.exceptOnAdditionalProperties();
-		return new UINewToken(auth.createToken(
+		return new NewExternalToken(auth.createToken(
 				getToken(token), new TokenName(create.tokenname), TokenType.AGENT));
 	}
 }

--- a/src/us/kbase/auth2/service/common/ExternalToken.java
+++ b/src/us/kbase/auth2/service/common/ExternalToken.java
@@ -1,4 +1,4 @@
-package us.kbase.auth2.service.ui;
+package us.kbase.auth2.service.common;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -10,7 +10,7 @@ import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.token.HashedToken;
 import us.kbase.auth2.lib.token.TokenType;
 
-public class UIToken {
+public class ExternalToken {
 	
 	//TODO TEST
 	//TODO JAVADOC
@@ -22,13 +22,13 @@ public class UIToken {
 	private final String name;
 	private final String user;
 
-	public UIToken(final HashedToken token) {
+	public ExternalToken(final HashedToken token) {
 		this(token.getTokenType(), token.getTokenName(), token.getId(),
 				token.getUserName(),
 				token.getCreationDate(), token.getExpirationDate());
 	}
 
-	UIToken(
+	ExternalToken(
 			final TokenType type,
 			final Optional<TokenName> tokenName,
 			final UUID id,

--- a/src/us/kbase/auth2/service/common/NewExternalToken.java
+++ b/src/us/kbase/auth2/service/common/NewExternalToken.java
@@ -1,15 +1,15 @@
-package us.kbase.auth2.service.ui;
+package us.kbase.auth2.service.common;
 
 import us.kbase.auth2.lib.token.NewToken;
 
-public class UINewToken extends UIToken {
+public class NewExternalToken extends ExternalToken {
 
 	private final String token;
 	
 	//TODO TEST
 	//TODO JAVADOC
 	
-	public UINewToken(final NewToken token) {
+	public NewExternalToken(final NewToken token) {
 		super(token.getTokenType(), token.getTokenName(), token.getId(),
 				token.getUserName(),
 				token.getCreationDate(), token.getExpirationDate());

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -71,6 +71,7 @@ import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
+import us.kbase.auth2.service.common.ExternalToken;
 
 @Path(UIPaths.ADMIN_ROOT)
 public class Admin {
@@ -140,7 +141,7 @@ public class Admin {
 		}
 		final HashedToken ht = auth.getToken(t);
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("token", new UIToken(ht));
+		ret.put("token", new ExternalToken(ht));
 		ret.put("revokeurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_USER + SEP +
 				ht.getUserName().getName() + SEP + UIPaths.ADMIN_TOKENS + SEP +
 				UIPaths.ADMIN_USER_TOKENS_REVOKE + SEP + ht.getId().toString()));
@@ -314,8 +315,8 @@ public class Admin {
 		
 		final Set<HashedToken> tokens = auth.getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()), new UserName(user));
-		final List<UIToken> uitokens = tokens.stream()
-				.map(t -> new UIToken(t)).collect(Collectors.toList());
+		final List<ExternalToken> uitokens = tokens.stream()
+				.map(t -> new ExternalToken(t)).collect(Collectors.toList());
 		final String urlPrefix = UIPaths.ADMIN_ROOT_USER + SEP + user + SEP +
 				UIPaths.ADMIN_TOKENS + SEP;
 		final Map<String, Object> ret = new HashMap<>();

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -558,6 +558,8 @@ public class Admin {
 				TokenLifetimeType.EXT_CACHE) / MIN_IN_MS);
 		ret.put("tokenlogin", cfgset.getCfg().getTokenLifetimeMS(
 				TokenLifetimeType.LOGIN) / DAY_IN_MS);
+		ret.put("tokenagent", cfgset.getCfg().getTokenLifetimeMS(
+				TokenLifetimeType.AGENT) / DAY_IN_MS);
 		ret.put("tokendev", cfgset.getCfg().getTokenLifetimeMS(
 				TokenLifetimeType.DEV) / DAY_IN_MS);
 		ret.put("tokenserv", cfgset.getCfg().getTokenLifetimeMS(
@@ -646,6 +648,7 @@ public class Admin {
 			@Context final HttpHeaders headers,
 			@FormParam("tokensugcache") final int sugcache,
 			@FormParam("tokenlogin") final int login,
+			@FormParam("tokenagent") final int agent,
 			@FormParam("tokendev") final int dev,
 			@FormParam("tokenserv") final long serv)
 			throws IllegalParameterException, InvalidTokenException,
@@ -659,6 +662,10 @@ public class Admin {
 			throw new IllegalParameterException(
 					"Login token expiration time must be at least 1");
 		}
+		if (agent < 1) {
+			throw new IllegalParameterException(
+					"Agent token expiration time must be at least 1");
+		}
 		if (dev < 1) {
 			throw new IllegalParameterException(
 					"Developer token expiration time must be at least 1");
@@ -670,6 +677,7 @@ public class Admin {
 		final Map<TokenLifetimeType, Long> t = new HashMap<>();
 		t.put(TokenLifetimeType.EXT_CACHE, safeMult(sugcache, MIN_IN_MS));
 		t.put(TokenLifetimeType.LOGIN, safeMult(login, DAY_IN_MS));
+		t.put(TokenLifetimeType.AGENT, safeMult(agent, DAY_IN_MS));
 		t.put(TokenLifetimeType.DEV, safeMult(dev, DAY_IN_MS));
 		t.put(TokenLifetimeType.SERV, safeMult(serv, DAY_IN_MS));
 		try {

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -72,6 +72,7 @@ import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
 import us.kbase.auth2.service.common.IdentityProviderInput;
 import us.kbase.auth2.service.common.IncomingJSON;
+import us.kbase.auth2.service.common.NewExternalToken;
 
 @Path(UIPaths.LOGIN_ROOT)
 public class Login {
@@ -240,7 +241,7 @@ public class Login {
 		final LoginToken lr = auth.login(provider, input.getAuthCode());
 		final Map<String, Object> choice = buildLoginChoice(uriInfo, lr.getLoginState(), redirect);
 		if (lr.isLoggedIn()) {
-			choice.put("token", new UINewToken(lr.getToken()));
+			choice.put("token", new NewExternalToken(lr.getToken()));
 			choice.put("logged_in", true);
 			choice.put("redirect", getRedirectURL(redirect));
 			final ResponseBuilder b = Response.ok(choice);
@@ -288,7 +289,7 @@ public class Login {
 		
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put(REDIRECT_URL, getRedirectURL(redirect));
-		ret.put("token", new UINewToken(newtoken));
+		ret.put("token", new NewExternalToken(newtoken));
 		return removeLoginProcessCookies(Response.status(status)).entity(ret).build();
 	}
 	

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -45,6 +45,7 @@ import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.lib.token.TokenSet;
+import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.common.IncomingJSON;
@@ -182,7 +183,7 @@ public class Tokens {
 			NoTokenProvidedException, InvalidTokenException,
 			UnauthorizedException, IllegalParameterException {
 		return new UINewToken(auth.createToken(userToken, new TokenName(tokenName),
-				"server".equals(tokenType)));
+				"server".equals(tokenType) ? TokenType.SERV : TokenType.DEV));
 	}
 
 	private Map<String, Object> getTokens(final IncomingToken token)

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -48,7 +48,9 @@ import us.kbase.auth2.lib.token.TokenSet;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
+import us.kbase.auth2.service.common.ExternalToken;
 import us.kbase.auth2.service.common.IncomingJSON;
+import us.kbase.auth2.service.common.NewExternalToken;
 
 @Path(UIPaths.TOKENS_ROOT)
 public class Tokens {
@@ -72,7 +74,7 @@ public class Tokens {
 			NoTokenProvidedException, DisabledUserException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		t.put("user", ((UIToken) t.get("current")).getUser());
+		t.put("user", ((ExternalToken) t.get("current")).getUser());
 		t.put("createurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
 		t.put("revokeurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
 				UIPaths.SEP));
@@ -94,7 +96,7 @@ public class Tokens {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces(MediaType.TEXT_HTML)
 	@Template(name = "/tokencreate")
-	public UINewToken createTokenHTML(
+	public NewExternalToken createTokenHTML(
 			@Context final HttpHeaders headers,
 			@FormParam("tokenname") final String tokenName,
 			@FormParam("tokentype") final String tokenType)
@@ -124,7 +126,7 @@ public class Tokens {
 	@Path(UIPaths.TOKENS_CREATE)
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public UINewToken createTokenJSON(
+	public NewExternalToken createTokenJSON(
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
 			final CreateTokenParams input)
 			throws AuthStorageException, MissingParameterException,
@@ -175,14 +177,14 @@ public class Tokens {
 	}
 			
 
-	private UINewToken createtoken(
+	private NewExternalToken createtoken(
 			final String tokenName,
 			final String tokenType,
 			final IncomingToken userToken)
 			throws AuthStorageException, MissingParameterException,
 			NoTokenProvidedException, InvalidTokenException,
 			UnauthorizedException, IllegalParameterException {
-		return new UINewToken(auth.createToken(userToken, new TokenName(tokenName),
+		return new NewExternalToken(auth.createToken(userToken, new TokenName(tokenName),
 				"server".equals(tokenType) ? TokenType.SERV : TokenType.DEV));
 	}
 
@@ -192,10 +194,10 @@ public class Tokens {
 		final AuthUser au = auth.getUser(token);
 		final TokenSet ts = auth.getTokens(token);
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("current", new UIToken(ts.getCurrentToken()));
+		ret.put("current", new ExternalToken(ts.getCurrentToken()));
 		
-		final List<UIToken> ats = ts.getTokens().stream()
-				.map(t -> new UIToken(t)).collect(Collectors.toList());
+		final List<ExternalToken> ats = ts.getTokens().stream()
+				.map(t -> new ExternalToken(t)).collect(Collectors.toList());
 		ret.put("tokens", ats);
 		ret.put("dev", Role.DEV_TOKEN.isSatisfiedBy(au.getRoles()));
 		ret.put("serv", Role.SERV_TOKEN.isSatisfiedBy(au.getRoles()));

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -968,13 +968,33 @@ public class AuthenticationTokenTest {
 	}
 	
 	@Test
+	public void createAgentToken() throws Exception {
+		final AuthUser user = AuthUser.getBuilder(
+				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				.build();
+		
+		createToken(user, new HashMap<>(), 7 * 24 * 3600 * 1000L, TokenType.AGENT);
+	}
+	
+	@Test
+	public void createAgentTokenWithAltLifeTime() throws Exception {
+		final AuthUser user = AuthUser.getBuilder(
+				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				.build();
+		
+		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
+		lifetimes.put(TokenLifetimeType.AGENT, 3 * 24 * 3600 * 1000L);
+		createToken(user, lifetimes, 3 * 24 * 3600 * 1000L, TokenType.AGENT);
+	}
+	
+	@Test
 	public void createDevToken() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
 				new UserName("foo"), new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@g.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
-		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, false);
+		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, TokenType.DEV);
 	}
 	
 	@Test
@@ -986,7 +1006,7 @@ public class AuthenticationTokenTest {
 		
 		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
 		lifetimes.put(TokenLifetimeType.DEV, 42 * 24 * 3600 * 1000L);
-		createToken(user, lifetimes, 42 * 24 * 3600 * 1000L, false);
+		createToken(user, lifetimes, 42 * 24 * 3600 * 1000L, TokenType.DEV);
 	}
 	
 	@Test
@@ -996,7 +1016,7 @@ public class AuthenticationTokenTest {
 				.withEmailAddress(new EmailAddress("f@g.com"))
 				.withRole(Role.SERV_TOKEN).build();
 		
-		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, false);
+		createToken(user, new HashMap<>(), 90 * 24 * 3600 * 1000L, TokenType.DEV);
 	}
 	
 	@Test
@@ -1006,7 +1026,7 @@ public class AuthenticationTokenTest {
 				.withEmailAddress(new EmailAddress("f@g.com"))
 				.withRole(Role.SERV_TOKEN).build();
 		
-		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, true);
+		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, TokenType.SERV);
 	}
 	
 	@Test
@@ -1016,7 +1036,7 @@ public class AuthenticationTokenTest {
 				.withEmailAddress(new EmailAddress("f@g.com"))
 				.withRole(Role.ADMIN).build();
 		
-		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, true);
+		createToken(user, new HashMap<>(), 100_000_000L * 24 * 3600 * 1000L, TokenType.SERV);
 	}
 	
 	@Test
@@ -1028,7 +1048,7 @@ public class AuthenticationTokenTest {
 		
 		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
 		lifetimes.put(TokenLifetimeType.SERV, 24 * 24 * 3600 * 1000L);
-		createToken(user, lifetimes, 24 * 24 * 3600 * 1000L, true);
+		createToken(user, lifetimes, 24 * 24 * 3600 * 1000L, TokenType.SERV);
 	}
 	
 	@Test
@@ -1040,7 +1060,7 @@ public class AuthenticationTokenTest {
 				.withUserDisabledState(
 						new UserDisabledState("foo", new UserName("baz"), Instant.now())).build();
 		
-		failCreateToken(user, false, new DisabledUserException());
+		failCreateToken(user, TokenType.AGENT, new DisabledUserException());
 	}
 	
 	@Test
@@ -1050,7 +1070,7 @@ public class AuthenticationTokenTest {
 				.withEmailAddress(new EmailAddress("f@g.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
-		failCreateToken(user, false, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+		failCreateToken(user, TokenType.DEV, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"User foo is not authorized to create this token type."));
 	}
 	
@@ -1062,7 +1082,7 @@ public class AuthenticationTokenTest {
 				.withRole(Role.DEV_TOKEN)
 				.withRole(Role.CREATE_ADMIN).build();
 		
-		failCreateToken(user, true, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+		failCreateToken(user, TokenType.SERV, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"User foo is not authorized to create this token type."));
 	}
 	
@@ -1070,10 +1090,20 @@ public class AuthenticationTokenTest {
 	public void createTokenFailNulls() throws Exception {
 		final Authentication auth = initTestMocks().auth;
 		
-		failCreateToken(auth, null, new TokenName("foo"), false,
+		failCreateToken(auth, null, new TokenName("foo"), TokenType.DEV,
 				new NullPointerException("token"));
-		failCreateToken(auth, new IncomingToken("foo"), null, false,
+		failCreateToken(auth, new IncomingToken("foo"), null, TokenType.DEV,
 				new NullPointerException("tokenName"));
+		failCreateToken(auth, new IncomingToken("foo"), new TokenName("bar"), null,
+				new NullPointerException("tokenType"));
+	}
+	
+	@Test
+	public void createTokenFailCreateLogin() throws Exception {
+		final Authentication auth = initTestMocks().auth;
+		failCreateToken(auth, new IncomingToken("foo"), new TokenName("bar"), TokenType.LOGIN,
+				new IllegalArgumentException(
+						"Cannot create a login token without logging in"));
 	}
 	
 	@Test
@@ -1086,9 +1116,14 @@ public class AuthenticationTokenTest {
 		
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
-		failCreateToken(auth, t, new TokenName("foo"), false, new InvalidTokenException());
+		failCreateToken(auth, t, new TokenName("foo"), TokenType.DEV, new InvalidTokenException());
 	}
 	
+	@Test
+	public void createTokenFailWithAgentToken() throws Exception {
+		createTokenFailWithNonLoginToken(TokenType.AGENT);
+	}
+
 	@Test
 	public void createTokenFailWithDevToken() throws Exception {
 		createTokenFailWithNonLoginToken(TokenType.DEV);
@@ -1110,7 +1145,7 @@ public class AuthenticationTokenTest {
 		
 		when(storage.getToken(t.getHashedToken())).thenReturn(ht, (HashedToken) null);
 		
-		failCreateToken(auth, t, new TokenName("foo"), false,
+		failCreateToken(auth, t, new TokenName("foo"), TokenType.DEV,
 				new UnauthorizedException(ErrorType.UNAUTHORIZED,
 						"Only login tokens may be used to create a token"));
 	}
@@ -1129,7 +1164,7 @@ public class AuthenticationTokenTest {
 		
 		when(storage.getUser(new UserName("foo"))).thenThrow(new NoSuchUserException("foo"));
 		
-		failCreateToken(auth, t, new TokenName("baz"), false, new RuntimeException(
+		failCreateToken(auth, t, new TokenName("baz"), TokenType.AGENT, new RuntimeException(
 				"There seems to be an error in the storage system. Token was valid, but no user"));
 	}
 	
@@ -1137,8 +1172,7 @@ public class AuthenticationTokenTest {
 			final AuthUser user,
 			final Map<TokenLifetimeType, Long> lifetimes,
 			final long expectedLifetime,
-			final boolean serverToken) throws Exception {
-		final TokenType tokenType = serverToken ? TokenType.SERV : TokenType.DEV;
+			final TokenType tokenType) throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
 		final Authentication auth = testauth.auth;
@@ -1166,21 +1200,20 @@ public class AuthenticationTokenTest {
 		when(clock.instant()).thenReturn(time, (Instant) null);
 		
 		try {
-			final NewToken nt = auth.createToken(t, new TokenName("a name"), serverToken);
+			final NewToken nt = auth.createToken(t, new TokenName("a name"), tokenType);
 			
 			final Instant expiration = Instant.ofEpochMilli(time.toEpochMilli() +
 					(expectedLifetime));
 			verify(storage).storeToken(new HashedToken(id, tokenType,
 					Optional.of(new TokenName("a name")),
 					"p40z9I2zpElkQqSkhbW6KG3jSgMRFr3ummqjSe7OzOc=", user.getUserName(),
-					time,
-					expiration));
+					time, expiration));
 			
 			final NewToken expected = new NewToken(id, tokenType,
 					new TokenName("a name"), "this is a token", user.getUserName(), time,
 					expectedLifetime);
 			
-		assertThat("incorrect token", nt, is(expected));
+			assertThat("incorrect token", nt, is(expected));
 		} catch (Throwable th) {
 			if (user.isDisabled()) {
 				verify(storage).deleteTokens(user.getUserName());
@@ -1191,10 +1224,10 @@ public class AuthenticationTokenTest {
 	
 	private void failCreateToken(
 			final AuthUser user,
-			final boolean serverToken,
+			final TokenType tokenType,
 			final Exception e) {
 		try {
-			createToken(user, new HashMap<>(), 3L, serverToken);
+			createToken(user, new HashMap<>(), 3L, tokenType);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
@@ -1205,10 +1238,10 @@ public class AuthenticationTokenTest {
 			final Authentication auth,
 			final IncomingToken t,
 			final TokenName name,
-			final boolean serverToken,
+			final TokenType tokenType,
 			final Exception e) {
 		try {
-			auth.createToken(t, name, serverToken);
+			auth.createToken(t, name, tokenType);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/lib/LoginTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginTokenTest.java
@@ -48,11 +48,11 @@ public class LoginTokenTest {
 	@Test
 	public void constructorNewToken() throws Exception {
 		final NewToken nt = new NewToken(UUID.randomUUID(),
-				TokenType.EXTENDED_LIFETIME, "foo", new UserName("bar"), Instant.now(), 10000);
+				TokenType.LOGIN, "foo", new UserName("bar"), Instant.now(), 10000);
 		final LoginToken lt = new LoginToken(nt, LOGIN_STATE);
 		assertThat("incorrect isLoggedIn", lt.isLoggedIn(), is(true));
 		assertThat("incorrect token type", lt.getToken().getTokenType(),
-				is(TokenType.EXTENDED_LIFETIME));
+				is(TokenType.LOGIN));
 		assertThat("incorrect creation date", lt.getToken().getCreationDate(),
 				is(nt.getCreationDate()));
 		assertThat("incorrect expiration date", lt.getToken().getExpirationDate(),
@@ -87,7 +87,7 @@ public class LoginTokenTest {
 	@Test
 	public void constructFail() throws Exception {
 		final NewToken nt = new NewToken(UUID.randomUUID(), 
-				TokenType.EXTENDED_LIFETIME, "foo", new UserName("bar"), Instant.now(), 10000);
+				TokenType.LOGIN, "foo", new UserName("bar"), Instant.now(), 10000);
 		failConstructToken((NewToken) null, LOGIN_STATE, new NullPointerException("token"));
 		failConstructToken(nt, null, new NullPointerException("loginState"));
 		

--- a/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
@@ -33,6 +33,7 @@ public class AuthConfigTest {
 		assertThat("incorrect provider force link default",
 				AuthConfig.DEFAULT_PROVIDER_CONFIG.isForceLinkChoice(), is(false));
 		final Map<TokenLifetimeType, Long> defaultLifeTimes = new HashMap<>();
+		defaultLifeTimes.put(TokenLifetimeType.AGENT, 7 * 24 * 60 * 60 * 1000L);
 		defaultLifeTimes.put(TokenLifetimeType.LOGIN, 14 * 24 * 60 * 60 * 1000L);
 		defaultLifeTimes.put(TokenLifetimeType.DEV, 90 * 24 * 60 * 60 * 1000L);
 		defaultLifeTimes.put(TokenLifetimeType.SERV, 100_000_000L * 24 * 60 * 60 * 1000L);
@@ -102,6 +103,8 @@ public class AuthConfigTest {
 				ac.getProviderConfig("pc2").isForceLinkChoice(), is((Boolean) null));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.EXT_CACHE),
 				is(5 * 60 * 1000L));
+		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.AGENT),
+				is(7 * 24 * 60 * 60 * 1000L));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.LOGIN),
 				is(70000000L));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.DEV),
@@ -133,6 +136,8 @@ public class AuthConfigTest {
 		assertThat("incorrect lifetimes", ac.getTokenLifetimeMS(), is(ltscopy));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.EXT_CACHE),
 				is(5 * 60 * 1000L));
+		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.AGENT),
+				is(7 * 24 * 60 * 60 * 1000L));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.LOGIN),
 				is(14 * 24 * 60 * 60 * 1000L));
 		assertThat("incorrect token lifetime", ac.getTokenLifetimeMS(TokenLifetimeType.DEV),

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
@@ -31,6 +31,32 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 	}
 	
 	@Test
+	public void updateConfigAndGetWithAllTokenLifeTimes() throws Exception {
+		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+				new AuthConfig(true, null,
+						ImmutableMap.of(
+								TokenLifetimeType.EXT_CACHE, 100000L,
+								TokenLifetimeType.LOGIN, 200000L,
+								TokenLifetimeType.AGENT, 300000L,
+								TokenLifetimeType.DEV, 400000L,
+								TokenLifetimeType.SERV, 500000L)),
+				new TestExternalConfig("foo"));
+		storage.updateConfig(cfgSet, false);
+		
+		final AuthConfig expected = new AuthConfig(true, null,
+				ImmutableMap.of(
+						TokenLifetimeType.EXT_CACHE, 100000L,
+						TokenLifetimeType.LOGIN, 200000L,
+						TokenLifetimeType.AGENT, 300000L,
+						TokenLifetimeType.DEV, 400000L,
+						TokenLifetimeType.SERV, 500000L));
+		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+				new TestExternalConfigMapper());
+		assertThat("incorrect config", res.getCfg(), is(expected));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo"));
+	}
+	
+	@Test
 	public void updateConfigAndGet() throws Exception {
 		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTokensTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTokensTest.java
@@ -60,7 +60,7 @@ public class MongoStorageTokensTest extends MongoStorageTester {
 		storage.storeToken(ht);
 		final Instant now = Instant.now();
 		failStoreToken(new HashedToken(ht.getId(),
-				TokenType.EXTENDED_LIFETIME,
+				TokenType.DEV,
 				Optional.of(new TokenName("bleah")), "somehash", new UserName("baz"), now, now.plusMillis(10000)),
 				new IllegalArgumentException(String.format(
 						"Token ID %s already exists in the database", ht.getId())));
@@ -75,7 +75,7 @@ public class MongoStorageTokensTest extends MongoStorageTester {
 		final Instant now = Instant.now();
 		final UUID id = UUID.randomUUID();
 		failStoreToken(new HashedToken(id,
-				TokenType.EXTENDED_LIFETIME, Optional.of(new TokenName("bleah")),
+				TokenType.SERV, Optional.of(new TokenName("bleah")),
 				ht.getTokenHash(), new UserName("baz"), now, now.plusMillis(10000)),
 				new IllegalArgumentException(String.format(
 						"Token hash for token ID %s already exists in the database", id)));

--- a/src/us/kbase/test/auth2/lib/token/TokenTest.java
+++ b/src/us/kbase/test/auth2/lib/token/TokenTest.java
@@ -62,8 +62,12 @@ public class TokenTest {
 	public void tokenTypeGetType() throws Exception {
 		assertThat("failed to get login token type", TokenType.getType("Login"),
 				is(TokenType.LOGIN));
-		assertThat("failed to get login token type", TokenType.getType("ExtLife"),
-				is(TokenType.EXTENDED_LIFETIME));
+		assertThat("failed to get agent token type", TokenType.getType("Agent"),
+				is(TokenType.AGENT));
+		assertThat("failed to get developer token type", TokenType.getType("Dev"),
+				is(TokenType.DEV));
+		assertThat("failed to get service token type", TokenType.getType("Serv"),
+				is(TokenType.SERV));
 		try {
 			TokenType.getType(null);
 			fail("got bad type");
@@ -77,10 +81,15 @@ public class TokenTest {
 		assertThat("Incorrect id for login token", TokenType.LOGIN.getID(), is("Login"));
 		assertThat("Incorrect description for login token", TokenType.LOGIN.getDescription(),
 				is("Login"));
-		assertThat("Incorrect id for ext life token", TokenType.EXTENDED_LIFETIME.getID(),
-				is("ExtLife"));
-		assertThat("Incorrect description for ext life token",
-				TokenType.EXTENDED_LIFETIME.getDescription(), is("Extended lifetime"));
+		assertThat("Incorrect id for agent token", TokenType.AGENT.getID(), is("Agent"));
+		assertThat("Incorrect description for agent token", TokenType.AGENT.getDescription(),
+				is("Agent"));
+		assertThat("Incorrect id for dev token", TokenType.DEV.getID(), is("Dev"));
+		assertThat("Incorrect description for dev token",
+				TokenType.DEV.getDescription(), is("Developer"));
+		assertThat("Incorrect id for serv token", TokenType.SERV.getID(), is("Serv"));
+		assertThat("Incorrect description for serv token",
+				TokenType.SERV.getDescription(), is("Service"));
 	}
 	
 	@Test
@@ -173,9 +182,9 @@ public class TokenTest {
 		// test with named token
 		final UUID id2 = UUID.randomUUID();
 		final HashedToken ht2 = new HashedToken(id2,
-				TokenType.EXTENDED_LIFETIME, Optional.of(new TokenName("ugh")), "foobar2",
+				TokenType.DEV, Optional.of(new TokenName("ugh")), "foobar2",
 				new UserName("whee2"), Instant.ofEpochMilli(27000), Instant.ofEpochMilli(42000));
-		assertThat("incorrect token type", ht2.getTokenType(), is(TokenType.EXTENDED_LIFETIME));
+		assertThat("incorrect token type", ht2.getTokenType(), is(TokenType.DEV));
 		assertThat("incorrect token name", ht2.getTokenName(),
 				is(Optional.of(new TokenName("ugh"))));
 		assertThat("incorrect token id", ht2.getId(), is(id2));
@@ -273,9 +282,9 @@ public class TokenTest {
 		// test with named token
 		final Instant i2 = Instant.ofEpochMilli(70000);
 		final UUID id2 = UUID.randomUUID();
-		final NewToken nt2 = new NewToken(id2, TokenType.EXTENDED_LIFETIME,
+		final NewToken nt2 = new NewToken(id2, TokenType.SERV,
 				new TokenName("myname"), "bar", new UserName("foo2"), i2, 15);
-		assertThat("incorrect token type", nt2.getTokenType(), is(TokenType.EXTENDED_LIFETIME));
+		assertThat("incorrect token type", nt2.getTokenType(), is(TokenType.SERV));
 		assertThat("incorrect token name", nt2.getTokenName(),
 				is(Optional.of(new TokenName("myname"))));
 		assertThat("incorrect token string", nt2.getToken(), is("bar"));
@@ -286,7 +295,7 @@ public class TokenTest {
 		assertThat("incorrect expiration date", nt2.getExpirationDate(), is(i2.plusMillis(15)));
 		
 		final HashedToken ht2 = nt2.getHashedToken();
-		assertThat("incorrect token type", ht2.getTokenType(), is(TokenType.EXTENDED_LIFETIME));
+		assertThat("incorrect token type", ht2.getTokenType(), is(TokenType.SERV));
 		assertThat("incorrect token name", ht2.getTokenName(),
 				is(Optional.of(new TokenName("myname"))));
 		assertThat("incorrect token string", ht2.getTokenHash(),
@@ -375,11 +384,11 @@ public class TokenTest {
 				new UserName("u"), Instant.ofEpochMilli(1000), Instant.ofEpochMilli(2000));
 		final UUID id2 = UUID.randomUUID();
 		final HashedToken ht2 = new HashedToken(id2,
-				TokenType.EXTENDED_LIFETIME, Optional.of(new TokenName("n2")), "h2",
+				TokenType.DEV, Optional.of(new TokenName("n2")), "h2",
 				new UserName("u"), Instant.ofEpochMilli(3000), Instant.ofEpochMilli(4000));
 		final UUID id3 = UUID.randomUUID();
 		final HashedToken ht3 = new HashedToken(id3,
-				TokenType.EXTENDED_LIFETIME, Optional.of(new TokenName("n3")), "h3",
+				TokenType.AGENT, Optional.of(new TokenName("n3")), "h3",
 				new UserName("u"), Instant.ofEpochMilli(5000), Instant.ofEpochMilli(6000));
 		
 		final Set<HashedToken> tokens = new HashSet<>(Arrays.asList(ht1, ht2, ht3));

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -55,6 +55,10 @@ provider, e.g. a choice of accounts is required.
 <input type="number" name="tokenlogin" {{#tokenlogin}}value="{{.}}"{{/tokenlogin}}/>
 </p>
 
+<p>Agent token (days):
+<input type="number" name="tokenagent" {{#tokenagent}}value="{{.}}"{{/tokenagent}}/>
+</p>
+
 <p>Developer token (days):
 <input type="number" name="tokendev" {{#tokendev}}value="{{.}}"{{/tokendev}}/>
 </p>


### PR DESCRIPTION
Agent tokens are short lived (1 week default) tokens that any user can create if they have a login token. They differ from dev and server tokens in that anyone can create an agent token and they have much shorter lifetimes. Like dev and server tokens, agent tokens cannot be used to create other tokens.

The purpose of agent tokens is to ensure that long running tasks do not fail if the user's login token expires. An agent that wishes to run a task on a user's behalf should get an agent token and run the task with that token. This ensures that the token lifetime will not run out if the login token was near expiration.

Also split the Extended Lifetime token type into Developer and Server tokens.