### PR TITLE
Refactor account linking errors

### DIFF
--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -346,14 +346,14 @@ public interface AuthStorage {
 	 * @param userName the user to which the remote identity will be linked. 
 	 * @param remoteID the remote identity.
 	 * @throws NoSuchUserException if the user does not exist.
-	 * @throws LinkFailedException if the user was a local user or the remote identity is already
-	 * linked to another user.
+	 * @throws LinkFailedException if the user is a local user.
+	 * @throws IdentityLinkedException if the identity is already linked to another user.
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
 	void link(UserName userName, RemoteIdentity remoteID)
 			throws NoSuchUserException, AuthStorageException,
-			LinkFailedException;
+			LinkFailedException, IdentityLinkedException;
 
 	/** Remove a remote identity from a user.
 	 * @param userName the user.

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -553,9 +553,7 @@ public class MongoStorage implements AuthStorage {
 						Fields.FIELD_SEP)) {
 					// either the provider / prov id combo or the local identity uuid are already
 					// in the db
-					final RemoteIdentityID ri = newUser.getIdentity().getRemoteID();
-					throw new IdentityLinkedException(
-							ri.getProviderName() + " : " + ri.getProviderIdentityId());
+					throw new IdentityLinkedException(newUser.getIdentity().getRemoteID().getID());
 				} // otherwise throw next exception
 			}
 			throw new AuthStorageException("Database write failed", mwe);
@@ -1297,8 +1295,8 @@ public class MongoStorage implements AuthStorage {
 	 */
 	@Override
 	public void link(final UserName user, final RemoteIdentity remoteID)
-			throws NoSuchUserException, AuthStorageException,
-			LinkFailedException {
+			throws NoSuchUserException, AuthStorageException, LinkFailedException,
+			IdentityLinkedException {
 		int count = 0;
 		boolean complete = false;
 		while (!complete) {
@@ -1320,7 +1318,8 @@ public class MongoStorage implements AuthStorage {
 	private boolean addIdentity(
 			final AuthUser user,
 			final RemoteIdentity remoteID)
-			throws NoSuchUserException, AuthStorageException, LinkFailedException {
+			throws NoSuchUserException, AuthStorageException, LinkFailedException,
+			IdentityLinkedException {
 		/* This method is written as it is to avoid adding the same provider ID to a user twice.
 		 * Since mongodb unique indexes only enforce uniqueness between documents, not within
 		 * documents, adding the same provider ID to a single document twice is possible without
@@ -1363,7 +1362,7 @@ public class MongoStorage implements AuthStorage {
 		} catch (MongoWriteException mwe) {
 			if (DuplicateKeyExceptionChecker.isDuplicate(mwe)) {
 				// another user already is linked to this ID, fail permanently, no retry
-				throw new LinkFailedException("Provider identity is already linked");
+				throw new IdentityLinkedException(remoteID.getRemoteID().getID());
 			} else {
 				throw new AuthStorageException("Database write failed", mwe);
 			}

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -46,6 +46,7 @@ import us.kbase.auth2.lib.LinkToken;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
+import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
@@ -330,8 +331,8 @@ public class Link {
 			@Context final HttpHeaders headers,
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@FormParam("id") String identityID)
-			throws NoTokenProvidedException, AuthenticationException,
-			AuthStorageException, LinkFailedException, DisabledUserException {
+			throws NoTokenProvidedException, AuthenticationException, AuthStorageException,
+			LinkFailedException, DisabledUserException, IdentityLinkedException {
 		if (identityID == null || identityID.trim().isEmpty()) {
 			identityID = null;
 		}
@@ -367,7 +368,7 @@ public class Link {
 			final LinkPick linkpick)
 			throws NoTokenProvidedException, AuthenticationException,
 			AuthStorageException, LinkFailedException, DisabledUserException,
-			IllegalParameterException, MissingParameterException {
+			IllegalParameterException, MissingParameterException, IdentityLinkedException {
 		if (linkpick == null) {
 			throw new MissingParameterException("JSON body missing");
 		}
@@ -381,7 +382,7 @@ public class Link {
 			final String linktoken,
 			final Optional<String> id)
 			throws NoTokenProvidedException, AuthStorageException, AuthenticationException,
-			LinkFailedException, DisabledUserException {
+			LinkFailedException, DisabledUserException, IdentityLinkedException {
 		final IncomingToken linkInProcessToken = getLinkInProcessToken(linktoken);
 		if (id.isPresent()) {
 			auth.link(token, linkInProcessToken, id.get());

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityException;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -217,8 +218,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 		final RemoteIdentity ri = new RemoteIdentity(
 				new RemoteIdentityID("prov", "bar2"),
 				new RemoteIdentityDetails("user10", "full10", "email10"));
-		failLink(new UserName("foo2"), ri,
-				new LinkFailedException("Provider identity is already linked"));
+		failLink(new UserName("foo2"), ri, new IdentityLinkedException(ri.getRemoteID().getID()));
 	}
 	
 	private void failLink(

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
@@ -418,7 +418,7 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 				.withEmailAddress(new EmailAddress("e@g1.com"))
 				.build();
 		
-		failCreateUser(nu2, new IdentityLinkedException("prov : bar1"));
+		failCreateUser(nu2, new IdentityLinkedException(ri.getRemoteID().getID()));
 	}
 	
 	private void failCreateUser(final NewUser user, final Exception e)


### PR DESCRIPTION
* Use IdentityLinkedException consistently
* In many cases just catch it and do nothing if we're linking a set of
identities.