### PR TITLE
Fix known inconsistencies in the API and UI.

### DIFF
--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -34,6 +34,7 @@ import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.user.AuthUser;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(APIPaths.API_V2_ME)
 public class Me {
@@ -52,7 +53,7 @@ public class Me {
 		// this code is almost identical to ui.Me but I don't want to couple the API and UI outputs
 		final AuthUser u = auth.getUser(getToken(token));
 		final Map<String, Object> ret = new HashMap<String, Object>();
-		ret.put("user", u.getUserName().getName());
+		ret.put(Fields.USER, u.getUserName().getName());
 		ret.put("local", u.isLocal());
 		ret.put("display", u.getDisplayName().getName());
 		ret.put("email", u.getEmail().getAddress());
@@ -63,23 +64,23 @@ public class Me {
 		final List<Map<String, String>> roles = new LinkedList<>();
 		for (final Role r: u.getRoles()) {
 			final Map<String, String> role = new HashMap<>();
-			role.put("id", r.getID());
+			role.put(Fields.ID, r.getID());
 			role.put("desc", r.getDescription());
 			roles.add(role);
 		}
 		ret.put("roles", roles);
 		final List<Map<String, String>> idents = new LinkedList<>();
-		ret.put("idents", idents);
+		ret.put(Fields.IDENTITIES, idents);
 		for (final RemoteIdentity ri: u.getIdentities()) {
 			final Map<String, String> i = new HashMap<>();
-			i.put("provider", ri.getRemoteID().getProviderName());
-			i.put("username", ri.getDetails().getUsername());
-			i.put("id", ri.getRemoteID().getID());
+			i.put(Fields.PROVIDER, ri.getRemoteID().getProviderName());
+			i.put(Fields.PROV_USER, ri.getDetails().getUsername());
+			i.put(Fields.ID, ri.getRemoteID().getID());
 			idents.add(i);
 		}
-		ret.put("policy_ids", u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
-			"id", id.getName(),
-			"agreed_on", u.getPolicyIDs().get(id).toEpochMilli()))
+		ret.put(Fields.POLICY_IDS, u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
+			Fields.ID, id.getName(),
+			Fields.AGREED_ON, u.getPolicyIDs().get(id).toEpochMilli()))
 			.collect(Collectors.toSet()));
 		return ret;
 	}

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -1,0 +1,39 @@
+package us.kbase.auth2.service.common;
+
+public class Fields {
+
+	//TODO JAVADOC
+	
+	/* general */
+	
+	public static final String ID = "id";
+	
+	/* login */
+	
+	public static final String STAY_LOGGED_IN = "stayloggedin";
+	
+	/* roles */
+	
+	public static final String HAS_ROLES = "hasroles";
+	
+	/* policy ids */
+	
+	public static final String POLICY_ID = "policyid";
+	public static final String POLICY_IDS = "policyids";
+	public static final String AGREED_ON = "agreedon";
+	
+	/* users */
+	
+	public static final String USER = "user";
+	
+	/* provider info */
+	
+	public static final String PROVIDERS = "providers";
+	public static final String HAS_PROVIDERS = "hasprov";
+	public static final String PROVIDER = "provider";
+	public static final String PROV_USER = "provusername";
+	public static final String PROV_USERS = "provusernames";
+	public static final String PROV_EMAIL = "provemail";
+	public static final String PROV_FULL = "provfullname";
+	public static final String IDENTITIES = "idents";
+}

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -76,6 +76,7 @@ import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(UIPaths.ADMIN_ROOT)
 public class Admin {
@@ -156,7 +157,7 @@ public class Admin {
 	@Path(UIPaths.ADMIN_POLICY_ID)
 	public void removePolicyID(
 			@Context final HttpHeaders headers,
-			@FormParam("policy_id") final String policyID)
+			@FormParam(Fields.POLICY_ID) final String policyID)
 			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
 				MissingParameterException, IllegalParameterException, AuthStorageException {
 		auth.removePolicyID(getTokenFromCookie(headers, cfg.getTokenCookieName()),
@@ -204,7 +205,7 @@ public class Admin {
 		final List<Map<String, String>> uiusers = new LinkedList<>();
 		for (final UserName user: users.keySet()) {
 			final Map<String, String> u = new HashMap<>();
-			u.put("user", user.getName());
+			u.put(Fields.USER, user.getName());
 			u.put("display", users.get(user).getName());
 			u.put("url", relativize(uriInfo, UIPaths.ADMIN_ROOT_USER + SEP + user.getName()));
 			uiusers.add(u);
@@ -227,7 +228,7 @@ public class Admin {
 	@Template(name = "/adminlocalaccountcreated")
 	public Map<String, String> createLocalAccountComplete(
 			@Context final HttpHeaders headers,
-			@FormParam("user") final String userName,
+			@FormParam(Fields.USER) final String userName,
 			@FormParam("display") final String displayName,
 			@FormParam("email") final String email)
 			throws AuthStorageException, UserExistsException,
@@ -239,7 +240,7 @@ public class Admin {
 				getTokenFromCookie(headers, cfg.getTokenCookieName()),
 				new UserName(userName), new DisplayName(displayName), new EmailAddress(email));
 		final Map<String, String> ret = ImmutableMap.of(
-				"user", userName,
+				Fields.USER, userName,
 				"display", displayName,
 				"email", email,
 				"password", new String(pwd.getPassword())); // char[] won't work
@@ -253,7 +254,7 @@ public class Admin {
 	@Produces(MediaType.TEXT_HTML)
 	public Map<String, Object> userDisplay(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user,
+			@PathParam(UIPaths.USER) final String user,
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, NoSuchUserException,
 			MissingParameterException, IllegalParameterException,
@@ -272,7 +273,7 @@ public class Admin {
 		ret.put("reseturl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_RESET_PWD));
 		ret.put("forcereseturl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_FORCE_RESET_PWD));
 		ret.put("tokenurl", relativize(uriInfo, userPrefix + UIPaths.ADMIN_TOKENS));
-		ret.put("user", au.getUserName().getName());
+		ret.put(Fields.USER, au.getUserName().getName());
 		ret.put("display", au.getDisplayName().getName());
 		ret.put("email", au.getEmail().getAddress());
 		ret.put("local", au.isLocal());
@@ -301,7 +302,7 @@ public class Admin {
 		for (final CustomRole r: roles) {
 			ret.add(ImmutableMap.of(
 					"desc", r.getDesc(),
-					"id", r.getID(),
+					Fields.ID, r.getID(),
 					"has", set.contains(r.getID())));
 		}
 		return ret;
@@ -313,7 +314,7 @@ public class Admin {
 	public Map<String, Object> getUserTokens(
 			@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo,
-			@PathParam("user") final String user)
+			@PathParam(UIPaths.USER) final String user)
 			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
 			MissingParameterException, IllegalParameterException, AuthStorageException {
 		
@@ -324,7 +325,7 @@ public class Admin {
 		final String urlPrefix = UIPaths.ADMIN_ROOT_USER + SEP + user + SEP +
 				UIPaths.ADMIN_TOKENS + SEP;
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("user", user);
+		ret.put(Fields.USER, user);
 		ret.put("tokens", uitokens);
 		ret.put("revokeurl", relativize(uriInfo, urlPrefix +
 				UIPaths.ADMIN_USER_TOKENS_REVOKE + SEP));
@@ -336,7 +337,7 @@ public class Admin {
 	@Path(UIPaths.ADMIN_USER_TOKENS_REVOKE_ID)
 	public void revokeUserToken(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user,
+			@PathParam(UIPaths.USER) final String user,
 			@PathParam("tokenid") final UUID tokenID)
 			throws InvalidTokenException, NoSuchTokenException, UnauthorizedException,
 			NoTokenProvidedException, MissingParameterException, IllegalParameterException,
@@ -349,7 +350,7 @@ public class Admin {
 	@Path(UIPaths.ADMIN_USER_TOKENS_REVOKE_ALL)
 	public void revokeUserToken(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user)
+			@PathParam(UIPaths.USER) final String user)
 			throws InvalidTokenException, UnauthorizedException, NoTokenProvidedException,
 			MissingParameterException, IllegalParameterException, AuthStorageException {
 		auth.revokeAllTokens(getTokenFromCookie(headers, cfg.getTokenCookieName()),
@@ -362,7 +363,7 @@ public class Admin {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void disableUser(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user,
+			@PathParam(UIPaths.USER) final String user,
 			@FormParam("disable") final String disableStr,
 			@FormParam("reason") final String reason)
 			throws MissingParameterException, IllegalParameterException, NoTokenProvidedException,
@@ -381,7 +382,7 @@ public class Admin {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void forcePasswordReset(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user)
+			@PathParam(UIPaths.USER) final String user)
 			throws MissingParameterException, IllegalParameterException, NoTokenProvidedException,
 			InvalidTokenException, UnauthorizedException, AuthStorageException,
 			NoSuchUserException {
@@ -394,14 +395,14 @@ public class Admin {
 	@Template(name = "/adminpwdreset")
 	public Map<String, Object> resetUserPassword(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user)
+			@PathParam(UIPaths.USER) final String user)
 			throws NoTokenProvidedException, InvalidTokenException, NoSuchUserException,
 			UnauthorizedException, MissingParameterException, IllegalParameterException,
 			AuthStorageException{
 		final IncomingToken token = getTokenFromCookie(headers, cfg.getTokenCookieName());
 		final Password pwd = auth.resetPassword(token, new UserName(user));
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("user", user);
+		ret.put(Fields.USER, user);
 		ret.put("pwd", new String(pwd.getPassword()));
 		pwd.clear();
 		return ret;
@@ -412,7 +413,7 @@ public class Admin {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void changeRoles(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user,
+			@PathParam(UIPaths.USER) final String user,
 			final MultivaluedMap<String, String> form)
 			throws NoSuchUserException, AuthStorageException,
 			NoSuchRoleException, MissingParameterException,
@@ -452,7 +453,7 @@ public class Admin {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void changeCustomRoles(
 			@Context final HttpHeaders headers,
-			@PathParam("user") final String user,
+			@PathParam(UIPaths.USER) final String user,
 			final MultivaluedMap<String, String> form)
 			throws NoSuchUserException, AuthStorageException,
 			NoSuchRoleException, MissingParameterException,
@@ -503,7 +504,7 @@ public class Admin {
 	@Path(UIPaths.ADMIN_CUSTOM_ROLES_SET)
 	public void createCustomRole(
 			@Context final HttpHeaders headers,
-			@FormParam("id") final String roleId,
+			@FormParam(Fields.ID) final String roleId,
 			@FormParam("desc") final String description)
 			throws MissingParameterException, AuthStorageException,
 			InvalidTokenException, UnauthorizedException,
@@ -516,7 +517,7 @@ public class Admin {
 	@Path(UIPaths.ADMIN_CUSTOM_ROLES_DELETE)
 	public void deleteCustomRole(
 			@Context final HttpHeaders headers,
-			@FormParam("id") final String roleId)
+			@FormParam(Fields.ID) final String roleId)
 			throws MissingParameterException, AuthStorageException,
 			InvalidTokenException, UnauthorizedException,
 			NoTokenProvidedException, NoSuchRoleException, IllegalParameterException {
@@ -552,11 +553,11 @@ public class Admin {
 		
 		final Map<String, Object> ret = new HashMap<>();
 		final List<Map<String, Object>> prov = new ArrayList<>();
-		ret.put("providers", prov);
+		ret.put(Fields.PROVIDERS, prov);
 		for (final Entry<String, ProviderConfig> e:
 				cfgset.getCfg().getProviders().entrySet()) {
 			final Map<String, Object> p = new HashMap<>();
-			p.put("name", e.getKey());
+			p.put(Fields.PROVIDER, e.getKey());
 			p.put("enabled", e.getValue().isEnabled());
 			p.put("forcelinkchoice", e.getValue().isForceLinkChoice());
 			p.put("forceloginchoice", e.getValue().isForceLoginChoice());
@@ -650,7 +651,7 @@ public class Admin {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void configProvider(
 			@Context final HttpHeaders headers,
-			@FormParam("provname") final String provname,
+			@FormParam(Fields.PROVIDER) final String provname,
 			@FormParam("enabled") final String enabled,
 			@FormParam("forceloginchoice") final String forceLogin,
 			@FormParam("forcelinkchoice") final String forcelink)

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -65,6 +65,7 @@ import us.kbase.auth2.lib.token.TemporaryToken;
 import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
+import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.common.IncomingJSON;
 
 @Path(UIPaths.LINK_ROOT)
@@ -94,17 +95,17 @@ public class Link {
 		final IncomingToken incToken = getTokenFromCookie(headers, cfg.getTokenCookieName());
 		final AuthUser u = auth.getUser(incToken);
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("user", u.getUserName().getName());
+		ret.put(Fields.USER, u.getUserName().getName());
 		ret.put("local", u.isLocal());
 		final List<Map<String, String>> provs = new LinkedList<>();
-		ret.put("providers", provs);
+		ret.put(Fields.PROVIDERS, provs);
 		for (final String prov: auth.getIdentityProviders()) {
 			final Map<String, String> rep = new HashMap<>();
-			rep.put("name", prov);
+			rep.put(Fields.PROVIDER, prov);
 			provs.add(rep);
 		}
 		ret.put("starturl", relativize(uriInfo, UIPaths.LINK_ROOT_START));
-		ret.put("hasprov", !provs.isEmpty());
+		ret.put(Fields.HAS_PROVIDERS, !provs.isEmpty());
 		return ret;
 	}
 	
@@ -118,7 +119,7 @@ public class Link {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Path(UIPaths.LINK_START)
 	public Response linkStart(
-			@FormParam("provider") final String provider)
+			@FormParam(Fields.PROVIDER) final String provider)
 			throws NoSuchIdentityProviderException, AuthStorageException {
 		
 		final String state = auth.getBareToken();
@@ -138,7 +139,7 @@ public class Link {
 	@Path(UIPaths.LINK_COMPLETE_PROVIDER)
 	public Response link(
 			@Context final HttpHeaders headers,
-			@PathParam("provider") final String provider,
+			@PathParam(Fields.PROVIDER) final String provider,
 			@CookieParam(LINK_STATE_COOKIE) final String state,
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthenticationException,
@@ -264,14 +265,14 @@ public class Link {
 		 * choice for link targets.
 		 */ 
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("user", ids.getUser().getUserName().getName());
-		ret.put("provider", ids.getProvider());
+		ret.put(Fields.USER, ids.getUser().getUserName().getName());
+		ret.put(Fields.PROVIDER, ids.getProvider());
 		final List<Map<String, String>> ris = new LinkedList<>();
-		ret.put("ids", ris);
+		ret.put(Fields.IDENTITIES, ris);
 		for (final RemoteIdentity ri: ids.getIdentities()) {
 			final Map<String, String> s = new HashMap<>();
-			s.put("id", ri.getRemoteID().getID());
-			s.put("prov_username", ri.getDetails().getUsername());
+			s.put(Fields.ID, ri.getRemoteID().getID());
+			s.put(Fields.PROV_USER, ri.getDetails().getUsername());
 			ris.add(s);
 		}
 		ret.put("cancelurl", relativize(uriInfo, UIPaths.LINK_ROOT_CANCEL));
@@ -319,7 +320,7 @@ public class Link {
 	public Response pickAccount(
 			@Context final HttpHeaders headers,
 			@CookieParam(IN_PROCESS_LINK_COOKIE) final String linktoken,
-			@FormParam("id") String identityID)
+			@FormParam(Fields.ID) String identityID)
 			throws NoTokenProvidedException, AuthStorageException, LinkFailedException,
 				IdentityLinkedException, UnauthorizedException, InvalidTokenException,
 				MissingParameterException {
@@ -338,7 +339,7 @@ public class Link {
 		
 		// don't throw exception in constructor. Bypasses custom error handler.
 		@JsonCreator
-		public LinkPick(@JsonProperty("id") final String id) {
+		public LinkPick(@JsonProperty(Fields.ID) final String id) {
 			this.id = id;
 		}
 		

--- a/src/us/kbase/auth2/service/ui/LocalAccounts.java
+++ b/src/us/kbase/auth2/service/ui/LocalAccounts.java
@@ -41,6 +41,7 @@ import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.UserAgentParser;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(UIPaths.LOCAL_ROOT)
 public class LocalAccounts {
@@ -71,16 +72,16 @@ public class LocalAccounts {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public Response loginResult(
 			@Context final HttpServletRequest req,
-			@FormParam("user") final String userName,
+			@FormParam(Fields.USER) final String userName,
 			@FormParam("pwd") String pwd, //char makes Jersey puke
 			//checkbox, so "on" = checked, null = not checked
-			@FormParam("stayloggedin") final String stayLoggedIn,
+			@FormParam(Fields.STAY_LOGGED_IN) final String stayLoggedIn,
 			@FormParam("customcontext") final String customContext)
 			throws AuthStorageException, MissingParameterException,
 			AuthenticationException, IllegalParameterException,
 			UnauthorizedException {
 		if (userName == null || userName.trim().isEmpty()) {
-			throw new MissingParameterException("user");
+			throw new MissingParameterException(Fields.USER);
 		}
 		if (pwd == null || pwd.trim().isEmpty()) {
 			throw new MissingParameterException("pwd");
@@ -106,24 +107,24 @@ public class LocalAccounts {
 	@Path(UIPaths.LOCAL_RESET)
 	@Template(name = "/localreset")
 	public Map<String, Object> resetPasswordStart(
-			@QueryParam("user") final String user,
+			@QueryParam(Fields.USER) final String user,
 			@Context final UriInfo uriInfo) {
 		return ImmutableMap.of("targeturl", relativize(uriInfo, UIPaths.LOCAL_ROOT_RESET_RESULT),
-				"user", user == null ? "" : user);
+				Fields.USER, user == null ? "" : user);
 	}
 	
 	//TODO UI will need an ajax version
 	@POST
 	@Path(UIPaths.LOCAL_RESET_RESULT)
 	public Response resetPassword(
-			@FormParam("user") final String userName,
+			@FormParam(Fields.USER) final String userName,
 			@FormParam("pwdold") String pwdold,
 			@FormParam("pwdnew") String pwdnew)
 			throws MissingParameterException, IllegalParameterException,
 				AuthenticationException, UnauthorizedException, AuthStorageException,
 				IllegalPasswordException {
 		if (userName == null || userName.trim().isEmpty()) {
-			throw new MissingParameterException("user");
+			throw new MissingParameterException(Fields.USER);
 		}
 		if (pwdold == null || pwdold.trim().isEmpty()) {
 			throw new MissingParameterException("pwdold");

--- a/src/us/kbase/auth2/service/ui/Logout.java
+++ b/src/us/kbase/auth2/service/ui/Logout.java
@@ -27,6 +27,7 @@ import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(UIPaths.LOGOUT_ROOT)
 public class Logout {
@@ -46,7 +47,7 @@ public class Logout {
 			InvalidTokenException {
 		final StoredToken ht = auth.getToken(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		return ImmutableMap.of("user", ht.getUserName().getName(),
+		return ImmutableMap.of(Fields.USER, ht.getUserName().getName(),
 				"logouturl", relativize(uriInfo, UIPaths.LOGOUT_ROOT_RESULT));
 	}
 	
@@ -57,7 +58,7 @@ public class Logout {
 		final Optional<StoredToken> ht = auth.revokeToken(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		return Response.ok(
-				new Viewable("/logoutresult", ImmutableMap.of("user", ht.isPresent() ?
+				new Viewable("/logoutresult", ImmutableMap.of(Fields.USER, ht.isPresent() ?
 						ht.get().getUserName().getName() : null)))
 				.cookie(getLoginCookie(cfg.getTokenCookieName(), null))
 				.build();

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -56,6 +56,7 @@ import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
+import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.common.IncomingJSON;
 
 @Path(UIPaths.ME_ROOT)
@@ -99,7 +100,7 @@ public class Me {
 		ret.put("userupdateurl", relativize(uriInfo, UIPaths.ME_ROOT));
 		ret.put("unlinkurl", relativize(uriInfo, UIPaths.ME_ROOT_UNLINK));
 		ret.put("rolesurl", relativize(uriInfo, UIPaths.ME_ROOT_ROLES));
-		ret.put("user", u.getUserName().getName());
+		ret.put(Fields.USER, u.getUserName().getName());
 		ret.put("local", u.isLocal());
 		ret.put("display", u.getDisplayName().getName());
 		ret.put("email", u.getEmail().getAddress());
@@ -111,24 +112,24 @@ public class Me {
 		final List<Map<String, String>> roles = new LinkedList<>();
 		for (final Role r: u.getRoles()) {
 			final Map<String, String> role = new HashMap<>();
-			role.put("id", r.getID());
+			role.put(Fields.ID, r.getID());
 			role.put("desc", r.getDescription());
 			roles.add(role);
 		}
 		ret.put("roles", roles);
-		ret.put("hasRoles", !roles.isEmpty());
+		ret.put(Fields.HAS_ROLES, !roles.isEmpty());
 		final List<Map<String, String>> idents = new LinkedList<>();
-		ret.put("idents", idents);
+		ret.put(Fields.IDENTITIES, idents);
 		for (final RemoteIdentity ri: u.getIdentities()) {
 			final Map<String, String> i = new HashMap<>();
-			i.put("provider", ri.getRemoteID().getProviderName());
-			i.put("username", ri.getDetails().getUsername());
-			i.put("id", ri.getRemoteID().getID());
+			i.put(Fields.PROVIDER, ri.getRemoteID().getProviderName());
+			i.put(Fields.PROV_USER, ri.getDetails().getUsername());
+			i.put(Fields.ID, ri.getRemoteID().getID());
 			idents.add(i);
 		}
-		ret.put("policy_ids", u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
+		ret.put(Fields.POLICY_IDS, u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
 			"id", id.getName(),
-			"agreed_on", u.getPolicyIDs().get(id).toEpochMilli()))
+			Fields.AGREED_ON, u.getPolicyIDs().get(id).toEpochMilli()))
 			.collect(Collectors.toSet()));
 		return ret;
 	}

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -54,6 +54,7 @@ import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
 import us.kbase.auth2.service.UserAgentParser;
+import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.common.IncomingJSON;
 
 @Path(UIPaths.TOKENS_ROOT)
@@ -81,7 +82,7 @@ public class Tokens {
 			NoTokenProvidedException, UnauthorizedException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		t.put("user", ((UIToken) t.get("current")).getUser());
+		t.put(Fields.USER, ((UIToken) t.get("current")).getUser());
 		t.put("createurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
 		t.put("revokeurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
 				UIPaths.SEP));

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -25,7 +25,8 @@ public class UIPaths {
 	private static final String LOGIN = "login";
 	private static final String LOCAL = "localaccount";
 	private static final String RESET = "reset";
-	private static final String USER = "user";
+	public static final String USER = "user";
+	private static final String USER_PARAM = "{" + USER + "}";
 	private static final String ROLES = "roles";
 	private static final String START = "start";
 	private static final String TOKEN = "token";
@@ -45,7 +46,7 @@ public class UIPaths {
 	public static final String ADMIN_ROOT_LOCAL_CREATE = ADMIN_ROOT + ADMIN_LOCAL_CREATE;
 
 	public static final String ADMIN_ROOT_USER = ADMIN_ROOT + USER;
-	public static final String ADMIN_USER_PARAM = USER + SEP + "{user}";
+	public static final String ADMIN_USER_PARAM = USER + SEP + USER_PARAM;
 
 	public static final String ADMIN_DISABLE = "disable";
 	public static final String ADMIN_USER_DISABLE = ADMIN_USER_PARAM + SEP + ADMIN_DISABLE;

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -83,9 +83,9 @@ provider, e.g. a choice of accounts is required.
 <h3>Identity Providers</h3>
 
 {{#providers}}
-<h4>{{name}}</h4>
+<h4>{{provider}}</h4>
 <form action="{{providerurl}}" method="post">
-<input type="hidden" name="provname" value="{{name}}"/>
+<input type="hidden" name="provider" value="{{provider}}"/>
 <p>Enabled: <input type="checkbox" name="enabled" {{#enabled}}checked{{/enabled}}/>
 </p>
 <p>When linking accounts show link choices even if there's only one choice:

--- a/templates/admingeneral.mustache
+++ b/templates/admingeneral.mustache
@@ -13,7 +13,7 @@
 </form>
 
 <form action="{{policyurl}}" method="post">
-	Remove policy ID: <input type="text" name="policy_id" /><br/>
+	Remove policy ID: <input type="text" name="policyid" /><br/>
 	<input type="submit" value="Submit" />
 </form>
 

--- a/templates/adminusertokens.mustache
+++ b/templates/adminusertokens.mustache
@@ -17,6 +17,11 @@ ID: {{id}}<br/>
 Type: {{type}}<br/>
 Created: {{created}}<br/>
 Expires: {{expires}}<br/>
+OS: {{os}} {{osver}}<br/>
+Agent: {{agent}} {{agentver}}<br/>
+Device: {{device}}<br/>
+IP: {{ip}}<br/>
+Custom: {{custom}}<br/>
 <form action="{{revokeurl}}{{id}}" method="post">
 	<input type="submit" value="Revoke"/>
 </form>

--- a/templates/linkchoice.mustache
+++ b/templates/linkchoice.mustache
@@ -13,13 +13,13 @@ Choices expire: {{expires}}<br/>
 <p>Link one of the following provider accounts to your <strong>{{user}}</strong>
 account:</p>
 
-{{#ids}}
-Provider username: {{prov_username}}<br/>
+{{#idents}}
+Provider username: {{provusername}}<br/>
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Link"/>
 </form>
-{{/ids}}
+{{/idents}}
 
 <p> or
 <form action="{{pickurl}}" method="post">

--- a/templates/linkstart.mustache
+++ b/templates/linkstart.mustache
@@ -20,7 +20,7 @@ provider and logout <strong>before</strong> starting the linking process.
 
 <form action="{{starturl}}" method="post">
 {{#providers}}
-	<input type="radio" name="provider" value="{{name}}"/>{{name}}<br/>
+	<input type="radio" name="provider" value="{{provider}}"/>{{provider}}<br/>
 {{/providers}}
 	<input type="submit" value="Submit"/>
 </form>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -15,16 +15,16 @@ Choices expire: {{expires}}<br/>
 <p>The login information from the provider allows you to access these
 accounts:</p>
 {{#login}}
-Username: {{username}} {{#disabled}}DISABLED{{/disabled}} {{#adminonly}}***Currently only admin accounts can log in***{{/adminonly}}<br/>
-Provider usernames: {{prov_usernames}}<br/>
+Username: {{user}} {{#disabled}}DISABLED{{/disabled}} {{#adminonly}}***Currently only admin accounts can log in***{{/adminonly}}<br/>
+Provider usernames: {{provusernames}}<br/>
 Policy IDs:<br/>
-{{#policy_ids}}
-{{id}}: {{agreed_on}}<br/>
-{{/policy_ids}}
+{{#policyids}}
+{{id}}: {{agreedon}}<br/>
+{{/policyids}}
 {{#loginallowed}}
 <form action="{{pickurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
-	Add policy IDs: <input type="text" name="policy_ids"/><br>
+	Add policy IDs: <input type="text" name="policyids"/><br>
 	Custom token creation context: <input type="text" name="customcontext"/><br/>
 	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="submit" value="Login"/>
@@ -41,13 +41,13 @@ Email is only visible to you, software acting on your behalf, and system adminis
 </p>
 {{#create}}
 {{#creationallowed}}
-<p>Create an account linked to {{prov_username}}</p>
+<p>Create an account linked to {{provusername}}</p>
 
 <form action="{{createurl}}" method="post">
 	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
-	Display name: <input type="text" name="display" value="{{prov_fullname}}"/><br/>
-	Email: <input type="text" name="email" value="{{prov_email}}"/><br/>
-	Policy IDs: <input type="text" name="policy_ids"/><br>
+	Display name: <input type="text" name="display" value="{{provfullname}}"/><br/>
+	Email: <input type="text" name="email" value="{{provemail}}"/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
 	Custom token creation context: <input type="text" name="customcontext"/><br/>
 	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
 	<input type="hidden" name="id" value="{{id}}"/>
@@ -55,7 +55,7 @@ Email is only visible to you, software acting on your behalf, and system adminis
 </form>
 {{/creationallowed}}
 {{^creationallowed}}
-Provider username: {{prov_username}}<br/>
+Provider username: {{provusername}}<br/>
 Sorry, account creation is currently disabled.<br/>
 {{/creationallowed}}
 {{/create}}

--- a/templates/loginstart.mustache
+++ b/templates/loginstart.mustache
@@ -6,9 +6,9 @@
 
 <form action="{{starturl}}" method="post">
 {{#providers}}
-	<input type="radio" name="provider" value="{{name}}"/>{{name}}<br/>
+	<input type="radio" name="provider" value="{{provider}}"/>{{provider}}<br/>
 {{/providers}}
-	<input type="checkbox" name="stayLoggedIn"/> Keep me logged in<br/>
+	<input type="checkbox" name="stayloggedin"/> Keep me logged in<br/>
 	Redirect after login: <input type="text" name="redirect"/><br/>
 	<input type="submit" value="Submit"/>
 </form>

--- a/templates/me.mustache
+++ b/templates/me.mustache
@@ -9,7 +9,7 @@ Last login: {{lastlogin}}<br/>
 Local account<br/>
 {{/local}}
 <h3>Roles:</h3>
-{{#hasRoles}}
+{{#hasroles}}
 <form action="{{rolesurl}}" method="post">
 {{#roles}}
 	<input type="checkbox" name="{{id}}"/> {{desc}}<br/>
@@ -17,7 +17,7 @@ Local account<br/>
 	<input type="reset" value="Reset" />
 	<input type="submit" value="Remove roles"/>
 </form>
-{{/hasRoles}}
+{{/hasroles}}
 <h3>Custom roles:</h3>
 {{#customroles}}
 {{.}}<br/>
@@ -36,7 +36,7 @@ Email is only visible to you, software acting on your behalf, and system adminis
 <h3>Identities:</h3>
 {{#idents}}
 Provider: {{provider}}<br/>
-User id: {{username}}<br/>
+User id: {{provusername}}<br/>
 {{#unlink}}
 <form action="{{unlinkurl}}/{{id}}" method="post">
 	<input type="submit" value="Unlink"/>


### PR DESCRIPTION
TODO: externalize all key strings into the Fields class and all path
strings into the UI/APIPaths classes.

always use alllowercase vs under_score or camelCase

user for username
policyid(s) for policy_id(s)
agreedon for agreed_on
hasrole for hasRole

provusername for prov_username
provfullname for prov_fullname
provemail for provemail

provider for provider name (there were quite a few of these)

stayloggedin for stayLoggedIn

idents for remote identities (was ids or idents)

Start a Fields class for keeping names consistent across multiple
classes

legacy APIs were excludes from this analysis as they need to maintain
the current API.