### PR TITLE
Add per id provider custom configuration

### DIFF
--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +28,7 @@ import us.kbase.common.service.JsonServerSyslog.RpcInfo;
 public class KBaseAuthConfig implements AuthStartupConfig {
 	
 	//TODO JAVADOC
-	//TODO TEST unittests
+	//TODO TEST
 	
 	private static final String KB_DEP = "KB_DEPLOYMENT_CONFIG";
 	private static final String CFG_LOC ="authserv2";
@@ -52,6 +53,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 			"-login-redirect-url";
 	private static final String KEY_SUFFIX_ID_PROVS_LINK_REDIRECT =
 			"-link-redirect-url";
+	private static final String KEY_SUFFIX_ID_PROVS_CUSTOM = "-custom-";
 	
 	private final SLF4JAutoLogger logger;
 	private final String mongoHost;
@@ -125,9 +127,10 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 			final URL api = getURL(pre + KEY_SUFFIX_ID_PROVS_API_URL, cfg);
 			final URL loginRedirect = getURL(pre + KEY_SUFFIX_ID_PROVS_LOGIN_REDIRECT, cfg);
 			final URL linkRedirect = getURL(pre + KEY_SUFFIX_ID_PROVS_LINK_REDIRECT, cfg);
+			final Map<String, String> custom = getCustom(pre + KEY_SUFFIX_ID_PROVS_CUSTOM, cfg);
 			try {
-				ips.add(new IdentityProviderConfig(
-						factory, login, api, cliid, clisec, loginRedirect, linkRedirect));
+				ips.add(new IdentityProviderConfig(factory, login, api, cliid, clisec,
+						loginRedirect, linkRedirect, custom));
 			} catch (IdentityProviderConfigurationException e) {
 				//TODO TEST ^ is ok in a url, but not in a URI
 				throw new AuthConfigurationException(String.format(
@@ -139,6 +142,16 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 		return Collections.unmodifiableSet(ips);
 	}
 	
+	private Map<String, String> getCustom(final String keyprefix, final Map<String, String> cfg) {
+		final Map<String, String> ret = new HashMap<>();
+		for (final String key: cfg.keySet()) {
+			if (key != null && key.startsWith(keyprefix)) {
+				ret.put(key.replace(keyprefix, ""), cfg.get(key));
+			}
+		}
+		return ret;
+	}
+
 	private URL getURL(final String key, final Map<String, String> cfg)
 			throws AuthConfigurationException {
 		final String url = getString(key, cfg, true);

--- a/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProviderConfig.java
@@ -1,7 +1,12 @@
 package us.kbase.auth2.lib.identity;
 
+import static us.kbase.auth2.lib.Utils.nonNull;
+
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /** A configuration for an identity provider.
  * @author gaprice@lbl.gov
@@ -18,6 +23,9 @@ public class IdentityProviderConfig {
 	private final URL apiURL;
 	private final URL loginRedirectURL;
 	private final URL linkRedirectURL;
+	private final Map<String, String> customConfig;
+	
+	// a builder would be nice, but there's only 1 optional item...
 	
 	/** Create a configuration for an identity provider.
 	 * @param identityProviderFactoryClass the class name of the identity provider factory for this
@@ -40,8 +48,10 @@ public class IdentityProviderConfig {
 			final String clientID,
 			final String clientSecret,
 			final URL loginRedirectURL,
-			final URL linkRedirectURL)
+			final URL linkRedirectURL,
+			final Map<String, String> customConfig)
 			throws IdentityProviderConfigurationException {
+		nonNull(customConfig, "customConfig");
 		notNullOrEmpty(identityProviderFactoryClass, "Identity provider name");
 		notNullOrEmpty(clientID, "Client ID for " + identityProviderFactoryClass +
 				" identity provider");
@@ -54,6 +64,7 @@ public class IdentityProviderConfig {
 		this.apiURL = apiURL;
 		this.loginRedirectURL = loginRedirectURL;
 		this.linkRedirectURL = linkRedirectURL;
+		this.customConfig = Collections.unmodifiableMap(new HashMap<>(customConfig));
 
 		checkValidURI(this.loginURL, "Login URL");
 		checkValidURI(this.apiURL, "API URL");
@@ -132,6 +143,13 @@ public class IdentityProviderConfig {
 	 */
 	public URL getLinkRedirectURL() {
 		return linkRedirectURL;
+	}
+	
+	/** Get any custom configuration options that have been provided for the identity provider.
+	 * @return the custom configuration.
+	 */
+	public Map<String, String> getCustomConfiguation() {
+		return customConfig;
 	}
 	
 	/** Thrown when the creating an identity provider configuration fails due to bad input.

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -113,7 +113,8 @@ public class AuthenticationConstructorTest {
 	public void nulls() throws Exception {
 		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"));
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
+				Collections.emptyMap());
 		
 		final AuthStorage storage = mock(AuthStorage.class);
 		failConstruct(null, Collections.emptySet(), new TestExternalConfig<>(SET_FOO),
@@ -161,10 +162,12 @@ public class AuthenticationConstructorTest {
 		final AuthStorage storage = mock(AuthStorage.class);
 		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"));
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
+				Collections.emptyMap());
 		final IdentityProviderConfig cfg2 = new IdentityProviderConfig(
 				"prov2", new URL("https://login2.com"), new URL("https://link2.com"),
-				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"));
+				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"),
+				Collections.emptyMap());
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv("Prov1", cfg1));
@@ -198,10 +201,12 @@ public class AuthenticationConstructorTest {
 		final AuthStorage storage = mock(AuthStorage.class);
 		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"));
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
+				Collections.emptyMap());
 		final IdentityProviderConfig cfg2 = new IdentityProviderConfig(
 				"prov2", new URL("https://login2.com"), new URL("https://link2.com"),
-				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"));
+				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"),
+				Collections.emptyMap());
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv("Prov1", cfg1));
@@ -223,7 +228,8 @@ public class AuthenticationConstructorTest {
 		final AuthStorage storage = mock(AuthStorage.class);
 		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"));
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
+				Collections.emptyMap());
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv(null, cfg1));

--- a/src/us/kbase/test/auth2/lib/identity/IdentityProviderConfigTest.java
+++ b/src/us/kbase/test/auth2/lib/identity/IdentityProviderConfigTest.java
@@ -5,11 +5,15 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.net.URL;
+import java.util.Collections;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 import us.kbase.auth2.lib.identity.IdentityProviderConfig;
 import us.kbase.auth2.lib.identity.IdentityProviderConfig.IdentityProviderConfigurationException;
+import us.kbase.test.auth2.TestCommon;
 
 public class IdentityProviderConfigTest {
 
@@ -22,7 +26,8 @@ public class IdentityProviderConfigTest {
 				"foo",
 				"bar",
 				new URL("https://loginredirect.com"),
-				new URL("https://linkredirect.com"));
+				new URL("https://linkredirect.com"),
+				ImmutableMap.of("foo", "bar", "baz", "bat"));
 		assertThat("incorrect api URL", c.getApiURL(), is(new URL("http://api.com")));
 		assertThat("incorrect client id", c.getClientID(), is("foo"));
 		assertThat("incorrect client secret", c.getClientSecret(), is("bar"));
@@ -32,6 +37,8 @@ public class IdentityProviderConfigTest {
 		assertThat("incorrect login redirect URL", c.getLoginRedirectURL(),
 				is(new URL("https://loginredirect.com")));
 		assertThat("incorrect login URL", c.getLoginURL(), is(new URL("http://login.com")));
+		assertThat("incorrect custom config", c.getCustomConfiguation(),
+				is(ImmutableMap.of("foo", "bar", "baz", "bat")));
 	}
 	
 	@Test
@@ -98,6 +105,14 @@ public class IdentityProviderConfigTest {
 				"Link redirect URL http://linkredir^foobar.com for MyProv identity provider is " +
 				"not a valid URI: Illegal character in authority at index 7: " +
 				"http://linkredir^foobar.com");
+		
+		try {
+			new IdentityProviderConfig(name, login, api, clientID, clientSecret, loginRedirect,
+					linkRedirect, null);
+			fail("expected NPE");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("customConfig"));
+		}
 	}
 
 	private void failCreateConfig(
@@ -111,7 +126,7 @@ public class IdentityProviderConfigTest {
 			final String exception) {
 		try {
 			new IdentityProviderConfig(name, login, api, clientID, clientSecret,
-					loginRedirect, linkRedirect);
+					loginRedirect, linkRedirect, Collections.emptyMap());
 			fail("created bad id provider config");
 		} catch (IdentityProviderConfigurationException e) {
 			assertThat("incorrect exception message", e.getMessage(), is(exception));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageInvalidDBDataTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageInvalidDBDataTest.java
@@ -1,5 +1,7 @@
 package us.kbase.test.auth2.lib.storage.mongo;
 
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -170,9 +172,10 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 		try {
 			storage.getToken(t.getHashedToken());
 			fail("expected exception");
-		} catch (Exception e) {
-			TestCommon.assertExceptionCorrect(e, new AuthStorageException(
-					"Illegal value stored in db: foobar: unknown error"));
+		} catch (AuthStorageException e) {
+			assertThat("incorrect exception message", e.getMessage(),
+					// error message from InetAddress changes based on test context
+					startsWith("Illegal value stored in db: foobar"));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
@@ -10,6 +10,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -92,7 +93,8 @@ public class GlobusIdentityProviderTest {
 					"foo",
 					"bar",
 					new URL("https://loginredir.com"),
-					new URL("https://linkredir.com"));
+					new URL("https://linkredir.com"),
+					Collections.emptyMap());
 		} catch (IdentityProviderConfigurationException | MalformedURLException e) {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
@@ -145,7 +147,8 @@ public class GlobusIdentityProviderTest {
 				CFG.getClientID(),
 				CFG.getClientSecret(),
 				CFG.getLoginRedirectURL(),
-				CFG.getLinkRedirectURL()),
+				CFG.getLinkRedirectURL(),
+				Collections.emptyMap()),
 				new IllegalArgumentException(
 						"Configuration class name doesn't match factory class name: foo"));
 	}
@@ -475,7 +478,8 @@ public class GlobusIdentityProviderTest {
 				"foo",
 				"bar",
 				new URL("https://loginredir.com"),
-				new URL("https://linkredir.com"));
+				new URL("https://linkredir.com"),
+				Collections.emptyMap());
 	}
 
 	private String getBasicAuth(final IdentityProviderConfig idconfig) {
@@ -609,7 +613,8 @@ public class GlobusIdentityProviderTest {
 				clientID,
 				"bar2",
 				new URL("https://loginredir2.com"),
-				new URL("https://linkredir2.com"));
+				new URL("https://linkredir2.com"),
+				Collections.emptyMap());
 		final IdentityProvider idp = new GlobusIdentityProvider(idconfig);
 		final String bauth = getBasicAuth(idconfig);
 		

--- a/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -90,7 +91,8 @@ public class GoogleIdentityProviderTest {
 					"gfoo",
 					"gbar",
 					new URL("https://gloginredir.com"),
-					new URL("https://glinkredir.com"));
+					new URL("https://glinkredir.com"),
+					Collections.emptyMap());
 		} catch (IdentityProviderConfigurationException | MalformedURLException e) {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
@@ -142,7 +144,8 @@ public class GoogleIdentityProviderTest {
 				CFG.getClientID(),
 				CFG.getClientSecret(),
 				CFG.getLoginRedirectURL(),
-				CFG.getLinkRedirectURL()),
+				CFG.getLinkRedirectURL(),
+				Collections.emptyMap()),
 				new IllegalArgumentException(
 						"Configuration class name doesn't match factory class name: foo"));
 	}
@@ -188,7 +191,8 @@ public class GoogleIdentityProviderTest {
 				"gfoo",
 				"gbar",
 				new URL("https://gloginredir.com"),
-				new URL("https://glinkredir.com"));
+				new URL("https://glinkredir.com"),
+				Collections.emptyMap());
 	}
 	
 	@Test
@@ -383,7 +387,8 @@ public class GoogleIdentityProviderTest {
 				"someclient",
 				"bar2",
 				new URL("https://gloginredir2.com"),
-				new URL("https://glinkredir2.com"));
+				new URL("https://glinkredir2.com"),
+				Collections.emptyMap());
 		final IdentityProvider idp = new GoogleIdentityProvider(idconfig);
 		
 		setUpCallAuthToken(authCode, "footoken2", "https://glinkredir2.com",


### PR DESCRIPTION
Allows setting arbitrary key-value configuration pairs to be provided to
a particular identity provider