### PR TITLE
Require login tokens for most operations.

### DIFF
--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -30,6 +30,7 @@ import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.user.AuthUser;
@@ -90,7 +91,7 @@ public class Me {
 			@FormParam("display") final String displayName,
 			@FormParam("email") final String email)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			IllegalParameterException {
+			IllegalParameterException, UnauthorizedException {
 		updateUser(auth, getToken(token), displayName, email);
 	}
 	
@@ -100,7 +101,7 @@ public class Me {
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
 			final Map<String, String> params)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			IllegalParameterException {
+			IllegalParameterException, UnauthorizedException {
 		updateUser(auth, getToken(token), params.get("display"), params.get("email"));
 	}
 }

--- a/src/us/kbase/auth2/service/common/ServiceCommon.java
+++ b/src/us/kbase/auth2/service/common/ServiceCommon.java
@@ -12,6 +12,7 @@ import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.service.exceptions.AuthConfigurationException;
@@ -36,7 +37,8 @@ public class ServiceCommon {
 			final IncomingToken token,
 			final String displayName,
 			final String email)
-			throws IllegalParameterException, InvalidTokenException, AuthStorageException {
+			throws IllegalParameterException, InvalidTokenException, AuthStorageException,
+				UnauthorizedException {
 		final UserUpdate.Builder uu = UserUpdate.getBuilder();
 		try {
 			if (displayName != null && !displayName.isEmpty()) {

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -53,6 +53,7 @@ import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
@@ -138,7 +139,7 @@ public class Link {
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthenticationException,
 			NoSuchProviderException, AuthStorageException,
-			NoTokenProvidedException, LinkFailedException, DisabledUserException {
+			NoTokenProvidedException, LinkFailedException, UnauthorizedException {
 		//TODO INPUT handle error in params (provider, state)
 		final MultivaluedMap<String, String> qps = uriInfo.getQueryParameters();
 		//TODO ERRHANDLE handle returned OAuth error code in queryparams
@@ -185,8 +186,8 @@ public class Link {
 			@Context final UriInfo uriInfo,
 			final IdentityProviderInput input)
 			throws MissingParameterException, AuthenticationException,
-				DisabledUserException, LinkFailedException, NoTokenProvidedException,
-				AuthStorageException, IllegalParameterException {
+				LinkFailedException, NoTokenProvidedException,
+				AuthStorageException, IllegalParameterException, UnauthorizedException {
 		if (input == null) {
 			throw new MissingParameterException("JSON body missing");
 		}
@@ -260,7 +261,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, LinkFailedException, DisabledUserException {
+			InvalidTokenException, LinkFailedException, UnauthorizedException {
 		return linkChoice(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 				linktoken, uriInfo);
 	}
@@ -274,7 +275,7 @@ public class Link {
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException,
-			InvalidTokenException, LinkFailedException, DisabledUserException {
+			InvalidTokenException, LinkFailedException, UnauthorizedException {
 		return linkChoice(getToken(token), linktoken, uriInfo);
 	}
 
@@ -283,7 +284,7 @@ public class Link {
 			final String linktoken,
 			final UriInfo uriInfo)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			LinkFailedException, DisabledUserException {
+			LinkFailedException, UnauthorizedException {
 		final LinkIdentities ids = auth.getLinkState(incomingToken,
 				getLinkInProcessToken(linktoken));
 		return buildLinkChoice(uriInfo, ids);
@@ -331,8 +332,8 @@ public class Link {
 			@Context final HttpHeaders headers,
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			@FormParam("id") String identityID)
-			throws NoTokenProvidedException, AuthenticationException, AuthStorageException,
-			LinkFailedException, DisabledUserException, IdentityLinkedException {
+			throws NoTokenProvidedException, AuthStorageException, LinkFailedException,
+				IdentityLinkedException, UnauthorizedException, InvalidTokenException {
 		if (identityID == null || identityID.trim().isEmpty()) {
 			identityID = null;
 		}
@@ -366,9 +367,9 @@ public class Link {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String token,
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
 			final LinkPick linkpick)
-			throws NoTokenProvidedException, AuthenticationException,
-			AuthStorageException, LinkFailedException, DisabledUserException,
-			IllegalParameterException, MissingParameterException, IdentityLinkedException {
+			throws NoTokenProvidedException, AuthStorageException,
+				LinkFailedException, IllegalParameterException, MissingParameterException,
+				IdentityLinkedException, UnauthorizedException, InvalidTokenException {
 		if (linkpick == null) {
 			throw new MissingParameterException("JSON body missing");
 		}
@@ -381,8 +382,8 @@ public class Link {
 			final IncomingToken token,
 			final String linktoken,
 			final Optional<String> id)
-			throws NoTokenProvidedException, AuthStorageException, AuthenticationException,
-			LinkFailedException, DisabledUserException, IdentityLinkedException {
+			throws NoTokenProvidedException, AuthStorageException, LinkFailedException,
+				IdentityLinkedException, UnauthorizedException, InvalidTokenException {
 		final IncomingToken linkInProcessToken = getLinkInProcessToken(linktoken);
 		if (id.isPresent()) {
 			auth.link(token, linkInProcessToken, id.get());

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -140,7 +140,7 @@ public class Me {
 			@FormParam("display") final String displayName,
 			@FormParam("email") final String email)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			IllegalParameterException {
+			IllegalParameterException, UnauthorizedException {
 		updateUser(auth, getTokenFromCookie(headers, cfg.getTokenCookieName()),
 				displayName, email);
 	}
@@ -165,7 +165,7 @@ public class Me {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String token,
 			final Update update)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			IllegalParameterException, MissingParameterException {
+			IllegalParameterException, MissingParameterException, UnauthorizedException {
 		
 		if (update == null) {
 			throw new MissingParameterException("Missing JSON body");
@@ -181,7 +181,7 @@ public class Me {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
 			@PathParam("id") final String id)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			UnLinkFailedException, DisabledUserException, NoSuchIdentityException {
+			UnLinkFailedException, NoSuchIdentityException, UnauthorizedException {
 		// id can't be null
 		final Optional<IncomingToken> token = getTokenFromCookie(
 				headers, cfg.getTokenCookieName(), false);

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -35,7 +35,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.TokenName;
-import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -71,7 +70,7 @@ public class Tokens {
 			@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException, DisabledUserException {
+			NoTokenProvidedException, UnauthorizedException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		t.put("user", ((ExternalToken) t.get("current")).getUser());
@@ -87,7 +86,7 @@ public class Tokens {
 	public Map<String, Object> getTokensJSON(
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException, DisabledUserException {
+			NoTokenProvidedException, UnauthorizedException {
 		return getTokens(getToken(headerToken));
 	}
 	
@@ -143,7 +142,7 @@ public class Tokens {
 			@PathParam("tokenid") final UUID tokenId)
 			throws AuthStorageException,
 			NoSuchTokenException, NoTokenProvidedException,
-			InvalidTokenException {
+			InvalidTokenException, UnauthorizedException {
 		auth.revokeToken(getTokenFromCookie(headers, cfg.getTokenCookieName()), tokenId);
 	}
 	
@@ -154,7 +153,7 @@ public class Tokens {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException,
 			NoSuchTokenException, NoTokenProvidedException,
-			InvalidTokenException {
+			InvalidTokenException, UnauthorizedException {
 		auth.revokeToken(getToken(headerToken), tokenId);
 	}
 	
@@ -162,7 +161,7 @@ public class Tokens {
 	@Path(UIPaths.TOKENS_REVOKE_ALL)
 	public Response revokeAllAndLogout(@Context final HttpHeaders headers)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException {
+			InvalidTokenException, UnauthorizedException {
 		auth.revokeTokens(getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		return Response.ok().cookie(getLoginCookie(cfg.getTokenCookieName(), null)).build();
 	}
@@ -172,7 +171,7 @@ public class Tokens {
 	public void revokeAll(
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException {
+			InvalidTokenException, UnauthorizedException {
 		auth.revokeTokens(getToken(headerToken));
 	}
 			
@@ -190,7 +189,7 @@ public class Tokens {
 
 	private Map<String, Object> getTokens(final IncomingToken token)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException, DisabledUserException {
+			InvalidTokenException, UnauthorizedException {
 		final AuthUser au = auth.getUser(token);
 		final TokenSet ts = auth.getTokens(token);
 		final Map<String, Object> ret = new HashMap<>();

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
@@ -297,6 +297,34 @@ public class AuthenticationCreateLocalUserTest {
 	}
 	
 	@Test
+	public void createUserFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+				new EmailAddress("f@g.com"), new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+				new EmailAddress("f@g.com"), new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+				new EmailAddress("f@g.com"), new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void createUserFailNoSuchUser() throws Exception {
 		// should never actually happen if db isn't corrupted
 		final TestMocks testauth = initTestMocks();

--- a/src/us/kbase/test/auth2/lib/AuthenticationCustomRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCustomRoleTest.java
@@ -84,6 +84,31 @@ public class AuthenticationCustomRoleTest {
 	}
 	
 	@Test
+	public void createRoleFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failCreateRole(auth, token, new CustomRole("a", "b"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failCreateRole(auth, token, new CustomRole("a", "b"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failCreateRole(auth, token, new CustomRole("a", "b"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void createRoleFailCatastrophic() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
@@ -220,6 +245,31 @@ public class AuthenticationCustomRoleTest {
 		when(storage.getToken(token.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 			
 		failDeleteRole(auth, token, "foo", new InvalidTokenException());
+	}
+	
+	@Test
+	public void deleteRoleFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failDeleteRole(auth, token, "foo", new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failDeleteRole(auth, token, "foo", new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failDeleteRole(auth, token, "foo", new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -360,6 +410,43 @@ public class AuthenticationCustomRoleTest {
 			
 		failGetCustomRoles(auth, token, true, new InvalidTokenException());
 		failGetCustomRoles(auth, token, false, new InvalidTokenException());
+	}
+	
+	@Test
+	public void getCustomRolesFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failGetCustomRoles(auth, token, true, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failGetCustomRoles(auth, token, true, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failGetCustomRoles(auth, token, true, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
+		failGetCustomRoles(auth, token, false, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failGetCustomRoles(auth, token, false, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failGetCustomRoles(auth, token, false, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -512,6 +599,34 @@ public class AuthenticationCustomRoleTest {
 		
 		failUpdateCustomRole(auth, token, new UserName("bar"), set("foo"), set("bar"),
 				new InvalidTokenException());
+	}
+	
+	@Test
+	public void updateCustomRoleFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failUpdateCustomRole(auth, token, new UserName("bar"), set("foo"), set("bar"),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Agent tokens are not allowed for this operation"));
+		failUpdateCustomRole(auth, token, new UserName("bar"), set("foo"), set("bar"),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Developer tokens are not allowed for this operation"));
+		failUpdateCustomRole(auth, token, new UserName("bar"), set("foo"), set("bar"),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Service tokens are not allowed for this operation"));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
@@ -402,6 +402,31 @@ public class AuthenticationGetUserTest {
 	}
 	
 	@Test
+	public void getUserAsAdminFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failGetUserAsAdmin(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failGetUserAsAdmin(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failGetUserAsAdmin(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void getUserAsAdminFailCatastrophic() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;

--- a/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
@@ -832,6 +832,31 @@ public class AuthenticationPasswordLoginTest {
 	}
 	
 	@Test
+	public void resetPasswordFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void resetPasswordFailCatastrophicNoUser() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
@@ -1230,6 +1255,31 @@ public class AuthenticationPasswordLoginTest {
 	}
 	
 	@Test
+	public void forceResetPasswordFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failForceResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failForceResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failForceResetPassword(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void forceResetPasswordFailCatastrophicNoUser() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
@@ -1387,6 +1437,31 @@ public class AuthenticationPasswordLoginTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failForceResetAllPasswords(auth, t, new InvalidTokenException());
+	}
+	
+	@Test
+	public void forceResetAllPasswordsFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failForceResetAllPasswords(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failForceResetAllPasswords(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failForceResetAllPasswords(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/AuthenticationPolicyIDTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationPolicyIDTest.java
@@ -75,6 +75,31 @@ public class AuthenticationPolicyIDTest {
 	}
 	
 	@Test
+	public void removePolicyIDFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRemovePolicyID(auth, token, new PolicyID("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failRemovePolicyID(auth, token, new PolicyID("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failRemovePolicyID(auth, token, new PolicyID("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
+	
+	@Test
 	public void failRemotePolicyIDFailCatastrophic() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;

--- a/src/us/kbase/test/auth2/lib/AuthenticationRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationRoleTest.java
@@ -186,6 +186,31 @@ public class AuthenticationRoleTest {
 			
 		failRemoveRoles(auth, token, set(Role.ADMIN), new InvalidTokenException());
 	}
+	
+	@Test
+	public void removeRolesFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRemoveRoles(auth, token, set(Role.ADMIN), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failRemoveRoles(auth, token, set(Role.ADMIN), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failRemoveRoles(auth, token, set(Role.ADMIN), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
+	}
 
 	private void failRemoveRoles(
 			final Authentication auth,
@@ -295,6 +320,34 @@ public class AuthenticationRoleTest {
 			
 		failUpdateRoles(auth, token, new UserName("foo"), Collections.emptySet(),
 				Collections.emptySet(), new InvalidTokenException());
+	}
+	
+	@Test
+	public void updateRolesFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failUpdateRoles(auth, token, new UserName("foo"), set(), set(),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Agent tokens are not allowed for this operation"));
+		failUpdateRoles(auth, token, new UserName("foo"), set(), set(),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Developer tokens are not allowed for this operation"));
+		failUpdateRoles(auth, token, new UserName("foo"), set(), set(),
+				new UnauthorizedException(ErrorType.UNAUTHORIZED,
+						"Service tokens are not allowed for this operation"));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -165,12 +165,37 @@ public class AuthenticationTokenTest {
 		failGetTokens(auth, t, new InvalidTokenException());
 	}
 	
+	@Test
+	public void getTokensFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failGetTokens(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failGetTokens(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failGetTokens(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
+	}
+	
 	private void failGetTokens(
 			final Authentication auth,
 			final IncomingToken t,
 			final Exception e) {
 		try {
-			auth.getToken(t);
+			auth.getTokens(t);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
@@ -250,6 +275,31 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failGetTokensUser(auth, t, new UserName("bar"), new InvalidTokenException());
+	}
+	
+	@Test
+	public void getTokensUserFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failGetTokensUser(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failGetTokensUser(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failGetTokensUser(auth, token, new UserName("bar"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -410,7 +460,31 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failRevokeToken(auth, t, UUID.randomUUID(), new InvalidTokenException());
+	}
+	
+	@Test
+	public void revokeTokenFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
 		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRevokeToken(auth, token, UUID.randomUUID(), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failRevokeToken(auth, token, UUID.randomUUID(), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failRevokeToken(auth, token, UUID.randomUUID(), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -529,6 +603,32 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failRevokeTokenAdmin(auth, t, new UserName("foo"), target, new InvalidTokenException());
+	}
+	
+	@Test
+	public void revokeTokenAdminFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		final UUID target = UUID.randomUUID();
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRevokeTokenAdmin(auth, token, new UserName("foo"), target, new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failRevokeTokenAdmin(auth, token, new UserName("foo"), target, new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failRevokeTokenAdmin(auth, token, new UserName("foo"), target, new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -659,7 +759,7 @@ public class AuthenticationTokenTest {
 	}
 	
 	@Test
-	public void revokeAllTokenUserFailBadToken() throws Exception {
+	public void revokeAllTokensUserFailBadToken() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;
 		final Authentication auth = testauth.auth;
@@ -669,6 +769,31 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failRevokeAllTokensUser(auth, t, new InvalidTokenException());
+	}
+	
+	@Test
+	public void revokeAllTokensUserFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRevokeAllTokensUser(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failRevokeAllTokensUser(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failRevokeAllTokensUser(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
 	}
 	
 	private void failRevokeAllTokensUser(
@@ -752,6 +877,31 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failRevokeAllTokensAdminAll(auth, t, new InvalidTokenException());
+	}
+	
+	@Test
+	public void revokeAllTokensAdminAllBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRevokeAllTokensAdminAll(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Agent tokens are not allowed for this operation"));
+		failRevokeAllTokensAdminAll(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Developer tokens are not allowed for this operation"));
+		failRevokeAllTokensAdminAll(auth, token, new UnauthorizedException(ErrorType.UNAUTHORIZED,
+				"Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -895,6 +1045,31 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenThrow(new NoSuchTokenException("foo"));
 		
 		failRevokeAllTokensAdminUser(auth, t, new UserName("foo"), new InvalidTokenException());
+	}
+	
+	@Test
+	public void revokeAllTokensAdminUserFailBadTokenType() throws Exception {
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		when(storage.getToken(token.getHashedToken())).thenReturn(
+				new HashedToken(UUID.randomUUID(), TokenType.AGENT, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.DEV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				new HashedToken(UUID.randomUUID(), TokenType.SERV, null, "foo",
+						new UserName("bar"), Instant.now(), Instant.now()),
+				null);
+		
+		failRevokeAllTokensAdminUser(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Agent tokens are not allowed for this operation"));
+		failRevokeAllTokensAdminUser(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Developer tokens are not allowed for this operation"));
+		failRevokeAllTokensAdminUser(auth, token, new UserName("foo"), new UnauthorizedException(
+				ErrorType.UNAUTHORIZED, "Service tokens are not allowed for this operation"));
 	}
 	
 	@Test
@@ -1146,8 +1321,8 @@ public class AuthenticationTokenTest {
 		when(storage.getToken(t.getHashedToken())).thenReturn(ht, (HashedToken) null);
 		
 		failCreateToken(auth, t, new TokenName("foo"), TokenType.DEV,
-				new UnauthorizedException(ErrorType.UNAUTHORIZED,
-						"Only login tokens may be used to create a token"));
+				new UnauthorizedException(ErrorType.UNAUTHORIZED, tokenType.getDescription() +
+						" tokens are not allowed for this operation"));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUserCreateGetTest.java
@@ -517,8 +517,6 @@ public class MongoStorageUserCreateGetTest extends MongoStorageTester {
 		assertThat("incorrect user", storage.getUser(REMOTE2), is(Optional.absent()));
 	}
 	
-	//TODO TEST case where user starts login, stores identity linked to user, id is unlinked, and then completes login. In Authentication tests
-	
 	@Test
 	public void getUserAndUpdateRemoteId() throws Exception {
 		storage.createUser(NewUser.getBuilder(


### PR DESCRIPTION
Login tokens are now required for most operations. Operations that don't
require a login token:

* Revoking a token by providing said token
* Getting the token details
* Getting the user's profile
* Getting a user name and display name for one or more users, or
searching for same