### PR TITLE
Finish config refactoring

### DIFF
--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -2160,9 +2160,8 @@ public class Authentication {
 			AuthStorageException, ExternalConfigMappingException {
 		nonNull(mapper, "mapper");
 		getUser(token, set(TokenType.LOGIN), Role.ADMIN);
-		//TODO CONFIG remove providers from config that aren't in set
 		final AuthConfigSet<CollectingExternalConfig> acs = cfg.getConfig();
-		return new AuthConfigSet<T>(acs.getCfg(),
+		return new AuthConfigSet<T>(acs.getCfg().filterProviders(idProviderSet.keySet()),
 				mapper.fromMap(acs.getExtcfg().getMap()));
 	}
 	

--- a/src/us/kbase/auth2/lib/config/AuthConfigSetWithUpdateTime.java
+++ b/src/us/kbase/auth2/lib/config/AuthConfigSetWithUpdateTime.java
@@ -1,0 +1,59 @@
+package us.kbase.auth2.lib.config;
+
+/** An authorization configuration set including how often the configuration is pulled from the 
+ * database. This update time determines how long it will take other authentication instances
+ * that use the same database to get any configuration updates.
+ * @author gaprice@lbl.gov
+ *
+ * @param <T> the type of the external configuration class.
+ */
+public class AuthConfigSetWithUpdateTime<T extends ExternalConfig> extends AuthConfigSet<T> {
+	
+	private final int updateTimeInSec;
+	
+	/** Create a new config set.
+	 * @param cfg the authorization configuration.
+	 * @param extcfg the external configuration.
+	 * @param updateTimeInSec the update time in seconds.
+	 */
+	public AuthConfigSetWithUpdateTime(
+			final AuthConfig cfg,
+			final T extcfg,
+			final int updateTimeInSec) {
+		super(cfg, extcfg);
+		this.updateTimeInSec = updateTimeInSec;
+	}
+
+	/** Get the update time in seconds.
+	 * @return the update time.
+	 */
+	public int getUpdateTimeInSec() {
+		return updateTimeInSec;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + updateTimeInSec;
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!super.equals(obj)) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		AuthConfigSetWithUpdateTime<?> other = (AuthConfigSetWithUpdateTime<?>) obj;
+		if (updateTimeInSec != other.updateTimeInSec) {
+			return false;
+		}
+		return true;
+	}
+}

--- a/src/us/kbase/auth2/lib/config/AuthConfigUpdate.java
+++ b/src/us/kbase/auth2/lib/config/AuthConfigUpdate.java
@@ -301,7 +301,7 @@ public class AuthConfigUpdate<T extends ExternalConfig> {
 		 */
 		public Builder<T> withProviderUpdate(final String provider, final ProviderUpdate update)
 				throws MissingParameterException {
-			//TODO CODE should consider provider name class
+			//TODO ZLATER CODE should consider provider name class
 			checkString(provider, "provider");
 			nonNull(update, "update");
 			providers.put(provider, update);

--- a/src/us/kbase/auth2/service/AuthExternalConfig.java
+++ b/src/us/kbase/auth2/service/AuthExternalConfig.java
@@ -30,7 +30,7 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 	private static final String IGNORE_IP_HEADERS = "ignoreIPHeaders";
 	private static final String INCLUDE_STACK_TRACE_IN_RESPONSE = "includeStackTraceInResponse";
 
-	private static final ConfigItem<URL, Action> MT_URL = ConfigItem.noAction();
+	private static final ConfigItem<URL, Action> MT_URL = ConfigItem.remove();
 	private static final ConfigItem<Boolean, Action> SET_FALSE = ConfigItem.set(false);
 
 	public static final AuthExternalConfig<Action> SET_DEFAULT;

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -49,7 +49,7 @@ import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.UserSearchSpec;
-import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.AuthConfigSetWithUpdateTime;
 import us.kbase.auth2.lib.config.AuthConfigUpdate;
 import us.kbase.auth2.lib.config.AuthConfigUpdate.ProviderUpdate;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
@@ -533,7 +533,7 @@ public class Admin {
 			@Context final UriInfo uriInfo)
 			throws InvalidTokenException, UnauthorizedException,
 			NoTokenProvidedException, AuthStorageException {
-		final AuthConfigSet<AuthExternalConfig<State>> cfgset;
+		final AuthConfigSetWithUpdateTime<AuthExternalConfig<State>> cfgset;
 		try {
 			cfgset = auth.getConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					new AuthExternalConfigMapper());
@@ -580,6 +580,8 @@ public class Admin {
 		ret.put("tokenserv", cfgset.getCfg().getTokenLifetimeMS(
 				TokenLifetimeType.SERV) / DAY_IN_MS);
 
+		ret.put("updatetimesec", cfgset.getUpdateTimeInSec());
+		
 		ret.put("basicurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_BASIC));
 		ret.put("tokenurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_TOKEN));
 		ret.put("providerurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_PROVIDER));

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -523,7 +523,15 @@ public class Admin {
 		auth.deleteCustomRole(getTokenFromCookie(headers, cfg.getTokenCookieName()), roleId);
 	}
 	
-	//TODO CONFIG reset to defaults
+	@POST
+	@Path(UIPaths.ADMIN_CONFIG_RESET)
+	public void resetConfig(
+			@Context final HttpHeaders headers)
+			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
+			AuthStorageException {
+		auth.resetConfigToDefault(getTokenFromCookie(headers, cfg.getTokenCookieName()));
+	}
+	
 	@GET
 	@Path(UIPaths.ADMIN_CONFIG)
 	@Template(name = "/adminconfig")
@@ -585,6 +593,7 @@ public class Admin {
 		ret.put("basicurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_BASIC));
 		ret.put("tokenurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_TOKEN));
 		ret.put("providerurl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_PROVIDER));
+		ret.put("reseturl", relativize(uriInfo, UIPaths.ADMIN_ROOT_CONFIG_RESET));
 		return ret;
 	}
 	

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -86,9 +86,11 @@ public class UIPaths {
 	public static final String ADMIN_CONFIG = "config";
 	public static final String ADMIN_CONFIG_BASIC = ADMIN_CONFIG + SEP + "basic";
 	public static final String ADMIN_CONFIG_PROVIDER = ADMIN_CONFIG + SEP + "provider";
+	public static final String ADMIN_CONFIG_RESET = ADMIN_CONFIG + SEP + RESET;
 	public static final String ADMIN_CONFIG_TOKEN = ADMIN_CONFIG + SEP + TOKEN;
 	public static final String ADMIN_ROOT_CONFIG_BASIC = ADMIN_ROOT + ADMIN_CONFIG_BASIC;
 	public static final String ADMIN_ROOT_CONFIG_PROVIDER = ADMIN_ROOT + ADMIN_CONFIG_PROVIDER;
+	public static final String ADMIN_ROOT_CONFIG_RESET = ADMIN_ROOT + ADMIN_CONFIG_RESET;
 	public static final String ADMIN_ROOT_CONFIG_TOKEN = ADMIN_ROOT + ADMIN_CONFIG_TOKEN;
 	
 	/* localaccount endpoint */

--- a/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/config/AuthConfigTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.config.AuthConfig;
 import us.kbase.auth2.lib.config.AuthConfigSet;
+import us.kbase.auth2.lib.config.AuthConfigSetWithUpdateTime;
 import us.kbase.auth2.lib.config.AuthConfigUpdate;
 import us.kbase.auth2.lib.config.AuthConfigUpdate.ProviderUpdate;
 import us.kbase.auth2.lib.config.ConfigAction.Action;
@@ -561,5 +562,26 @@ public class AuthConfigTest {
 		} catch (NullPointerException e) {
 			assertThat("incorrect exception message", e.getMessage(), is(exception));
 		}
+	}
+	
+	@Test
+	public void configSetWithUpdateEquals() {
+		EqualsVerifier.forClass(AuthConfigSetWithUpdateTime.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void configSetWithUpdateConstructAndGetters() throws Exception {
+		final Map<TokenLifetimeType, Long> lts = new HashMap<>();
+		lts.put(TokenLifetimeType.DEV, 350000L);
+		final AuthConfig cfg = new AuthConfig(false, null, lts);
+		final AuthConfigSetWithUpdateTime<TestExtCfg> ac =
+				new AuthConfigSetWithUpdateTime<TestExtCfg>(cfg, new TestExtCfg(), -1);
+		assertThat("incorrect config login", ac.getCfg().isLoginAllowed(), is(false));
+		assertThat("incorrect config providers", ac.getCfg().getProviders(), is(new HashMap<>()));
+		assertThat("incorrect config token lifetimes", ac.getCfg().getTokenLifetimeMS(),
+				is(lts));
+		assertThat("incorrect ext config", ac.getExtcfg().toMap(),
+				is(ImmutableMap.of("foo", ConfigItem.set("bar"))));
+		assertThat("incorrect update time", ac.getUpdateTimeInSec(), is(-1));
 	}
 }

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -1,6 +1,9 @@
 <html>
 <body>
 <h2>Server Configuration</h2>
+
+<p><strong>It will take up to {{updatetimesec}} seconds for configuration changes to synch to other
+server instances.</strong></p>
 <h3>Basic</h3>
 
 <form action="{{basicurl}}" method="post">

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -4,6 +4,11 @@
 
 <p><strong>It will take up to {{updatetimesec}} seconds for configuration changes to synch to other
 server instances.</strong></p>
+
+<form action="{{reseturl}}" method="post">
+	<input type="submit" value="Reset to defaults"/>
+</form>	
+
 <h3>Basic</h3>
 
 <form action="{{basicurl}}" method="post">


### PR DESCRIPTION
1) Filter out providers that weren't loaded at startup when retrieving the config from the DB.
2) Provide information regarding config propagation times to other instances.
3) Fn to reset config to defaults.

Next is testing this config system at the Authentication level (done at the storage level).