### PR TITLE
Fix leaking password hashes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -236,6 +236,7 @@
       <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
       <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
       <test name="us.kbase.test.auth2.lib.NameTest"/>
+      <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
       <test name="us.kbase.test.auth2.lib.PasswordTest"/>
       <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
       <test name="us.kbase.test.auth2.lib.RoleTest"/>

--- a/src/us/kbase/auth2/lib/PasswordHashAndSalt.java
+++ b/src/us/kbase/auth2/lib/PasswordHashAndSalt.java
@@ -1,0 +1,53 @@
+package us.kbase.auth2.lib;
+
+/** Wrapper around credentials for a user, consisting of a hashed password and a salt used to
+ * hash that password.
+ * 
+ * Note that the password and salt are not copied in the constructor and therefore changes to the
+ * input arrays will be reflected in the class. For this reason equals() and hashCode() are not
+ * implemented.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class PasswordHashAndSalt {
+	
+	final byte[] passwordHash;
+	final byte[] salt;
+	
+	/** Create user credentials. Note this class can be mutated by manipulating the input arrays.
+	 * @param passwordHash the hash of the a user's password.
+	 * @param salt the salt used when hashing the password.
+	 */
+	public PasswordHashAndSalt(byte[] passwordHash, byte[] salt) {
+		// what's the right # here? Have to rely on user to some extent
+		if (passwordHash == null || passwordHash.length < 10) {
+			throw new IllegalArgumentException("passwordHash missing or too small");
+		}
+		if (salt == null || salt.length < 2) {
+			throw new IllegalArgumentException("salt missing or too small");
+		}
+		this.passwordHash = passwordHash;
+		this.salt = salt;
+	}
+
+	/** Get the password hash. Note that mutating the returned array will mutate this class.
+	 * @return the password hash.
+	 */
+	public byte[] getPasswordHash() {
+		return passwordHash;
+	}
+
+	/** Get the salt. Note that mutating the returned array will mutate this class.
+	 * @return the salt.
+	 */
+	public byte[] getSalt() {
+		return salt;
+	}
+	
+	/** Zero the contents of the hash and salt arrays. */
+	public void clear() {
+		Utils.clear(passwordHash);
+		Utils.clear(salt);
+	}
+
+}

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -9,6 +9,7 @@ import com.google.common.base.Optional;
 
 import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.PasswordHashAndSalt;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
@@ -24,6 +25,7 @@ import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityException;
+import us.kbase.auth2.lib.exceptions.NoSuchLocalUserException;
 import us.kbase.auth2.lib.exceptions.NoSuchRoleException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
 import us.kbase.auth2.lib.exceptions.NoSuchUserException;
