### PR TITLE
Configuration system refactor phase 1

### DIFF
--- a/src/us/kbase/auth2/cli/AuthCLI.java
+++ b/src/us/kbase/auth2/cli/AuthCLI.java
@@ -93,7 +93,7 @@ public class AuthCLI {
 		final AuthStartupConfig cfg;
 		try {
 			cfg = new KBaseAuthConfig(Paths.get(a.deploy), true);
-			auth = new AuthBuilder(cfg, AuthExternalConfig.DEFAULT).getAuth();
+			auth = new AuthBuilder(cfg, AuthExternalConfig.SET_DEFAULT).getAuth();
 		} catch (AuthConfigurationException | StorageInitException e) {
 			error(e, a);
 			throw new RuntimeException(); // error() stops execution

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -213,8 +213,7 @@ public class Authentication {
 		final AuthConfig ac =  new AuthConfig(AuthConfig.DEFAULT_LOGIN_ALLOWED, provs,
 				AuthConfig.DEFAULT_TOKEN_LIFETIMES_MS);
 		try {
-			storage.updateConfig(new AuthConfigSet<ExternalConfig>(
-					ac, defaultExternalConfig), false);
+			storage.updateConfig(new AuthConfigSet<>(ac, defaultExternalConfig), false);
 		} catch (AuthStorageException e) {
 			throw new StorageInitException("Failed to set config in storage: " +
 					e.getMessage(), e);
@@ -2117,7 +2116,7 @@ public class Authentication {
 		//TODO NOW remove providers from config that aren't in set
 		final AuthConfigSet<CollectingExternalConfig> acs = cfg.getConfig();
 		return new AuthConfigSet<T>(acs.getCfg(),
-				mapper.fromMap(acs.getExtcfg().toMap()));
+				mapper.fromMap(acs.getExtcfg().getMap()));
 	}
 	
 	/** Returns the suggested cache time for tokens.
@@ -2143,7 +2142,7 @@ public class Authentication {
 			throws AuthStorageException, ExternalConfigMappingException {
 		nonNull(mapper, "mapper");
 		final AuthConfigSet<CollectingExternalConfig> acs = cfg.getConfig();
-		return mapper.fromMap(acs.getExtcfg().toMap());
+		return mapper.fromMap(acs.getExtcfg().getMap());
 	}
 
 	/** Imports a user from an external service without requiring credentials.

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -2114,6 +2114,7 @@ public class Authentication {
 			AuthStorageException, ExternalConfigMappingException {
 		nonNull(mapper, "mapper");
 		getUser(token, set(TokenType.LOGIN), Role.ADMIN);
+		//TODO NOW remove providers from config that aren't in set
 		final AuthConfigSet<CollectingExternalConfig> acs = cfg.getConfig();
 		return new AuthConfigSet<T>(acs.getCfg(),
 				mapper.fromMap(acs.getExtcfg().toMap()));

--- a/src/us/kbase/auth2/lib/config/AuthConfig.java
+++ b/src/us/kbase/auth2/lib/config/AuthConfig.java
@@ -20,7 +20,9 @@ public class AuthConfig {
 	 * change classes. Try with the conflated semantics for now.
 	 */
 	
-	private static final int MIN_TOKEN_LIFE = 60 * 1000;
+	//TODO NOW include custom config
+	
+	public static final int MIN_TOKEN_LIFE_MS = 60 * 1000;
 	
 	/** Default configuration for a identity provider. */
 	public static final ProviderConfig DEFAULT_PROVIDER_CONFIG =
@@ -185,6 +187,8 @@ public class AuthConfig {
 	private final Map<String, ProviderConfig> providers;
 	private final Map<TokenLifetimeType, Long> tokenLifetimeMS;
 	
+	//TODO NOW don't allow nulls
+	
 	/** Create an authentication configuration.
 	 * @param loginAllowed true if non-admin logins are allowed, false if not, or null if no
 	 * changes should be made.
@@ -215,9 +219,9 @@ public class AuthConfig {
 		for (final TokenLifetimeType t: tokenLifetimeMS.keySet()) {
 			nonNull(t, "null key in token life time map");
 			nonNull(tokenLifetimeMS.get(t), String.format("lifetime for key %s is null", t));
-			if (tokenLifetimeMS.get(t) < MIN_TOKEN_LIFE) {
+			if (tokenLifetimeMS.get(t) < MIN_TOKEN_LIFE_MS) {
 				throw new IllegalArgumentException(String.format(
-						"lifetime for key %s must be at least %s ms", t, MIN_TOKEN_LIFE));
+						"lifetime for key %s must be at least %s ms", t, MIN_TOKEN_LIFE_MS));
 			}
 		}
 		this.loginAllowed = loginAllowed;

--- a/src/us/kbase/auth2/lib/config/CollectingExternalConfig.java
+++ b/src/us/kbase/auth2/lib/config/CollectingExternalConfig.java
@@ -5,7 +5,7 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 import java.util.Map;
 
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 
 /** An external configuration stored as a map. The corresponding mapper simply stores the map
@@ -15,12 +15,12 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
  */
 public class CollectingExternalConfig implements ExternalConfig {
 	
-	private final Map<String, ConfigItem<String, ConfigState>> cfg;
+	private final Map<String, ConfigItem<String, State>> cfg;
 	
 	/** Create a new configuration.
 	 * @param map the map defining the configuration.
 	 */
-	public CollectingExternalConfig(final Map<String, ConfigItem<String, ConfigState>> map) {
+	public CollectingExternalConfig(final Map<String, ConfigItem<String, State>> map) {
 		nonNull(map, "map");
 		cfg = map;
 	}
@@ -33,7 +33,7 @@ public class CollectingExternalConfig implements ExternalConfig {
 	/** Get the collected map.
 	 * @return the map.
 	 */
-	public Map<String, ConfigItem<String, ConfigState>> getMap() {
+	public Map<String, ConfigItem<String, State>> getMap() {
 		return cfg;
 	}
 
@@ -76,7 +76,7 @@ public class CollectingExternalConfig implements ExternalConfig {
 
 		@Override
 		public CollectingExternalConfig fromMap(
-				final Map<String, ConfigItem<String, ConfigState>> config)
+				final Map<String, ConfigItem<String, State>> config)
 				throws ExternalConfigMappingException {
 			return new CollectingExternalConfig(config);
 		}

--- a/src/us/kbase/auth2/lib/config/CollectingExternalConfig.java
+++ b/src/us/kbase/auth2/lib/config/CollectingExternalConfig.java
@@ -4,6 +4,8 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.util.Map;
 
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 
 /** An external configuration stored as a map. The corresponding mapper simply stores the map
@@ -13,18 +15,25 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
  */
 public class CollectingExternalConfig implements ExternalConfig {
 	
-	private final Map<String, String> cfg;
+	private final Map<String, ConfigItem<String, ConfigState>> cfg;
 	
 	/** Create a new configuration.
 	 * @param map the map defining the configuration.
 	 */
-	public CollectingExternalConfig(final Map<String, String> map) {
+	public CollectingExternalConfig(final Map<String, ConfigItem<String, ConfigState>> map) {
 		nonNull(map, "map");
 		cfg = map;
 	}
 	
 	@Override
-	public Map<String, String> toMap() {
+	public Map<String, ConfigItem<String, Action>> toMap() {
+		throw new UnsupportedOperationException();
+	}
+	
+	/** Get the collected map.
+	 * @return the map.
+	 */
+	public Map<String, ConfigItem<String, ConfigState>> getMap() {
 		return cfg;
 	}
 
@@ -66,7 +75,8 @@ public class CollectingExternalConfig implements ExternalConfig {
 			ExternalConfigMapper<CollectingExternalConfig> {
 
 		@Override
-		public CollectingExternalConfig fromMap(final Map<String, String> config)
+		public CollectingExternalConfig fromMap(
+				final Map<String, ConfigItem<String, ConfigState>> config)
 				throws ExternalConfigMappingException {
 			return new CollectingExternalConfig(config);
 		}

--- a/src/us/kbase/auth2/lib/config/ConfigAction.java
+++ b/src/us/kbase/auth2/lib/config/ConfigAction.java
@@ -1,0 +1,182 @@
+package us.kbase.auth2.lib.config;
+
+/** An action to take with relation to a configuration item.
+ * @author gaprice@lbl.gov
+ *
+ */
+public interface ConfigAction {
+	
+	//TODO NOW TEST
+
+	/** Returns true if this ConfigAction simply represents the state of the configuration item.
+	 * 
+	 * No action is required, but a value for the configuration item may be expected.
+	 * @return true if the action is actually a state.
+	 */
+	public boolean isState();
+	
+	/** Returns true if no action is required.
+	 * @return true if no action is required.
+	 */
+	public boolean isNoAction();
+	
+	/** Returns true if this ConfigAction represents a set action - the configuration item should
+	 * be set to a new value.
+	 * @return true if this action is a set.
+	 */
+	public boolean isSet();
+	
+	/** Returns true if this ConfigAction represents a remove action - the configuration item
+	 * should be removed from the configuration.
+	 * @return true if this action is a remove.
+	 */
+	public boolean isRemove();
+	
+	static ConfigState state() {
+		return ConfigState.INSTANCE;
+	}
+	
+	static RemoveAction remove() {
+		return RemoveAction.INSTANCE;
+	}
+	
+	static NoAction noAction() {
+		return NoAction.INSTANCE;
+	}
+	
+	static SetAction set() {
+		return SetAction.INSTANCE;
+	}
+	
+	/** A configuration state. 
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public final static class ConfigState implements ConfigAction {
+		
+		private static final ConfigState INSTANCE = new ConfigState();
+		
+		private ConfigState() {}
+		
+		@Override
+		public boolean isRemove() {
+			return false;
+		}
+
+		@Override
+		public boolean isNoAction() {
+			return false;
+		}
+
+		@Override
+		public boolean isSet() {
+			return false;
+		}
+		
+		@Override
+		public boolean isState() {
+			return true;
+		}
+	}
+	
+	/** An action, as opposed to a configuration state.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public interface Action extends ConfigAction {}
+	
+	
+	/** A remove action.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public final class RemoveAction implements Action {
+		
+		private static final RemoveAction INSTANCE = new RemoveAction();
+		
+		private RemoveAction() {}
+
+		@Override
+		public boolean isRemove() {
+			return true;
+		}
+
+		@Override
+		public boolean isNoAction() {
+			return false;
+		}
+
+		@Override
+		public boolean isSet() {
+			return false;
+		}
+
+		@Override
+		public boolean isState() {
+			return false;
+		}
+	}
+	
+	/** A set action.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public final class SetAction implements Action {
+		
+		private static final SetAction INSTANCE = new SetAction();
+		
+		private SetAction() {}
+
+		@Override
+		public boolean isRemove() {
+			return false;
+		}
+
+		@Override
+		public boolean isNoAction() {
+			return false;
+		}
+
+		@Override
+		public boolean isSet() {
+			return true;
+		}
+
+		@Override
+		public boolean isState() {
+			return false;
+		}
+	}
+	
+	/** An action that represents that no action is required.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public final class NoAction implements Action {
+		
+		private static final NoAction INSTANCE = new NoAction();
+
+		private NoAction() {}
+
+		@Override
+		public boolean isRemove() {
+			return false;
+		}
+
+		@Override
+		public boolean isNoAction() {
+			return true;
+		}
+
+		@Override
+		public boolean isSet() {
+			return false;
+		}
+
+		@Override
+		public boolean isState() {
+			return false;
+		}
+	}
+}
+

--- a/src/us/kbase/auth2/lib/config/ConfigAction.java
+++ b/src/us/kbase/auth2/lib/config/ConfigAction.java
@@ -4,7 +4,9 @@ package us.kbase.auth2.lib.config;
  * @author gaprice@lbl.gov
  *
  */
-public interface ConfigAction {
+public abstract class ConfigAction {
+	
+	private ConfigAction() {}
 	
 	//TODO NOW TEST
 
@@ -13,38 +15,38 @@ public interface ConfigAction {
 	 * No action is required, but a value for the configuration item may be expected.
 	 * @return true if the action is actually a state.
 	 */
-	public boolean isState();
+	public abstract boolean isState();
 	
 	/** Returns true if no action is required.
 	 * @return true if no action is required.
 	 */
-	public boolean isNoAction();
+	public abstract boolean isNoAction();
 	
 	/** Returns true if this ConfigAction represents a set action - the configuration item should
 	 * be set to a new value.
 	 * @return true if this action is a set.
 	 */
-	public boolean isSet();
+	public abstract boolean isSet();
 	
 	/** Returns true if this ConfigAction represents a remove action - the configuration item
 	 * should be removed from the configuration.
 	 * @return true if this action is a remove.
 	 */
-	public boolean isRemove();
+	public abstract boolean isRemove();
 	
 	static ConfigState state() {
 		return ConfigState.INSTANCE;
 	}
 	
-	static RemoveAction remove() {
+	static Action remove() {
 		return RemoveAction.INSTANCE;
 	}
 	
-	static NoAction noAction() {
+	static Action noAction() {
 		return NoAction.INSTANCE;
 	}
 	
-	static SetAction set() {
+	static Action set() {
 		return SetAction.INSTANCE;
 	}
 	
@@ -52,7 +54,7 @@ public interface ConfigAction {
 	 * @author gaprice@lbl.gov
 	 *
 	 */
-	public final static class ConfigState implements ConfigAction {
+	public static final class ConfigState extends ConfigAction {
 		
 		private static final ConfigState INSTANCE = new ConfigState();
 		
@@ -83,14 +85,12 @@ public interface ConfigAction {
 	 * @author gaprice@lbl.gov
 	 *
 	 */
-	public interface Action extends ConfigAction {}
+	public static abstract class Action extends ConfigAction {
+		
+		private Action() {}
+	}
 	
-	
-	/** A remove action.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	public final class RemoveAction implements Action {
+	private static final class RemoveAction extends Action {
 		
 		private static final RemoveAction INSTANCE = new RemoveAction();
 		
@@ -117,11 +117,7 @@ public interface ConfigAction {
 		}
 	}
 	
-	/** A set action.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	public final class SetAction implements Action {
+	private static final class SetAction extends Action {
 		
 		private static final SetAction INSTANCE = new SetAction();
 		
@@ -148,11 +144,7 @@ public interface ConfigAction {
 		}
 	}
 	
-	/** An action that represents that no action is required.
-	 * @author gaprice@lbl.gov
-	 *
-	 */
-	public final class NoAction implements Action {
+	private static final class NoAction extends Action {
 		
 		private static final NoAction INSTANCE = new NoAction();
 

--- a/src/us/kbase/auth2/lib/config/ConfigAction.java
+++ b/src/us/kbase/auth2/lib/config/ConfigAction.java
@@ -8,8 +8,6 @@ public abstract class ConfigAction {
 	
 	private ConfigAction() {}
 	
-	//TODO NOW TEST
-
 	/** Returns true if this ConfigAction simply represents the state of the configuration item.
 	 * 
 	 * No action is required, but a value for the configuration item may be expected.
@@ -88,6 +86,18 @@ public abstract class ConfigAction {
 	public static abstract class Action extends ConfigAction {
 		
 		private Action() {}
+		
+		@Override
+		public abstract boolean isRemove();
+
+		@Override
+		public abstract boolean isNoAction();
+
+		@Override
+		public abstract boolean isSet();
+		
+		@Override
+		public abstract boolean isState();
 	}
 	
 	private static final class RemoveAction extends Action {

--- a/src/us/kbase/auth2/lib/config/ConfigAction.java
+++ b/src/us/kbase/auth2/lib/config/ConfigAction.java
@@ -34,8 +34,8 @@ public abstract class ConfigAction {
 	 */
 	public abstract boolean isRemove();
 	
-	static ConfigState state() {
-		return ConfigState.INSTANCE;
+	static State state() {
+		return State.INSTANCE;
 	}
 	
 	static Action remove() {
@@ -54,11 +54,11 @@ public abstract class ConfigAction {
 	 * @author gaprice@lbl.gov
 	 *
 	 */
-	public static final class ConfigState extends ConfigAction {
+	public static final class State extends ConfigAction {
 		
-		private static final ConfigState INSTANCE = new ConfigState();
+		private static final State INSTANCE = new State();
 		
-		private ConfigState() {}
+		private State() {}
 		
 		@Override
 		public boolean isRemove() {

--- a/src/us/kbase/auth2/lib/config/ConfigItem.java
+++ b/src/us/kbase/auth2/lib/config/ConfigItem.java
@@ -14,8 +14,6 @@ import us.kbase.auth2.lib.config.ConfigAction.State;
  */
 public class ConfigItem<T, A extends ConfigAction> {
 	
-	//TODO NOW TEST
-
 	private final T item;
 	private final A action;
 	

--- a/src/us/kbase/auth2/lib/config/ConfigItem.java
+++ b/src/us/kbase/auth2/lib/config/ConfigItem.java
@@ -3,7 +3,7 @@ package us.kbase.auth2.lib.config;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 
 /** A configuration item. A configuration item consists of an action to take, and possibly an item
  * associated with that action.
@@ -24,7 +24,7 @@ public class ConfigItem<T, A extends ConfigAction> {
 	 * @param item the item to associate with the action.
 	 * @return a new ConfigItem with the state "action".
 	 */
-	public static <T> ConfigItem<T, ConfigState> state(T item) {
+	public static <T> ConfigItem<T, State> state(T item) {
 		nonNull(item, "item");
 		return new ConfigItem<>(item, ConfigAction.state());
 	}
@@ -34,7 +34,7 @@ public class ConfigItem<T, A extends ConfigAction> {
 	 * the action.
 	 * @return an empty ConfigItem with the state "action".
 	 */
-	public static <T> ConfigItem<T, ConfigState> emptyState() {
+	public static <T> ConfigItem<T, State> emptyState() {
 		return new ConfigItem<>(null, ConfigAction.state());
 	}
 	

--- a/src/us/kbase/auth2/lib/config/ConfigItem.java
+++ b/src/us/kbase/auth2/lib/config/ConfigItem.java
@@ -1,0 +1,132 @@
+package us.kbase.auth2.lib.config;
+
+import static us.kbase.auth2.lib.Utils.nonNull;
+
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+
+/** A configuration item. A configuration item consists of an action to take, and possibly an item
+ * associated with that action.
+ * @author gaprice@lbl.gov
+ *
+ * @param <T> the type of the item, if any, in this configuration item.
+ * @param <A> the type of the action in this configuration item.
+ */
+public class ConfigItem<T, A extends ConfigAction> {
+	
+	//TODO NOW TEST
+
+	private final T item;
+	private final A action;
+	
+	/** Get a configuration state action that, rather than being a true action, represents the
+	 * state of the configuration item.
+	 * @param item the item to associate with the action.
+	 * @return a new ConfigItem with the state "action".
+	 */
+	public static <T> ConfigItem<T, ConfigState> state(T item) {
+		nonNull(item, "item");
+		return new ConfigItem<>(item, ConfigAction.state());
+	}
+	
+	/** Get an empty configuration state action that, rather than being a true action, represents
+	 * the state of the configuration item. This configuration item has no item associated with
+	 * the action.
+	 * @return an empty ConfigItem with the state "action".
+	 */
+	public static <T> ConfigItem<T, ConfigState> emptyState() {
+		return new ConfigItem<>(null, ConfigAction.state());
+	}
+	
+	/** Get a remove action. There is never an item associated with this type of action.
+	 * @return a new ConfigItem with the remove action.
+	 */
+	public static <T> ConfigItem<T, Action> remove() {
+		return new ConfigItem<>(null, ConfigAction.remove());
+	}
+	
+	/** Get an action specifying that no action should be taken. There is never an item associated
+	 * with this type of action.
+	 * @return a new ConfigItem with a no-op action.
+	 */
+	public static <T> ConfigItem<T, Action> noAction() {
+		return new ConfigItem<>(null, ConfigAction.noAction());
+	}
+	
+	/** Get a set action with an associated item.
+	 * @param item the item to associate with the set action.
+	 * @return a new ConfigItem with a set action.
+	 */
+	public static <T> ConfigItem<T, Action> set(T item) {
+		nonNull(item, "item");
+		return new ConfigItem<>(item, ConfigAction.set());
+	}
+
+	private ConfigItem(T item, A action) {
+		this.item = item;
+		this.action = action;
+	}
+
+	/** Get the item associated with the action.
+	 * @return the item.
+	 * @throws IllegalStateException if there is no item.
+	 */
+	public T getItem() {
+		if (item == null) {
+			throw new IllegalStateException("getItem() cannot be called on an absent item");
+		}
+		return item;
+	}
+	
+	/** Returns true if there is an item associated with the config action.
+	 * @return true if this ConfigItem contains an item.
+	 */
+	public boolean hasItem() {
+		return item != null;
+	}
+
+	/** Get the action associated with this ConfigItem.
+	 * @return the action.
+	 */
+	public A getAction() {
+		return action;
+	}
+	
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((action == null) ? 0 : action.hashCode());
+		result = prime * result + ((item == null) ? 0 : item.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ConfigItem<?, ?> other = (ConfigItem<?, ?>) obj;
+		if (action == null) {
+			if (other.action != null) {
+				return false;
+			}
+		} else if (!action.equals(other.action)) {
+			return false;
+		}
+		if (item == null) {
+			if (other.item != null) {
+				return false;
+			}
+		} else if (!item.equals(other.item)) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/us/kbase/auth2/lib/config/ExternalConfig.java
+++ b/src/us/kbase/auth2/lib/config/ExternalConfig.java
@@ -2,6 +2,8 @@ package us.kbase.auth2.lib.config;
 
 import java.util.Map;
 
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+
 /** A configuration external to the Authentication instance. As a convenience, the Authorization
  * instance allows storing arbitrary configurations as key value pairs in Authorization
  * storage.
@@ -15,6 +17,6 @@ public interface ExternalConfig {
 	 * the authorization storage system.
 	 * @return a map of configuration key value pairs.
 	 */
-	Map<String, String> toMap();
+	Map<String, ConfigItem<String, Action>> toMap();
 	
 }

--- a/src/us/kbase/auth2/lib/config/ExternalConfigMapper.java
+++ b/src/us/kbase/auth2/lib/config/ExternalConfigMapper.java
@@ -2,7 +2,7 @@ package us.kbase.auth2.lib.config;
 
 import java.util.Map;
 
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 
 /** A mapper for mapping a set of key-value pairs into an ExternalConfig class. The Authentication
@@ -18,15 +18,13 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
  */
 public interface ExternalConfigMapper<T extends ExternalConfig> {
 	
-	//TODO NOW rename to customconfig
-
 	/** Convert a set of key-value pairs into an ExternalConfig instance. 
 	 * @param config the key-value pairs.
 	 * @return an ExternalConfig instance.
 	 * @throws ExternalConfigMappingException if the key-value pairs could not be mapped into
 	 * the ExternalConfig instance.
 	 */
-	T fromMap(Map<String, ConfigItem<String, ConfigState>> config)
+	T fromMap(Map<String, ConfigItem<String, State>> config)
 			throws ExternalConfigMappingException;
 	
 }

--- a/src/us/kbase/auth2/lib/config/ExternalConfigMapper.java
+++ b/src/us/kbase/auth2/lib/config/ExternalConfigMapper.java
@@ -2,6 +2,7 @@ package us.kbase.auth2.lib.config;
 
 import java.util.Map;
 
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 
 /** A mapper for mapping a set of key-value pairs into an ExternalConfig class. The Authentication
@@ -16,6 +17,8 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
  * @param <T> the type of the ExternalConfig that is the target of the mapper.
  */
 public interface ExternalConfigMapper<T extends ExternalConfig> {
+	
+	//TODO NOW rename to customconfig
 
 	/** Convert a set of key-value pairs into an ExternalConfig instance. 
 	 * @param config the key-value pairs.
@@ -23,6 +26,7 @@ public interface ExternalConfigMapper<T extends ExternalConfig> {
 	 * @throws ExternalConfigMappingException if the key-value pairs could not be mapped into
 	 * the ExternalConfig instance.
 	 */
-	T fromMap(Map<String, String> config) throws ExternalConfigMappingException;
+	T fromMap(Map<String, ConfigItem<String, ConfigState>> config)
+			throws ExternalConfigMappingException;
 	
 }

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -55,7 +55,7 @@ import us.kbase.auth2.lib.Utils;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
@@ -1648,7 +1648,7 @@ public class MongoStorage implements AuthStorage {
 		nonNull(mapper, "mapper");
 		try {
 			final FindIterable<Document> extiter = db.getCollection(COL_CONFIG_EXTERNAL).find();
-			final Map<String, ConfigItem<String, ConfigState>> ext = new HashMap<>();
+			final Map<String, ConfigItem<String, State>> ext = new HashMap<>();
 			for (final Document d: extiter) {
 				ext.put(d.getString(Fields.CONFIG_KEY),
 						ConfigItem.state(d.getString(Fields.CONFIG_VALUE)));

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -54,6 +54,9 @@ import us.kbase.auth2.lib.UserUpdate;
 import us.kbase.auth2.lib.Utils;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
@@ -1557,6 +1560,19 @@ public class MongoStorage implements AuthStorage {
 		updateConfig(COL_CONFIG_PROVIDERS, q, value, overwrite);
 	}
 	
+	private void removeConfig(final String collection, final String key, final boolean overwrite)
+			throws AuthStorageException {
+		if (!overwrite) {
+			return; // don't remove keys unless overwrite is specified
+		}
+		try {
+			db.getCollection(collection).deleteOne(new Document(Fields.CONFIG_KEY, key));
+		} catch (MongoException e) {
+			throw new AuthStorageException("Connection to database failed: " + e.getMessage(), e);
+		}
+	}
+
+	
 	@Override
 	public <T extends ExternalConfig> void updateConfig(
 			final AuthConfigSet<T> cfgSet,
@@ -1580,8 +1596,13 @@ public class MongoStorage implements AuthStorage {
 					e.getValue().isForceLinkChoice(), overwrite);
 		}
 		
-		for (final Entry<String, String> e: cfgSet.getExtcfg().toMap().entrySet()) {
-			updateConfig(COL_CONFIG_EXTERNAL, e.getKey(), e.getValue(), overwrite);
+		for (final Entry<String, ConfigItem<String, Action>> e:
+				cfgSet.getExtcfg().toMap().entrySet()) {
+			if (e.getValue().getAction().isSet()) {
+				updateConfig(COL_CONFIG_EXTERNAL, e.getKey(), e.getValue().getItem(), overwrite);
+			} else if (e.getValue().getAction().isRemove()) {
+				removeConfig(COL_CONFIG_EXTERNAL, e.getKey(), overwrite);
+			}
 		}
 	}
 	
@@ -1627,9 +1648,10 @@ public class MongoStorage implements AuthStorage {
 		nonNull(mapper, "mapper");
 		try {
 			final FindIterable<Document> extiter = db.getCollection(COL_CONFIG_EXTERNAL).find();
-			final Map<String, String> ext = new HashMap<>();
+			final Map<String, ConfigItem<String, ConfigState>> ext = new HashMap<>();
 			for (final Document d: extiter) {
-				ext.put(d.getString(Fields.CONFIG_KEY), d.getString(Fields.CONFIG_VALUE));
+				ext.put(d.getString(Fields.CONFIG_KEY),
+						ConfigItem.state(d.getString(Fields.CONFIG_VALUE)));
 			}
 			final Map<String, ProviderConfig> provs = getProviderConfig();
 			final Map<String, Document> appcfg = getAppConfig();

--- a/src/us/kbase/auth2/service/AppEventListener.java
+++ b/src/us/kbase/auth2/service/AppEventListener.java
@@ -3,12 +3,14 @@ package us.kbase.auth2.service;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import us.kbase.auth2.kbase.KBaseAuthConfig;
+
 public class AppEventListener implements ServletContextListener {
 	
 	@Override
 	public void contextInitialized(final ServletContextEvent arg0) {
 		// may want to make this configurable with the -D switch later
-		AuthenticationService.setConfig("us.kbase.auth2.kbase.KBaseAuthConfig");
+		AuthenticationService.setConfig(KBaseAuthConfig.class.getName());
 	}
 	
 	@Override

--- a/src/us/kbase/auth2/service/AuthExternalConfig.java
+++ b/src/us/kbase/auth2/service/AuthExternalConfig.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import us.kbase.auth2.lib.config.ConfigAction;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
@@ -175,26 +175,26 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 	}
 	
 	public static class AuthExternalConfigMapper implements
-			ExternalConfigMapper<AuthExternalConfig<ConfigState>> {
+			ExternalConfigMapper<AuthExternalConfig<State>> {
 
 		@Override
-		public AuthExternalConfig<ConfigState> fromMap(
-				final Map<String, ConfigItem<String, ConfigState>> config)
+		public AuthExternalConfig<State> fromMap(
+				final Map<String, ConfigItem<String, State>> config)
 				throws ExternalConfigMappingException {
-			final ConfigItem<URL, ConfigState> allowedPostLogin =
+			final ConfigItem<URL, State> allowedPostLogin =
 					getURL(config, ALLOWED_POST_LOGIN_REDIRECT_PREFIX);
-			final ConfigItem<URL, ConfigState> completeLogin =
+			final ConfigItem<URL, State> completeLogin =
 					getURL(config, COMPLETE_LOGIN_REDIRECT);
-			final ConfigItem<URL, ConfigState> postLink =
+			final ConfigItem<URL, State> postLink =
 					getURL(config, POST_LINK_REDIRECT);
-			final ConfigItem<URL, ConfigState> completeLink =
+			final ConfigItem<URL, State> completeLink =
 					getURL(config, COMPLETE_LINK_REDIRECT);
-			final ConfigItem<Boolean, ConfigState> ignoreIPs =
+			final ConfigItem<Boolean, State> ignoreIPs =
 					getBoolean(config, IGNORE_IP_HEADERS);
-			final ConfigItem<Boolean, ConfigState> includeStack =
+			final ConfigItem<Boolean, State> includeStack =
 					getBoolean(config, INCLUDE_STACK_TRACE_IN_RESPONSE);
 			try {
-				return new AuthExternalConfig<ConfigState>(allowedPostLogin, completeLogin,
+				return new AuthExternalConfig<State>(allowedPostLogin, completeLogin,
 						postLink, completeLink, ignoreIPs, includeStack);
 			} catch (IllegalParameterException e) {
 				throw new ExternalConfigMappingException(
@@ -202,11 +202,11 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 			}
 		}
 
-		private ConfigItem<URL, ConfigState> getURL(
-				final Map<String, ConfigItem<String, ConfigState>> config, final String key)
+		private ConfigItem<URL, State> getURL(
+				final Map<String, ConfigItem<String, State>> config, final String key)
 				throws ExternalConfigMappingException {
-			final ConfigItem<String, ConfigState> url = config.get(key);
-			final ConfigItem<URL, ConfigState> allowed;
+			final ConfigItem<String, State> url = config.get(key);
+			final ConfigItem<URL, State> allowed;
 			if (url == null || !url.hasItem()) {
 				allowed = ConfigItem.emptyState();
 			} else {
@@ -222,12 +222,12 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 			return allowed;
 		}
 
-		private ConfigItem<Boolean, ConfigState> getBoolean(
-				final Map<String, ConfigItem<String, ConfigState>> config,
+		private ConfigItem<Boolean, State> getBoolean(
+				final Map<String, ConfigItem<String, State>> config,
 				final String paramName)
 				throws ExternalConfigMappingException {
-			final ConfigItem<String, ConfigState> value = config.get(paramName);
-			final ConfigItem<Boolean, ConfigState> ret;
+			final ConfigItem<String, State> value = config.get(paramName);
+			final ConfigItem<Boolean, State> ret;
 			if (value == null || !value.hasItem()) {
 				ret = ConfigItem.emptyState();
 			} else if (TRUE.equals(value.getItem())) {

--- a/src/us/kbase/auth2/service/AuthenticationService.java
+++ b/src/us/kbase/auth2/service/AuthenticationService.java
@@ -52,7 +52,7 @@ public class AuthenticationService extends ResourceConfig {
 		quietLogger();
 		logger = cfg.getLogger();
 		try {
-			buildApp(cfg, AuthExternalConfig.DEFAULT);
+			buildApp(cfg, AuthExternalConfig.SET_DEFAULT);
 		} catch (StorageInitException e) {
 			LoggerFactory.getLogger(getClass()).error(
 					"Failed to initialize storage engine: " + e.getMessage(),

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Context;
 import org.slf4j.LoggerFactory;
 
 import us.kbase.auth2.lib.Authentication;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
@@ -41,7 +41,7 @@ public class LoggingFilter implements ContainerRequestFilter,
 			throws IOException {
 		boolean ignoreIPheaders = true;
 		try {
-			final AuthExternalConfig<ConfigState> ext = auth.getExternalConfig(
+			final AuthExternalConfig<State> ext = auth.getExternalConfig(
 					new AuthExternalConfigMapper());
 			ignoreIPheaders = ext.isIgnoreIPHeadersOrDefault();
 		} catch (AuthStorageException | ExternalConfigMappingException e) {

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Context;
 import org.slf4j.LoggerFactory;
 
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
@@ -40,9 +41,9 @@ public class LoggingFilter implements ContainerRequestFilter,
 			throws IOException {
 		boolean ignoreIPheaders = true;
 		try {
-			final AuthExternalConfig ext = auth.getExternalConfig(
+			final AuthExternalConfig<ConfigState> ext = auth.getExternalConfig(
 					new AuthExternalConfigMapper());
-			ignoreIPheaders = ext.isIgnoreIPHeaders();
+			ignoreIPheaders = ext.isIgnoreIPHeadersOrDefault();
 		} catch (AuthStorageException | ExternalConfigMappingException e) {
 			LoggerFactory.getLogger(getClass()).error(
 					"An error occurred in the logger when attempting " +

--- a/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 
 import us.kbase.auth2.lib.Authentication;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig;
@@ -59,7 +59,7 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 
 		boolean includeStack = false;
 		try {
-			final AuthExternalConfig<ConfigState> ext = auth.getExternalConfig(
+			final AuthExternalConfig<State> ext = auth.getExternalConfig(
 					new AuthExternalConfigMapper());
 			includeStack = ext.isIncludeStackTraceInResponseOrDefault();
 		} catch (AuthStorageException | ExternalConfigMappingException e) {

--- a/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig;
@@ -58,9 +59,9 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 
 		boolean includeStack = false;
 		try {
-			final AuthExternalConfig ext = auth.getExternalConfig(
+			final AuthExternalConfig<ConfigState> ext = auth.getExternalConfig(
 					new AuthExternalConfigMapper());
-			includeStack = ext.isIncludeStackTraceInResponse();
+			includeStack = ext.isIncludeStackTraceInResponseOrDefault();
 		} catch (AuthStorageException | ExternalConfigMappingException e) {
 			LoggerFactory.getLogger(getClass()).error(
 					"An error occurred in the error handler when attempting " +

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -52,7 +52,7 @@ import us.kbase.auth2.lib.UserSearchSpec;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
 import us.kbase.auth2.lib.config.AuthConfig.TokenLifetimeType;
@@ -532,7 +532,7 @@ public class Admin {
 			@Context final UriInfo uriInfo)
 			throws InvalidTokenException, UnauthorizedException,
 			NoTokenProvidedException, AuthStorageException {
-		final AuthConfigSet<AuthExternalConfig<ConfigState>> cfgset;
+		final AuthConfigSet<AuthExternalConfig<State>> cfgset;
 		try {
 			cfgset = auth.getConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					new AuthExternalConfigMapper());
@@ -555,15 +555,15 @@ public class Admin {
 		}
 		ret.put("showstack", cfgset.getExtcfg().isIncludeStackTraceInResponseOrDefault());
 		ret.put("ignoreip", cfgset.getExtcfg().isIgnoreIPHeadersOrDefault());
-		final ConfigItem<URL, ConfigState> loginallowed =
+		final ConfigItem<URL, State> loginallowed =
 				cfgset.getExtcfg().getAllowedLoginRedirectPrefix();
 		ret.put("allowedloginredirect", loginallowed.hasItem() ? loginallowed.getItem() : null);
-		final ConfigItem<URL, ConfigState> logincomplete =
+		final ConfigItem<URL, State> logincomplete =
 				cfgset.getExtcfg().getCompleteLoginRedirect();
 		ret.put("completeloginredirect", logincomplete.hasItem() ? logincomplete.getItem() : null);
-		final ConfigItem<URL, ConfigState> postlink = cfgset.getExtcfg().getPostLinkRedirect();
+		final ConfigItem<URL, State> postlink = cfgset.getExtcfg().getPostLinkRedirect();
 		ret.put("postlinkredirect", postlink.hasItem() ? postlink.getItem() : null);
-		final ConfigItem<URL, ConfigState> completelink =
+		final ConfigItem<URL, State> completelink =
 				cfgset.getExtcfg().getCompleteLinkRedirect();
 		ret.put("completelinkredirect", completelink.hasItem() ? completelink.getItem() : null);
 		

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -51,6 +51,9 @@ import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserSearchSpec;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
 import us.kbase.auth2.lib.config.AuthConfig.TokenLifetimeType;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
@@ -529,7 +532,7 @@ public class Admin {
 			@Context final UriInfo uriInfo)
 			throws InvalidTokenException, UnauthorizedException,
 			NoTokenProvidedException, AuthStorageException {
-		final AuthConfigSet<AuthExternalConfig> cfgset;
+		final AuthConfigSet<AuthExternalConfig<ConfigState>> cfgset;
 		try {
 			cfgset = auth.getConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					new AuthExternalConfigMapper());
@@ -550,12 +553,19 @@ public class Admin {
 			p.put("forceloginchoice", e.getValue().isForceLoginChoice());
 			prov.add(p);
 		}
-		ret.put("showstack", cfgset.getExtcfg().isIncludeStackTraceInResponse());
-		ret.put("ignoreip", cfgset.getExtcfg().isIgnoreIPHeaders());
-		ret.put("allowedloginredirect", cfgset.getExtcfg().getAllowedLoginRedirectPrefix());
-		ret.put("completeloginredirect", cfgset.getExtcfg().getCompleteLoginRedirect());
-		ret.put("postlinkredirect", cfgset.getExtcfg().getPostLinkRedirect());
-		ret.put("completelinkredirect", cfgset.getExtcfg().getCompleteLinkRedirect());
+		ret.put("showstack", cfgset.getExtcfg().isIncludeStackTraceInResponseOrDefault());
+		ret.put("ignoreip", cfgset.getExtcfg().isIgnoreIPHeadersOrDefault());
+		final ConfigItem<URL, ConfigState> loginallowed =
+				cfgset.getExtcfg().getAllowedLoginRedirectPrefix();
+		ret.put("allowedloginredirect", loginallowed.hasItem() ? loginallowed.getItem() : null);
+		final ConfigItem<URL, ConfigState> logincomplete =
+				cfgset.getExtcfg().getCompleteLoginRedirect();
+		ret.put("completeloginredirect", logincomplete.hasItem() ? logincomplete.getItem() : null);
+		final ConfigItem<URL, ConfigState> postlink = cfgset.getExtcfg().getPostLinkRedirect();
+		ret.put("postlinkredirect", postlink.hasItem() ? postlink.getItem() : null);
+		final ConfigItem<URL, ConfigState> completelink =
+				cfgset.getExtcfg().getCompleteLinkRedirect();
+		ret.put("completelinkredirect", completelink.hasItem() ? completelink.getItem() : null);
 		
 		ret.put("allowlogin", cfgset.getCfg().isLoginAllowed());
 		ret.put("tokensugcache", cfgset.getCfg().getTokenLifetimeMS(
@@ -590,14 +600,15 @@ public class Admin {
 			throws IllegalParameterException, InvalidTokenException,
 			UnauthorizedException, NoTokenProvidedException,
 			AuthStorageException {
-		final URL postlogin = getURL(allowedloginredirect);
-		final URL completelogin = getURL(completeloginredirect);
-		final URL postlink = getURL(postlinkredirect);
-		final URL completelink = getURL(completelinkredirect);
+		final ConfigItem<URL, Action> postlogin = getURL(allowedloginredirect);
+		final ConfigItem<URL, Action> completelogin = getURL(completeloginredirect);
+		final ConfigItem<URL, Action> postlink = getURL(postlinkredirect);
+		final ConfigItem<URL, Action> completelink = getURL(completelinkredirect);
+		final ConfigItem<Boolean, Action> ignore = ConfigItem.set(!nullOrEmpty(ignoreip));
+		final ConfigItem<Boolean, Action> stack = ConfigItem.set(!nullOrEmpty(showstack));
 		
-		final AuthExternalConfig ext = new AuthExternalConfig(
-				postlogin, completelogin, postlink, completelink,
-				!nullOrEmpty(ignoreip), !nullOrEmpty(showstack));
+		final AuthExternalConfig<Action> ext = new AuthExternalConfig<>(
+				postlogin, completelogin, postlink, completelink, ignore, stack);
 		try {
 			auth.updateConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					new AuthConfigSet<>(new AuthConfig(!nullOrEmpty(allowLogin), null, null),
@@ -607,13 +618,14 @@ public class Admin {
 		}
 	}
 
-	private URL getURL(final String putativeURL) throws IllegalParameterException {
-		final URL redirect;
-		if (putativeURL == null || putativeURL.isEmpty()) {
-			redirect = null;
+	private ConfigItem<URL, Action> getURL(final String putativeURL)
+			throws IllegalParameterException {
+		final ConfigItem<URL, Action> redirect;
+		if (putativeURL == null || putativeURL.trim().isEmpty()) {
+			redirect = ConfigItem.remove();
 		} else {
 			try {
-				redirect = new URL(putativeURL);
+				redirect = ConfigItem.set(new URL(putativeURL));
 			} catch (MalformedURLException e) {
 				throw new IllegalParameterException("Illegal URL: " + putativeURL, e);
 			}

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -43,6 +43,8 @@ import com.google.common.base.Optional;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.LinkIdentities;
 import us.kbase.auth2.lib.LinkToken;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
@@ -210,36 +212,36 @@ public class Link {
 	
 	// the two methods below are very similar and there's another similar method in Login
 	private URI getCompleteLinkRedirectURI(final String deflt) throws AuthStorageException {
-		final URL url;
+		final ConfigItem<URL, ConfigState> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getCompleteLinkRedirect();
 		} catch (ExternalConfigMappingException e) {
 			throw new RuntimeException("Dude, like, what just happened?", e);
 		}
-		if (url == null) {
+		if (!url.hasItem()) {
 			return toURI(deflt);
 		}
 		try {
-			return url.toURI();
+			return url.getItem().toURI();
 		} catch (URISyntaxException e) {
 			throw new RuntimeException("this should be impossible" , e);
 		}
 	}
 	
 	private URI getPostLinkRedirectURI(final String deflt) throws AuthStorageException {
-		final URL url;
+		final ConfigItem<URL, ConfigState> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getPostLinkRedirect();
 		} catch (ExternalConfigMappingException e) {
 			throw new RuntimeException("Dude, like, what just happened?", e);
 		}
-		if (url == null) {
+		if (!url.hasItem()) {
 			return toURI(deflt);
 		}
 		try {
-			return url.toURI();
+			return url.getItem().toURI();
 		} catch (URISyntaxException e) {
 			throw new RuntimeException("this should be impossible" , e);
 		}

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -43,7 +43,7 @@ import com.google.common.base.Optional;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.LinkIdentities;
 import us.kbase.auth2.lib.LinkToken;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
@@ -212,7 +212,7 @@ public class Link {
 	
 	// the two methods below are very similar and there's another similar method in Login
 	private URI getCompleteLinkRedirectURI(final String deflt) throws AuthStorageException {
-		final ConfigItem<URL, ConfigState> url;
+		final ConfigItem<URL, State> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getCompleteLinkRedirect();
@@ -230,7 +230,7 @@ public class Link {
 	}
 	
 	private URI getPostLinkRedirectURI(final String deflt) throws AuthStorageException {
-		final ConfigItem<URL, ConfigState> url;
+		final ConfigItem<URL, State> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getPostLinkRedirect();

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -49,6 +49,8 @@ import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
@@ -138,7 +140,7 @@ public class Login {
 	private URL getRedirectURL(final String redirect)
 			throws AuthStorageException, IllegalParameterException {
 		if (redirect != null && !redirect.trim().isEmpty()) {
-			final AuthExternalConfig ext;
+			final AuthExternalConfig<ConfigState> ext;
 			try {
 				ext = auth.getExternalConfig(new AuthExternalConfigMapper());
 			} catch (ExternalConfigMappingException e) {
@@ -150,8 +152,9 @@ public class Login {
 			} catch (MalformedURLException e) {
 				throw new IllegalParameterException("Illegal redirect URL: " + redirect);
 			}
-			if (ext.getAllowedLoginRedirectPrefix() != null) {
-				if (!redirect.startsWith(ext.getAllowedLoginRedirectPrefix().toString())) {
+			if (ext.getAllowedLoginRedirectPrefix().hasItem()) {
+				if (!redirect.startsWith(
+						ext.getAllowedLoginRedirectPrefix().getItem().toString())) {
 					throw new IllegalParameterException(
 							"Illegal redirect url: " + redirect);
 				}
@@ -291,18 +294,18 @@ public class Login {
 	}
 	
 	private URI getCompleteLoginRedirectURI(final String deflt) throws AuthStorageException {
-		final URL url;
+		final ConfigItem<URL, ConfigState> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getCompleteLoginRedirect();
 		} catch (ExternalConfigMappingException e) {
 			throw new RuntimeException("Dude, like, what just happened?", e);
 		}
-		if (url == null) {
+		if (!url.hasItem()) {
 			return toURI(deflt);
 		}
 		try {
-			return url.toURI();
+			return url.getItem().toURI();
 		} catch (URISyntaxException e) {
 			throw new RuntimeException("this should be impossible" , e);
 		}

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -49,7 +49,7 @@ import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.UserName;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
@@ -140,7 +140,7 @@ public class Login {
 	private URL getRedirectURL(final String redirect)
 			throws AuthStorageException, IllegalParameterException {
 		if (redirect != null && !redirect.trim().isEmpty()) {
-			final AuthExternalConfig<ConfigState> ext;
+			final AuthExternalConfig<State> ext;
 			try {
 				ext = auth.getExternalConfig(new AuthExternalConfigMapper());
 			} catch (ExternalConfigMappingException e) {
@@ -294,7 +294,7 @@ public class Login {
 	}
 	
 	private URI getCompleteLoginRedirectURI(final String deflt) throws AuthStorageException {
-		final ConfigItem<URL, ConfigState> url;
+		final ConfigItem<URL, State> url;
 		try {
 			url = auth.getExternalConfig(new AuthExternalConfigMapper())
 					.getCompleteLoginRedirect();

--- a/src/us/kbase/test/auth2/StartAuthServer.java
+++ b/src/us/kbase/test/auth2/StartAuthServer.java
@@ -5,13 +5,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.glassfish.jersey.servlet.ServletContainer;
 
+import us.kbase.auth2.kbase.KBaseAuthConfig;
 import us.kbase.auth2.service.AuthenticationService;
 
 public class StartAuthServer {
 
 	public static void main(String[] args) throws Exception {
 
-		AuthenticationService.setConfig("us.kbase.auth2.kbase.KBaseAuthConfig");
+		AuthenticationService.setConfig(KBaseAuthConfig.class.getName());
 		
 		final Server server = new Server(Integer.valueOf(args[0]));
 

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -32,7 +32,7 @@ import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
 import us.kbase.auth2.lib.config.CollectingExternalConfig.CollectingExternalConfigMapper;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.identity.IdentityProvider;
 import us.kbase.auth2.lib.identity.IdentityProviderConfig;
@@ -47,7 +47,7 @@ import us.kbase.test.auth2.lib.config.TestExternalConfig.TestExternalConfigMappe
 public class AuthenticationConstructorTest {
 	
 	private static final ConfigItem<String, Action> SET_FOO = ConfigItem.set("foo");
-	private static final ConfigItem<String, ConfigState> STATE_FOO = ConfigItem.state("foo");
+	private static final ConfigItem<String, State> STATE_FOO = ConfigItem.state("foo");
 	private static final ConfigItem<String, Action> SET_THINGY = ConfigItem.set("thingy");
 	
 	@Test
@@ -65,7 +65,7 @@ public class AuthenticationConstructorTest {
 		verify(storage).updateConfig(new AuthConfigSet<TestExternalConfig<Action>>(ac,
 				new TestExternalConfig<>(SET_THINGY)), false);
 		
-		final TestExternalConfig<ConfigState> t =
+		final TestExternalConfig<State> t =
 				auth.getExternalConfig(new TestExternalConfigMapper());
 		assertThat("incorrect external config", t, is(new TestExternalConfig<>(STATE_FOO)));
 		assertThat("incorrect providers", auth.getIdentityProviders(),

--- a/src/us/kbase/test/auth2/lib/AuthenticationTester.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTester.java
@@ -28,6 +28,7 @@ import us.kbase.auth2.lib.config.CollectingExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.identity.IdentityProvider;
 import us.kbase.auth2.lib.config.CollectingExternalConfig.CollectingExternalConfigMapper;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.storage.AuthStorage;
 import us.kbase.auth2.lib.user.LocalUser;
 import us.kbase.test.auth2.lib.config.TestExternalConfig;
@@ -64,15 +65,15 @@ public class AuthenticationTester {
 		final AuthConfig ac =  new AuthConfig(AuthConfig.DEFAULT_LOGIN_ALLOWED, null,
 				AuthConfig.DEFAULT_TOKEN_LIFETIMES_MS);
 		when(storage.getConfig(isA(CollectingExternalConfigMapper.class))).thenReturn(
-				new AuthConfigSet<>(ac,
-						new CollectingExternalConfig(ImmutableMap.of("thing", "foo"))));
+				new AuthConfigSet<>(ac, new CollectingExternalConfig(
+						ImmutableMap.of("thing", ConfigItem.state("foo")))));
 		
 		final Constructor<Authentication> c = Authentication.class.getDeclaredConstructor(
 				AuthStorage.class, Set.class, ExternalConfig.class,
 				RandomDataGenerator.class, Clock.class);
 		c.setAccessible(true);
 		final Authentication instance = c.newInstance(storage, providers,
-				new TestExternalConfig("foo"), randGen, clock);
+				new TestExternalConfig<>(ConfigItem.set("foo")), randGen, clock);
 		reset(storage);
 		return new TestMocks(storage, randGen, instance, clock);
 	}

--- a/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
@@ -15,6 +15,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
@@ -24,7 +25,95 @@ import us.kbase.test.auth2.TestCommon;
 
 public class AuthConfigTest {
 
+	@Test
+	public void configItemEquals() throws Exception {
+		EqualsVerifier.forClass(ConfigItem.class).usingGetClass().verify();
+	}
 	
+	@Test
+	public void configItemNoAction() throws Exception {
+		final ConfigItem<String, Action> ci = ConfigItem.noAction();
+		
+		assertThat("incorrect isstate", ci.getAction().isState(), is(false));
+		assertThat("incorrect isnoaction", ci.getAction().isNoAction(), is(true));
+		assertThat("incorrect isremove", ci.getAction().isRemove(), is(false));
+		assertThat("incorrect isset", ci.getAction().isSet(), is(false));
+		assertThat("incorrect hasItem", ci.hasItem(), is(false));
+		failGetItem(ci);
+	}
+	
+	@Test
+	public void configItemRemove() throws Exception {
+		final ConfigItem<String, Action> ci = ConfigItem.remove();
+		
+		assertThat("incorrect isstate", ci.getAction().isState(), is(false));
+		assertThat("incorrect isnoaction", ci.getAction().isNoAction(), is(false));
+		assertThat("incorrect isremove", ci.getAction().isRemove(), is(true));
+		assertThat("incorrect isset", ci.getAction().isSet(), is(false));
+		assertThat("incorrect hasItem", ci.hasItem(), is(false));
+		failGetItem(ci);
+	}
+	
+	@Test
+	public void configItemSet() throws Exception {
+		final ConfigItem<String, Action> ci = ConfigItem.set("foo");
+		
+		assertThat("incorrect isstate", ci.getAction().isState(), is(false));
+		assertThat("incorrect isnoaction", ci.getAction().isNoAction(), is(false));
+		assertThat("incorrect isremove", ci.getAction().isRemove(), is(false));
+		assertThat("incorrect isset", ci.getAction().isSet(), is(true));
+		assertThat("incorrect hasItem", ci.hasItem(), is(true));
+		assertThat("incorrect getItem", ci.getItem(), is("foo"));
+		
+		try {
+			ConfigItem.set(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("item"));
+		}
+	}
+	
+	@Test
+	public void configItemState() throws Exception {
+		final ConfigItem<String, State> ci = ConfigItem.state("foo");
+		
+		assertThat("incorrect isstate", ci.getAction().isState(), is(true));
+		assertThat("incorrect isnoaction", ci.getAction().isNoAction(), is(false));
+		assertThat("incorrect isremove", ci.getAction().isRemove(), is(false));
+		assertThat("incorrect isset", ci.getAction().isSet(), is(false));
+		assertThat("incorrect hasItem", ci.hasItem(), is(true));
+		assertThat("incorrect getItem", ci.getItem(), is("foo"));
+		
+		try {
+			ConfigItem.state(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("item"));
+		}
+	}
+	
+	@Test
+	public void configItemEmptyState() throws Exception {
+		final ConfigItem<String, State> ci = ConfigItem.emptyState();
+		
+		assertThat("incorrect isstate", ci.getAction().isState(), is(true));
+		assertThat("incorrect isnoaction", ci.getAction().isNoAction(), is(false));
+		assertThat("incorrect isremove", ci.getAction().isRemove(), is(false));
+		assertThat("incorrect isset", ci.getAction().isSet(), is(false));
+		assertThat("incorrect hasItem", ci.hasItem(), is(false));
+		failGetItem(ci);
+	}
+	
+	private void failGetItem(final ConfigItem<String, ?> ci) {
+		try {
+			ci.getItem();
+			fail("expected exception");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, new IllegalStateException(
+					"getItem() cannot be called on an absent item"));
+		}
+	}
+
 	@Test
 	public void defaults() throws Exception {
 		assertThat("incorrect login default", AuthConfig.DEFAULT_LOGIN_ALLOWED, is(false));

--- a/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
@@ -14,6 +14,8 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
@@ -220,8 +222,8 @@ public class AuthConfigTest {
 	class TestExtCfg implements ExternalConfig {
 
 		@Override
-		public Map<String, String> toMap() {
-			return ImmutableMap.of("foo", "bar");
+		public Map<String, ConfigItem<String, Action>> toMap() {
+			return ImmutableMap.of("foo", ConfigItem.set("bar"));
 		}
 		
 		@Override
@@ -241,7 +243,7 @@ public class AuthConfigTest {
 		assertThat("incorrect config token lifetimes", ac.getCfg().getTokenLifetimeMS(),
 				is(lts));
 		assertThat("incorrect ext config", ac.getExtcfg().toMap(),
-				is(ImmutableMap.of("foo", "bar")));
+				is(ImmutableMap.of("foo", ConfigItem.set("bar"))));
 		assertThat("incorrect toString", ac.toString(), is(
 				"AuthConfigSet [cfg=AuthConfig [loginAllowed=false, providers={}, " +
 				"tokenLifetimeMS={DEV=350000}], " +

--- a/src/us/kbase/test/auth2/lib/config/CollectingExternalConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/config/CollectingExternalConfigTest.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.config.CollectingExternalConfig;
 import us.kbase.auth2.lib.config.CollectingExternalConfig.CollectingExternalConfigMapper;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.test.auth2.TestCommon;
 
@@ -24,15 +25,29 @@ public class CollectingExternalConfigTest {
 	@Test
 	public void construct() {
 		final CollectingExternalConfig cfg = new CollectingExternalConfig(
-				ImmutableMap.of("foo", "bar"));
-		assertThat("incorrect config", cfg.toMap(), is(ImmutableMap.of("foo", "bar")));
+				ImmutableMap.of("foo", ConfigItem.state("bar")));
+		assertThat("incorrect config", cfg.getMap(),
+				is(ImmutableMap.of("foo", ConfigItem.state("bar"))));
 	}
 	
 	@Test
 	public void map() throws ExternalConfigMappingException {
 		final CollectingExternalConfig cfg = new CollectingExternalConfigMapper().fromMap(
-				ImmutableMap.of("baz", "bat"));
-		assertThat("incorrect config", cfg.toMap(), is(ImmutableMap.of("baz", "bat")));
+				ImmutableMap.of("baz", ConfigItem.state("bat")));
+		assertThat("incorrect config", cfg.getMap(),
+				is(ImmutableMap.of("baz", ConfigItem.state("bat"))));
+	}
+	
+	@Test
+	public void unsupportedOp() {
+		final CollectingExternalConfig cfg = new CollectingExternalConfig(
+				ImmutableMap.of("foo", ConfigItem.state("bar")));
+		try {
+			cfg.toMap();
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			// test passed
+		}
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/config/TestExternalConfig.java
+++ b/src/us/kbase/test/auth2/lib/config/TestExternalConfig.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth2.lib.config.ConfigAction;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
@@ -77,11 +77,11 @@ public class TestExternalConfig<T extends ConfigAction> implements ExternalConfi
 	}
 
 	public static class TestExternalConfigMapper implements
-			ExternalConfigMapper<TestExternalConfig<ConfigState>> {
+			ExternalConfigMapper<TestExternalConfig<State>> {
 
 		@Override
-		public TestExternalConfig<ConfigState> fromMap(
-				final Map<String, ConfigItem<String, ConfigState>> config)
+		public TestExternalConfig<State> fromMap(
+				final Map<String, ConfigItem<String, State>> config)
 				throws ExternalConfigMappingException {
 			
 			return new TestExternalConfig<>(config.get("thing"));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
@@ -13,7 +13,7 @@ import com.google.common.collect.ImmutableMap;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
-import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigAction.State;
 import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
@@ -25,15 +25,15 @@ import us.kbase.test.auth2.lib.config.TestExternalConfig.TestExternalConfigMappe
 
 public class MongoStorageConfigTest extends MongoStorageTester {
 	
-	private static final ConfigItem<String, ConfigState> STATE_FOO = ConfigItem.state("foo");
+	private static final ConfigItem<String, State> STATE_FOO = ConfigItem.state("foo");
 	
 	@Test
 	public void getEmptyConfig() throws Exception {
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(new AuthConfig(null, null, null)));
 		assertThat("incorrect external config", res.getExtcfg().aThing,
-				is((ConfigItem<String, ConfigState>) null));
+				is((ConfigItem<String, State>) null));
 	}
 	
 	@Test
@@ -56,7 +56,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.AGENT, 300000L,
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.SERV, 500000L));
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
@@ -82,7 +82,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L));
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
@@ -123,7 +123,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
@@ -164,7 +164,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 600000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing,
@@ -184,11 +184,11 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		storage.updateConfig(cfgSet2, true);
 		
 		final AuthConfig expected = new AuthConfig(true, null, null);
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing,
-				is((ConfigItem<String, ConfigState>) null));
+				is((ConfigItem<String, State>) null));
 	}
 	
 	@Test
@@ -204,7 +204,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 		storage.updateConfig(cfgSet2, false);
 		
 		final AuthConfig expected = new AuthConfig(true, null, null);
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
@@ -246,17 +246,17 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 300000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<State>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
 		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
-	private class BadMapper implements ExternalConfigMapper<TestExternalConfig<ConfigState>> {
+	private class BadMapper implements ExternalConfigMapper<TestExternalConfig<State>> {
 
 		@Override
-		public TestExternalConfig<ConfigState> fromMap(
-				final Map<String, ConfigItem<String, ConfigState>> config)
+		public TestExternalConfig<State> fromMap(
+				final Map<String, ConfigItem<String, State>> config)
 				throws ExternalConfigMappingException {
 			throw new ExternalConfigMappingException("borkborkbork");
 		}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageConfigTest.java
@@ -12,6 +12,9 @@ import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.ConfigAction.Action;
+import us.kbase.auth2.lib.config.ConfigAction.ConfigState;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
 import us.kbase.auth2.lib.config.AuthConfig.ProviderConfig;
 import us.kbase.auth2.lib.config.AuthConfig.TokenLifetimeType;
@@ -22,17 +25,20 @@ import us.kbase.test.auth2.lib.config.TestExternalConfig.TestExternalConfigMappe
 
 public class MongoStorageConfigTest extends MongoStorageTester {
 	
+	private static final ConfigItem<String, ConfigState> STATE_FOO = ConfigItem.state("foo");
+	
 	@Test
 	public void getEmptyConfig() throws Exception {
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(new AuthConfig(null, null, null)));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is((String) null));
+		assertThat("incorrect external config", res.getExtcfg().aThing,
+				is((ConfigItem<String, ConfigState>) null));
 	}
 	
 	@Test
 	public void updateConfigAndGetWithAllTokenLifeTimes() throws Exception {
-		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true, null,
 						ImmutableMap.of(
 								TokenLifetimeType.EXT_CACHE, 100000L,
@@ -40,7 +46,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 								TokenLifetimeType.AGENT, 300000L,
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.SERV, 500000L)),
-				new TestExternalConfig("foo"));
+				new TestExternalConfig<>(ConfigItem.set("foo")));
 		storage.updateConfig(cfgSet, false);
 		
 		final AuthConfig expected = new AuthConfig(true, null,
@@ -50,15 +56,15 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.AGENT, 300000L,
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.SERV, 500000L));
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo"));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
 	@Test
 	public void updateConfigAndGet() throws Exception {
-		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(false, true, false),
@@ -66,7 +72,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
-				new TestExternalConfig("foo"));
+				new TestExternalConfig<>(ConfigItem.set("foo")));
 		storage.updateConfig(cfgSet, false);
 		
 		final AuthConfig expected = new AuthConfig(true,
@@ -76,15 +82,15 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 				ImmutableMap.of(
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L));
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo"));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
 	@Test
 	public void updateConfigWithoutOverwrite() throws Exception {
-		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(false, true, false),
@@ -92,10 +98,10 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
-				new TestExternalConfig("foo"));
+				new TestExternalConfig<>(ConfigItem.set("foo")));
 		storage.updateConfig(cfgSet, false);
 		
-		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(false,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(true, true, true),
@@ -105,7 +111,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.LOGIN, 600000L,
 								TokenLifetimeType.SERV, 800000L)),
-				new TestExternalConfig("foo1"));
+				new TestExternalConfig<>(ConfigItem.set("foo1")));
 		storage.updateConfig(cfgSet2, false);
 		
 		final AuthConfig expected = new AuthConfig(true,
@@ -117,15 +123,15 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 200000L,
 						TokenLifetimeType.LOGIN, 300000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo"));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
 	@Test
 	public void updateConfigWithOverwrite() throws Exception {
-		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(false, true, false),
@@ -133,10 +139,10 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
-				new TestExternalConfig("foo"));
+				new TestExternalConfig<>(ConfigItem.set("foo")));
 		storage.updateConfig(cfgSet, false);
 		
-		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(false,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(true, true, true),
@@ -146,7 +152,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.LOGIN, 600000L,
 								TokenLifetimeType.SERV, 800000L)),
-				new TestExternalConfig("foo1"));
+				new TestExternalConfig<>(ConfigItem.set("foo1")));
 		storage.updateConfig(cfgSet2, true);
 		
 		final AuthConfig expected = new AuthConfig(false,
@@ -158,17 +164,57 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 600000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo1"));
+		assertThat("incorrect external config", res.getExtcfg().aThing,
+				is(ConfigItem.state("foo1")));
+	}
+	
+	@Test
+	public void updateConfigRemoveExternal() throws Exception {
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
+				new AuthConfig(true, null, null),
+				new TestExternalConfig<>(ConfigItem.set("foo")));
+		storage.updateConfig(cfgSet, false);
+		
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet2 = new AuthConfigSet<>(
+				new AuthConfig(true, null, null),
+				new TestExternalConfig<>(ConfigItem.remove()));
+		storage.updateConfig(cfgSet2, true);
+		
+		final AuthConfig expected = new AuthConfig(true, null, null);
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+				new TestExternalConfigMapper());
+		assertThat("incorrect config", res.getCfg(), is(expected));
+		assertThat("incorrect external config", res.getExtcfg().aThing,
+				is((ConfigItem<String, ConfigState>) null));
+	}
+	
+	@Test
+	public void updateConfigRemoveExternalWithoutOverwrite() throws Exception {
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
+				new AuthConfig(true, null, null),
+				new TestExternalConfig<>(ConfigItem.set("foo")));
+		storage.updateConfig(cfgSet, false);
+		
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet2 = new AuthConfigSet<>(
+				new AuthConfig(true, null, null),
+				new TestExternalConfig<>(ConfigItem.remove()));
+		storage.updateConfig(cfgSet2, false);
+		
+		final AuthConfig expected = new AuthConfig(true, null, null);
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
+				new TestExternalConfigMapper());
+		assertThat("incorrect config", res.getCfg(), is(expected));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
 	@Test
 	public void updateConfigWithOverwriteAndNullValues() throws Exception {
 		// tests that a null value causes no update
 		// if you believe Google (and I probably should) I should use an Optional instead of nulls
-		final AuthConfigSet<TestExternalConfig> cfgSet = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet = new AuthConfigSet<>(
 				new AuthConfig(true,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(false, true, false),
@@ -176,10 +222,10 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 200000L,
 								TokenLifetimeType.LOGIN, 300000L)),
-				new TestExternalConfig("foo"));
+				new TestExternalConfig<>(ConfigItem.set("foo")));
 		storage.updateConfig(cfgSet, false);
 		
-		final AuthConfigSet<TestExternalConfig> cfgSet2 = new AuthConfigSet<>(
+		final AuthConfigSet<TestExternalConfig<Action>> cfgSet2 = new AuthConfigSet<>(
 				new AuthConfig(null,
 						ImmutableMap.of(
 								"prov1", new ProviderConfig(true, true, true),
@@ -188,7 +234,7 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						ImmutableMap.of(
 								TokenLifetimeType.DEV, 400000L,
 								TokenLifetimeType.SERV, 800000L)),
-				new TestExternalConfig(null));
+				new TestExternalConfig<>(ConfigItem.noAction()));
 		storage.updateConfig(cfgSet2, true);
 		
 		final AuthConfig expected = new AuthConfig(true,
@@ -200,16 +246,17 @@ public class MongoStorageConfigTest extends MongoStorageTester {
 						TokenLifetimeType.DEV, 400000L,
 						TokenLifetimeType.LOGIN, 300000L,
 						TokenLifetimeType.SERV, 800000L));
-		final AuthConfigSet<TestExternalConfig> res = storage.getConfig(
+		final AuthConfigSet<TestExternalConfig<ConfigState>> res = storage.getConfig(
 				new TestExternalConfigMapper());
 		assertThat("incorrect config", res.getCfg(), is(expected));
-		assertThat("incorrect external config", res.getExtcfg().aThing, is("foo"));
+		assertThat("incorrect external config", res.getExtcfg().aThing, is(STATE_FOO));
 	}
 	
-	private class BadMapper implements ExternalConfigMapper<TestExternalConfig> {
+	private class BadMapper implements ExternalConfigMapper<TestExternalConfig<ConfigState>> {
 
 		@Override
-		public TestExternalConfig fromMap(final Map<String, String> config)
+		public TestExternalConfig<ConfigState> fromMap(
+				final Map<String, ConfigItem<String, ConfigState>> config)
 				throws ExternalConfigMappingException {
 			throw new ExternalConfigMappingException("borkborkbork");
 		}

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -5,7 +5,8 @@
 
 <form action="{{basicurl}}" method="post">
 
-<p>Allow non-admin login. This does not stop currently logged-in users from using the system:
+<p>Allow non-admin login. Disabling this does not stop currently logged-in users from using the
+system:
 <input type="checkbox" name="allowlogin" {{#allowlogin}}checked{{/allowlogin}}/>
 </p>
 


### PR DESCRIPTION
The user facing benefit is that now external config items (e.g. urls) can be removed. Currently once a url is set it can be replaced by another url but not removed.

Refactored external configuration to allow setting a new value, removing the value, or taking no action per value on an update.

Phase 2 is cleanup, handling any remaining config related TODOs, and adding / modifying tests for changed code that already has tests.

Phase 3 is completing config testing on the Authorization class.