### PR TITLE
Return error as JSON for login and link cancellation DELETE methods.

### DIFF
--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -300,6 +300,7 @@ public class Link {
 	
 	@DELETE
 	@Path(UIPaths.LINK_CANCEL)
+	@Produces(MediaType.APPLICATION_JSON)
 	public Response cancelLinkDELETE(@CookieParam(IN_PROCESS_LINK_COOKIE) final String token)
 			throws NoTokenProvidedException, AuthStorageException {
 		return cancelLink(token);

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -450,6 +450,7 @@ public class Login {
 	
 	@DELETE
 	@Path(UIPaths.LOGIN_CANCEL)
+	@Produces(MediaType.APPLICATION_JSON)
 	public Response cancelLoginDELETE(@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token)
 			throws NoTokenProvidedException, AuthStorageException {
 		return cancelLogin(token);


### PR DESCRIPTION
- tested against the auth2 client
- this is important because it allows cancellation of login or link session to differentiate between a token merely begin missing or expired (typically ignored) and other errors.
- just changed the DELETE methods, POST is not used by the kbase-ui auth2 client.