@@ -50,25 +52,34 @@ public interface AuthStorage {
 	
 	/** Create a new local account.
 	 * @param local the user to create.
+	 * @param creds the credentials to assign to the user.
 	 * @throws UserExistsException if the user already exists.
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 * @throws NoSuchRoleException if a custom role provided with the user doesn't exist.
 	 */
-	void createLocalUser(LocalUser local)
+	void createLocalUser(LocalUser local, PasswordHashAndSalt creds)
 			throws AuthStorageException, UserExistsException, NoSuchRoleException;
-
+	
+	/** Get the user's credentials.
+	 * @param userName the name of the user.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 * @throws NoSuchLocalUserException if the local user does not exist.
+	 */
+	PasswordHashAndSalt getPasswordHashAndSalt(UserName userName)
+			throws AuthStorageException, NoSuchLocalUserException;
+	
 	/** Change a local user's password.
 	 * @param name the name of the user.
-	 * @param pwdHash the new encrypted password.
-	 * @param salt the salt used to encrypt the password.
+	 * @param creds the new hashed password and salt.
 	 * @param forceReset whether the user should be forced to reset their password on the next
 	 * login.
 	 * @throws NoSuchUserException if the user doesn't exist or is not a local user.
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	void changePassword(UserName name, byte[] pwdHash, byte[] salt, boolean forceReset)
+	void changePassword(UserName name, PasswordHashAndSalt creds, boolean forceReset)
 			throws NoSuchUserException, AuthStorageException;
 	
 	/** Force a local user to reset their password on the next login.
@@ -169,11 +180,12 @@ public interface AuthStorage {
 	/** Get a local user.
 	 * @param userName the user to get.
 	 * @return a local user.
-	 * @throws NoSuchUserException if the local user does not exist.
+	 * @throws NoSuchLocalUserException if the local user does not exist.
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	LocalUser getLocalUser(UserName userName) throws AuthStorageException, NoSuchUserException;
+	LocalUser getLocalUser(UserName userName)
+			throws AuthStorageException, NoSuchLocalUserException;
 	
 	/** Update the display name and/or email address for a user.
 	 * @param userName the user to update.

--- a/src/us/kbase/auth2/lib/user/LocalUser.java
+++ b/src/us/kbase/auth2/lib/user/LocalUser.java
@@ -3,7 +3,6 @@ package us.kbase.auth2.lib.user;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -24,8 +23,6 @@ import us.kbase.auth2.lib.UserName;
  */
 public class LocalUser extends AuthUser {
 	
-	private final byte[] passwordHash;
-	private final byte[] salt;
 	private final boolean forceReset;
 	private final Optional<Instant> lastReset;
 	
@@ -39,30 +36,12 @@ public class LocalUser extends AuthUser {
 			final Map<PolicyID, Instant> policyIDs,
 			final Optional<Instant> lastLogin,
 			final UserDisabledState disabledState,
-			final byte[] passwordHash,
-			final byte[] salt,
 			final boolean forceReset,
 			final Optional<Instant> lastReset) {
 		super(userName, displayName, created, Collections.emptySet(), email, roles, customRoles,
 				policyIDs, lastLogin, disabledState);
-		this.passwordHash = passwordHash;
-		this.salt = salt;
 		this.forceReset = forceReset;
 		this.lastReset = lastReset;
-	}
-
-	/** Get the salted hash of the user's password.
-	 * @return the password.
-	 */
-	public byte[] getPasswordHash() {
-		return passwordHash;
-	}
-
-	/** Get the salt for the user's password.
-	 * @return the password's salt.
-	 */
-	public byte[] getSalt() {
-		return salt;
 	}
 
 	/** Check if a password reset is required on next login.
@@ -85,8 +64,6 @@ public class LocalUser extends AuthUser {
 		int result = super.hashCode();
 		result = prime * result + (forceReset ? 1231 : 1237);
 		result = prime * result + ((lastReset == null) ? 0 : lastReset.hashCode());
-		result = prime * result + Arrays.hashCode(passwordHash);
-		result = prime * result + Arrays.hashCode(salt);
 		return result;
 	}
 
@@ -112,12 +89,6 @@ public class LocalUser extends AuthUser {
 		} else if (!lastReset.equals(other.lastReset)) {
 			return false;
 		}
-		if (!Arrays.equals(passwordHash, other.passwordHash)) {
-			return false;
-		}
-		if (!Arrays.equals(salt, other.salt)) {
-			return false;
-		}
 		return true;
 	}
 	
@@ -134,13 +105,11 @@ public class LocalUser extends AuthUser {
 	 * @param salt the salt used to hash the password.
 	 * @return a builder.
 	 */
-	public static Builder getBuilder(
+	public static Builder getLocalUserBuilder(
 			final UserName userName,
 			final DisplayName displayName,
-			final Instant creationDate,
-			final byte[] passwordHash,
-			final byte[] salt) {
-		return new Builder(userName, displayName, creationDate, passwordHash, salt);
+			final Instant creationDate) {
+		return new Builder(userName, displayName, creationDate);
 		
 	}
 	
@@ -150,27 +119,14 @@ public class LocalUser extends AuthUser {
 	 */
 	public static class Builder extends AbstractBuilder<Builder> {
 		
-		private final byte[] passwordHash;
-		private final byte[] salt;
 		private boolean forceReset = false;
 		private Optional<Instant> lastReset = Optional.absent();
 
 		private Builder(
 				final UserName userName,
 				final DisplayName displayName,
-				final Instant creationDate,
-				final byte[] passwordHash,
-				final byte[] salt) {
+				final Instant creationDate) {
 			super(userName, displayName, creationDate);
-			// what's the right # here? Have to rely on user to some extent
-			if (passwordHash == null || passwordHash.length < 10) {
-				throw new IllegalArgumentException("passwordHash missing or too small");
-			}
-			if (salt == null || salt.length < 2) {
-				throw new IllegalArgumentException("salt missing or too small");
-			}
-			this.passwordHash = passwordHash;
-			this.salt = salt;
 		}
 
 		@Override
@@ -202,8 +158,7 @@ public class LocalUser extends AuthUser {
 		 */
 		public LocalUser build() {
 			return new LocalUser(userName, displayName, created, email, roles, customRoles,
-					policyIDs, lastLogin, disabledState, passwordHash, salt, forceReset,
-					lastReset);
+					policyIDs, lastLogin, disabledState, forceReset, lastReset);
 		}
 		
 	}

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -186,7 +186,6 @@ public class Tokens {
 
 	//TODO CTX update token page with set context
 	//TODO CTX update login pages with set context
-	//TODO NOW don't return user policy IDs with API (any other fields not needed?)
 	private NewUIToken createtoken(
 			final HttpServletRequest req,
 			final String tokenName,

--- a/src/us/kbase/test/auth2/lib/PasswordHashAndSaltTest.java
+++ b/src/us/kbase/test/auth2/lib/PasswordHashAndSaltTest.java
@@ -1,0 +1,60 @@
+package us.kbase.test.auth2.lib;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.PasswordHashAndSalt;
+import us.kbase.test.auth2.TestCommon;
+
+public class PasswordHashAndSaltTest {
+
+	@Test
+	public void construct() {
+		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
+				new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				new byte[] {11, 12});
+		assertThat("incorrect hash", creds.getPasswordHash(),
+				is(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+		assertThat("incorrect salt", creds.getSalt(),
+				is(new byte[] {11, 12}));
+	}
+	
+	@Test
+	public void clear() {
+		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
+				new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+				new byte[] {11, 12});
+		creds.clear();
+		assertThat("incorrect hash", creds.getPasswordHash(),
+				is(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+		assertThat("incorrect salt", creds.getSalt(),
+				is(new byte[] {0, 0}));
+	}
+	
+	@Test
+	public void constructFail() {
+		failConstruct(null, new byte[2],
+				new IllegalArgumentException("passwordHash missing or too small"));
+		failConstruct(new byte[9], new byte[2],
+				new IllegalArgumentException("passwordHash missing or too small"));
+		failConstruct(new byte[10], null,
+				new IllegalArgumentException("salt missing or too small"));
+		failConstruct(new byte[10], new byte[1],
+				new IllegalArgumentException("salt missing or too small"));
+	}
+
+	private void failConstruct(
+			final byte[] hash,
+			final byte[] salt,
+			final Exception e) {
+		try {
+			new PasswordHashAndSalt(hash, salt);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
@@ -13,6 +13,7 @@ import java.time.Instant;
 import org.junit.Test;
 
 import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.PasswordHashAndSalt;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
@@ -200,10 +201,10 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	public void linkFailLocalUser() throws Exception {
 		final byte[] pwd = "foobarbaz2".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
-		final LocalUser nlu = LocalUser.getBuilder(
-				new UserName("local"), new DisplayName("bar"), NOW, pwd, salt).build();
+		final LocalUser nlu = LocalUser.getLocalUserBuilder(
+				new UserName("local"), new DisplayName("bar"), NOW).build();
 				
-		storage.createLocalUser(nlu);
+		storage.createLocalUser(nlu, new PasswordHashAndSalt(pwd, salt));
 		failLink(new UserName("local"), REMOTE2,
 				new LinkFailedException("Cannot link identities to a local user"));
 	}
@@ -255,10 +256,10 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	public void unlinkFailLocalUser() throws Exception {
 		final byte[] pwd = "foobarbaz2".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
-		final LocalUser nlu = LocalUser.getBuilder(
-				new UserName("local"), new DisplayName("bar"), NOW, pwd, salt).build();
+		final LocalUser nlu = LocalUser.getLocalUserBuilder(
+				new UserName("local"), new DisplayName("bar"), NOW).build();
 				
-		storage.createLocalUser(nlu);
+		storage.createLocalUser(nlu, new PasswordHashAndSalt(pwd, salt));
 		failUnlink(new UserName("local"), "foobar",
 				new UnLinkFailedException("Local users have no identities"));
 	}


### PR DESCRIPTION
The LocalUser class returned from the database included a password hash
and salt, which is almost never needed. This class is returned from the
Authentication class and so that hash is exposed, although currently not
via the API. 

Split the hash and salt into a separate class and retrieval method and
only call that method when needed (e.g. for a login or on a password
change.

Also change the changePassword() storage method to take the same class.