### PR TITLE
Externalize API and UI data structure key strings

### DIFF
--- a/src/us/kbase/auth2/service/api/APIPaths.java
+++ b/src/us/kbase/auth2/service/api/APIPaths.java
@@ -2,9 +2,13 @@ package us.kbase.auth2.service.api;
 
 public class APIPaths {
 
+	//TODO JAVADOC
+	
 	private static final String SEP = "/";
 	private static final String TOKEN = "token";
 	private static final String USERS = "users";
+	public static final String PREFIX = "prefix";
+	private static final String PREFIX_PARAM = "{" + PREFIX + "}";
 	
 	private static final String API = "/api";
 	private static final String API_V2 = API + "/V2";
@@ -20,7 +24,7 @@ public class APIPaths {
 	public static final String API_V2_TOKEN = API_V2 + SEP + TOKEN;
 	
 	public static final String API_V2_USERS = API_V2 + SEP + USERS;
-	public static final String USERS_SEARCH = "search/{prefix}";
+	public static final String USERS_SEARCH = "search" + SEP + PREFIX_PARAM;
 	
 	public static final String API_V2_ME = API_V2 + SEP + "me";
 }

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -54,21 +54,21 @@ public class Me {
 		final AuthUser u = auth.getUser(getToken(token));
 		final Map<String, Object> ret = new HashMap<String, Object>();
 		ret.put(Fields.USER, u.getUserName().getName());
-		ret.put("local", u.isLocal());
-		ret.put("display", u.getDisplayName().getName());
-		ret.put("email", u.getEmail().getAddress());
-		ret.put("created", u.getCreated().toEpochMilli());
+		ret.put(Fields.LOCAL, u.isLocal());
+		ret.put(Fields.DISPLAY, u.getDisplayName().getName());
+		ret.put(Fields.EMAIL, u.getEmail().getAddress());
+		ret.put(Fields.CREATED, u.getCreated().toEpochMilli());
 		final Optional<Instant> ll = u.getLastLogin();
-		ret.put("lastlogin", ll.isPresent() ? ll.get().toEpochMilli() : null);
-		ret.put("customroles", u.getCustomRoles());
+		ret.put(Fields.LAST_LOGIN, ll.isPresent() ? ll.get().toEpochMilli() : null);
+		ret.put(Fields.CUSTOM_ROLES, u.getCustomRoles());
 		final List<Map<String, String>> roles = new LinkedList<>();
 		for (final Role r: u.getRoles()) {
 			final Map<String, String> role = new HashMap<>();
 			role.put(Fields.ID, r.getID());
-			role.put("desc", r.getDescription());
+			role.put(Fields.DESCRIPTION, r.getDescription());
 			roles.add(role);
 		}
-		ret.put("roles", roles);
+		ret.put(Fields.ROLES, roles);
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put(Fields.IDENTITIES, idents);
 		for (final RemoteIdentity ri: u.getIdentities()) {
@@ -89,8 +89,8 @@ public class Me {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void updateForm(
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
-			@FormParam("display") final String displayName,
-			@FormParam("email") final String email)
+			@FormParam(Fields.DISPLAY) final String displayName,
+			@FormParam(Fields.EMAIL) final String email)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
 			IllegalParameterException, UnauthorizedException {
 		updateUser(auth, getToken(token), displayName, email);
@@ -103,6 +103,6 @@ public class Me {
 			final Map<String, String> params)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
 			IllegalParameterException, UnauthorizedException {
-		updateUser(auth, getToken(token), params.get("display"), params.get("email"));
+		updateUser(auth, getToken(token), params.get(Fields.DISPLAY), params.get(Fields.EMAIL));
 	}
 }

--- a/src/us/kbase/auth2/service/api/Token.java
+++ b/src/us/kbase/auth2/service/api/Token.java
@@ -34,6 +34,7 @@ import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.lib.token.TokenName;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.service.UserAgentParser;
+import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.common.IncomingJSON;
 
 @Path(APIPaths.API_V2_TOKEN)
@@ -63,7 +64,7 @@ public class Token {
 	public NewAPIToken createAgentTokenForm(
 			@Context final HttpServletRequest req,
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
-			@FormParam("name") final String name)
+			@FormParam(Fields.TOKEN_NAME) final String name)
 			throws InvalidTokenException, MissingParameterException, UnauthorizedException,
 			NoTokenProvidedException, IllegalParameterException, AuthStorageException {
 		
@@ -81,8 +82,8 @@ public class Token {
 
 		@JsonCreator
 		public CreateToken(
-				@JsonProperty("name") final String name,
-				@JsonProperty("customcontext") final Map<String, String> customContext) {
+				@JsonProperty(Fields.TOKEN_NAME) final String name,
+				@JsonProperty(Fields.CUSTOM_CONTEXT) final Map<String, String> customContext) {
 			this.name = name;
 			this.customContext = customContext;
 		}

--- a/src/us/kbase/auth2/service/api/Users.java
+++ b/src/us/kbase/auth2/service/api/Users.java
@@ -28,6 +28,7 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(APIPaths.API_V2_USERS)
 public class Users {
@@ -45,7 +46,7 @@ public class Users {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, String> getUsers(
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
-			@QueryParam("list") final String users)
+			@QueryParam(Fields.LIST) final String users)
 			throws MissingParameterException, IllegalParameterException, NoTokenProvidedException,
 			InvalidTokenException, AuthStorageException {
 		final Map<String, String> ret = new HashMap<>();
@@ -74,8 +75,8 @@ public class Users {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, String> getUsersByPrefix(
 			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
-			@PathParam("prefix") final String prefix,
-			@QueryParam("fields") final String fields)
+			@PathParam(APIPaths.PREFIX) final String prefix,
+			@QueryParam(Fields.FIELDS) final String fields)
 			throws InvalidTokenException, NoTokenProvidedException, AuthStorageException,
 			IllegalParameterException {
 		final UserSearchSpec.Builder build = UserSearchSpec.getBuilder();
@@ -87,9 +88,9 @@ public class Users {
 			final String[] splitFields = fields.split(",");
 			for (String s: splitFields) {
 				s = s.trim();
-				if (s.equals("username")) {
+				if (s.equals(Fields.SEARCH_USER)) {
 					build.withSearchOnUserName(true);
-				} else if (s.equals("displayname")) {
+				} else if (s.equals(Fields.SEARCH_DISPLAY)) {
 					build.withSearchOnDisplayName(true);
 				}
 			}

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -7,6 +7,7 @@ public class Fields {
 	/* general */
 	
 	public static final String ID = "id";
+	public static final String DESCRIPTION = "desc";
 	
 	/* login */
 	
@@ -25,6 +26,23 @@ public class Fields {
 	/* users */
 	
 	public static final String USER = "user";
+	public static final String LOCAL = "local";
+	public static final String DISPLAY = "display";
+	public static final String EMAIL = "email";
+	public static final String CREATED = "created";
+	public static final String LAST_LOGIN = "lastlogin";
+	
+	/* roles */
+	
+	public static final String ROLES = "roles";
+	public static final String CUSTOM_ROLES = "customroles";
+	
+	/* search */
+	
+	public static final String SEARCH_USER = "username";
+	public static final String SEARCH_DISPLAY = "displayname";
+	public static final String LIST = "list";
+	public static final String FIELDS = "fields";
 	
 	/* provider info */
 	
@@ -36,4 +54,9 @@ public class Fields {
 	public static final String PROV_EMAIL = "provemail";
 	public static final String PROV_FULL = "provfullname";
 	public static final String IDENTITIES = "idents";
+	
+	/* tokens */
+	
+	public static final String TOKEN_NAME = "name";
+	public static final String CUSTOM_CONTEXT = "customcontext";
 }

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -38,7 +38,12 @@ public class Fields {
 	public static final String ENABLE_TOGGLE_DATE = "enabletoggledate";
 	public static final String ENABLE_TOGGLED_BY = "enabletoggledby";
 	public static final String LAST_LOGIN = "lastlogin";
+	
+	/* passwords */
+	
 	public static final String PASSWORD = "pwd";
+	public static final String PASSWORD_OLD = "pwdold";
+	public static final String PASSWORD_NEW = "pwdnew";
 	
 	/* roles */
 	
@@ -96,6 +101,7 @@ public class Fields {
 	public static final String URL_START = "starturl";
 	public static final String URL_CANCEL = "cancelurl";
 	public static final String URL_PICK = "pickurl";
+	public static final String URL_LOGIN = "loginurl";
 	
 	/* errors */
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -25,6 +25,10 @@ public class Fields {
 	public static final String ADMIN_ONLY = "adminonly";
 	public static final String LINK_ALL = "linkall";
 	
+	/* linking */
+	
+	public static final String UNLINK = "unlink";
+	
 	/* login and linking */
 	
 	public static final String CHOICE_EXPIRES = "expires";
@@ -119,6 +123,8 @@ public class Fields {
 	public static final String URL_LOGOUT = "logouturl";
 	public static final String URL_REDIRECT = "redirecturl";
 	public static final String URL_SUGGESTNAME = "suggestnameurl";
+	public static final String URL_USER_UPDATE = "userupdateurl";
+	public static final String URL_UNLINK = "unlinkurl";
 	
 	/* errors */
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -14,6 +14,10 @@ public class Fields {
 	
 	public static final String STAY_LOGGED_IN = "stayloggedin";
 	
+	/* login and linking */
+	
+	public static final String CHOICE_EXPIRES = "expires";
+	
 	/* policy ids */
 	
 	public static final String POLICY_ID = "policyid";
@@ -62,6 +66,8 @@ public class Fields {
 	public static final String PROV_EMAIL = "provemail";
 	public static final String PROV_FULL = "provfullname";
 	public static final String IDENTITIES = "idents";
+	public static final String PROVIDER_CODE = "code";
+	public static final String PROVIDER_STATE = "state";
 	
 	/* tokens */
 	
@@ -87,6 +93,9 @@ public class Fields {
 	public static final String URL_FORCE_RESET = "forcereseturl";
 	public static final String URL_BASIC = "basicurl";
 	public static final String URL_PROVIDER = "providerurl";
+	public static final String URL_START = "starturl";
+	public static final String URL_CANCEL = "cancelurl";
+	public static final String URL_PICK = "pickurl";
 	
 	/* errors */
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -13,6 +13,12 @@ public class Fields {
 	/* login */
 	
 	public static final String STAY_LOGGED_IN = "stayloggedin";
+	public static final String LOGIN = "login";
+	public static final String CREATE = "create";
+	public static final String LOGIN_ALLOWED = "loginallowed";
+	public static final String CREATION_ALLOWED = "creationallowed";
+	public static final String ADMIN_ONLY = "adminonly";
+	public static final String LINK_ALL = "linkall";
 	
 	/* login and linking */
 	
@@ -44,6 +50,9 @@ public class Fields {
 	public static final String PASSWORD = "pwd";
 	public static final String PASSWORD_OLD = "pwdold";
 	public static final String PASSWORD_NEW = "pwdnew";
+	
+	/* suggested names */
+	public static final String AVAILABLE_NAME = "availablename";
 	
 	/* roles */
 	
@@ -102,6 +111,8 @@ public class Fields {
 	public static final String URL_CANCEL = "cancelurl";
 	public static final String URL_PICK = "pickurl";
 	public static final String URL_LOGIN = "loginurl";
+	public static final String URL_REDIRECT = "redirecturl";
+	public static final String URL_SUGGESTNAME = "suggestnameurl";
 	
 	/* errors */
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -111,6 +111,7 @@ public class Fields {
 	public static final String URL_CANCEL = "cancelurl";
 	public static final String URL_PICK = "pickurl";
 	public static final String URL_LOGIN = "loginurl";
+	public static final String URL_LOGOUT = "logouturl";
 	public static final String URL_REDIRECT = "redirecturl";
 	public static final String URL_SUGGESTNAME = "suggestnameurl";
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -14,10 +14,6 @@ public class Fields {
 	
 	public static final String STAY_LOGGED_IN = "stayloggedin";
 	
-	/* roles */
-	
-	public static final String HAS_ROLES = "hasroles";
-	
 	/* policy ids */
 	
 	public static final String POLICY_ID = "policyid";
@@ -27,21 +23,31 @@ public class Fields {
 	/* users */
 	
 	public static final String USER = "user";
+	public static final String USERS = "users";
+	public static final String HAS_USERS = "hasusers";
 	public static final String LOCAL = "local";
 	public static final String DISPLAY = "display";
 	public static final String EMAIL = "email";
 	public static final String CREATED = "created";
+	public static final String DISABLED = "disabled";
+	public static final String DISABLED_REASON = "disabledreason";
+	public static final String ENABLE_TOGGLE_DATE = "enabletoggledate";
+	public static final String ENABLE_TOGGLED_BY = "enabletoggledby";
 	public static final String LAST_LOGIN = "lastlogin";
+	public static final String PASSWORD = "pwd";
 	
 	/* roles */
 	
 	public static final String ROLES = "roles";
+	public static final String HAS_ROLES = "hasroles";
 	public static final String CUSTOM_ROLES = "customroles";
+	public static final String HAS_CUSTOM_ROLES = "hascustomroles";
 	
 	/* search */
 	
 	public static final String SEARCH_USER = "username";
 	public static final String SEARCH_DISPLAY = "displayname";
+	public static final String SEARCH_PREFIX = "prefix";
 	public static final String LIST = "list";
 	public static final String FIELDS = "fields";
 	
@@ -58,14 +64,54 @@ public class Fields {
 	
 	/* tokens */
 	
+	public static final String TOKEN = "token";
+	public static final String TOKENS = "tokens";
 	public static final String TOKEN_NAME = "name";
 	public static final String CUSTOM_CONTEXT = "customcontext";
 	
 	/* urls */
 	
+	public static final String URL_USER = "userurl";
 	public static final String URL_RESET = "reseturl";
 	public static final String URL_REVOKE = "revokeurl";
+	public static final String URL_REVOKE_ALL = "revokeallurl";
 	public static final String URL_TOKEN = "tokenurl";
 	public static final String URL_POLICY = "policyurl";
 	public static final String URL_SEARCH = "searchurl";
+	public static final String URL_CREATE = "createurl";
+	public static final String URL_ROLE = "roleurl";
+	public static final String URL_CUSTOM_ROLE = "customroleurl";
+	public static final String URL_DELETE_CUSTOM_ROLE = "deletecustomroleurl";
+	public static final String URL_DISABLE = "disableurl";
+	public static final String URL_FORCE_RESET = "forcereseturl";
+	public static final String URL_BASIC = "basicurl";
+	public static final String URL_PROVIDER = "providerurl";
+	
+	/* ***** config ***** */
+	
+	/* providers */
+	
+	public static final String CFG_PROV_ENABLED = "enabled";
+	public static final String CFG_PROV_FORCE_LOGIN_CHOICE = "forceloginchoice";
+	public static final String CFG_PROV_FORCE_LINK_CHOICE = "forcelinkchoice";
+
+	/* tokens */
+	
+	public static final String CFG_TOKEN_CACHE_TIME = "tokensugcache";
+	public static final String CFG_TOKEN_LOGIN = "tokenlogin";
+	public static final String CFG_TOKEN_AGENT = "tokenagent";
+	public static final String CFG_TOKEN_DEV = "tokendev";
+	public static final String CFG_TOKEN_SERV = "tokenserv";
+	
+	/* other */
+	
+	public static final String CFG_SHOW_STACK_TRACE = "showstack";
+	public static final String CFG_IGNORE_IP_HEADERS = "ignoreip";
+	public static final String CFG_ALLOWED_LOGIN_REDIRECT = "allowedloginredirect";
+	public static final String CFG_COMPLETE_LOGIN_REDIRECT = "completeloginredirect";
+	public static final String CFG_POST_LINK_REDIRECT = "postlinkredirect";
+	public static final String CFG_COMPLETE_LINK_REDIRECT = "completelinkredirect";
+	public static final String CFG_ALLOW_LOGIN = "allowlogin";
+	public static final String CFG_UPDATE_TIME_SEC = "updatetimesec";
+	
 }

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -42,6 +42,7 @@ public class Fields {
 	public static final String HAS_ROLES = "hasroles";
 	public static final String CUSTOM_ROLES = "customroles";
 	public static final String HAS_CUSTOM_ROLES = "hascustomroles";
+	public static final String CUSTOM_ROLE_FORM_PREFIX = "crole_";
 	
 	/* search */
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -10,6 +10,11 @@ public class Fields {
 	public static final String DESCRIPTION = "desc";
 	public static final String HAS = "has";
 	
+	/* root */
+	
+	public static final String VERSION = "version";
+	public static final String SERVER_TIME = "servertime";
+	
 	/* login */
 	
 	public static final String STAY_LOGGED_IN = "stayloggedin";

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -8,6 +8,7 @@ public class Fields {
 	
 	public static final String ID = "id";
 	public static final String DESCRIPTION = "desc";
+	public static final String HAS = "has";
 	
 	/* login */
 	
@@ -59,4 +60,12 @@ public class Fields {
 	
 	public static final String TOKEN_NAME = "name";
 	public static final String CUSTOM_CONTEXT = "customcontext";
+	
+	/* urls */
+	
+	public static final String URL_RESET = "reseturl";
+	public static final String URL_REVOKE = "revokeurl";
+	public static final String URL_TOKEN = "tokenurl";
+	public static final String URL_POLICY = "policyurl";
+	public static final String URL_SEARCH = "searchurl";
 }

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -88,6 +88,10 @@ public class Fields {
 	public static final String URL_BASIC = "basicurl";
 	public static final String URL_PROVIDER = "providerurl";
 	
+	/* errors */
+	
+	public static final String ERROR = "error";
+	
 	/* ***** config ***** */
 	
 	/* providers */

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -97,7 +97,11 @@ public class Fields {
 	public static final String TOKEN = "token";
 	public static final String TOKENS = "tokens";
 	public static final String TOKEN_NAME = "name";
+	public static final String TOKEN_TYPE = "type";
+	public static final String TOKEN_DEV = "dev";
+	public static final String TOKEN_SERVICE = "service";
 	public static final String CUSTOM_CONTEXT = "customcontext";
+	public static final String CURRENT = "current";
 	
 	/* urls */
 	

--- a/src/us/kbase/auth2/service/exceptions/ErrorMessage.java
+++ b/src/us/kbase/auth2/service/exceptions/ErrorMessage.java
@@ -29,43 +29,43 @@ public class ErrorMessage {
 	//TODO TEST unit tests
 	//TODO JAVADOC
 
-	private final int httpCode;
-	private final String httpStatus;
-	private final Integer appCode;
-	private final String appError;
+	private final int httpcode;
+	private final String httpstatus;
+	private final Integer appcode;
+	private final String apperror;
 	private final String message;
 	private final String exception;
-	private final String callID;
+	private final String callid;
 	private final long time = Instant.now().toEpochMilli();
 	@JsonIgnore
-	private final List<String> exceptionLines;
+	private final List<String> exceptionlines;
 	@JsonIgnore
-	private final boolean hasException;
+	private final boolean hasexception;
 	
 	public ErrorMessage(
 			final Throwable ex,
 			final String callID,
 			final boolean includeTrace) {
 		nonNull(ex, "ex");
-		this.callID = callID; // null ok
+		this.callid = callID; // null ok
 		if (includeTrace) {
 			final StringWriter st = new StringWriter();
 			ex.printStackTrace(new PrintWriter(st));
 			exception = st.toString();
-			exceptionLines = Collections.unmodifiableList(
+			exceptionlines = Collections.unmodifiableList(
 					Arrays.asList(exception.split("\n")));
-			hasException = true;
+			hasexception = true;
 		} else {
 			exception = null;
-			exceptionLines = null;
-			hasException = false;
+			exceptionlines = null;
+			hasexception = false;
 		}
 		message = ex.getMessage();
 		final StatusType status;
 		if (ex instanceof AuthException) {
 			final AuthException ae = (AuthException) ex;
-			appCode = ae.getErr().getErrorCode();
-			appError = ae.getErr().getError();
+			appcode = ae.getErr().getErrorCode();
+			apperror = ae.getErr().getError();
 			if (ae instanceof AuthenticationException) {
 				status = Response.Status.UNAUTHORIZED;
 			} else if (ae instanceof UnauthorizedException) {
@@ -76,8 +76,8 @@ public class ErrorMessage {
 				status = Response.Status.BAD_REQUEST;
 			}
 		} else if (ex instanceof WebApplicationException) {
-			appCode = null;
-			appError = null;
+			appcode = null;
+			apperror = null;
 			status = ((WebApplicationException) ex).getResponse()
 					.getStatusInfo();
 		} else if (ex instanceof JsonMappingException) {
@@ -85,32 +85,32 @@ public class ErrorMessage {
 			 * This may not 100% accurate, but if we're attempting to return unserializable data
 			 * that should be caught in tests.
 			 */
-			appCode = null;
-			appError = null;
+			appcode = null;
+			apperror = null;
 			status = Response.Status.BAD_REQUEST;
 		} else {
-			appCode = null;
-			appError = null;
+			appcode = null;
+			apperror = null;
 			status = Response.Status.INTERNAL_SERVER_ERROR;
 		}
-		httpCode = status.getStatusCode();
-		httpStatus = status.getReasonPhrase();
+		httpcode = status.getStatusCode();
+		httpstatus = status.getReasonPhrase();
 	}
 
-	public int getHttpCode() {
-		return httpCode;
+	public int getHttpcode() {
+		return httpcode;
 	}
 
-	public String getHttpStatus() {
-		return httpStatus;
+	public String getHttpstatus() {
+		return httpstatus;
 	}
 
-	public Integer getAppCode() {
-		return appCode;
+	public Integer getAppcode() {
+		return appcode;
 	}
 
-	public String getAppError() {
-		return appError;
+	public String getApperror() {
+		return apperror;
 	}
 
 	public String getMessage() {
@@ -121,46 +121,19 @@ public class ErrorMessage {
 		return exception;
 	}
 
-	public List<String> getExceptionLines() {
-		return exceptionLines;
+	public List<String> getExceptionlines() {
+		return exceptionlines;
 	}
 
-	public boolean hasException() {
-		return hasException;
+	public boolean hasexception() {
+		return hasexception;
 	}
 
-	public String getCallID() {
-		return callID;
+	public String getCallid() {
+		return callid;
 	}
 
 	public long getTime() {
 		return time;
-	}
-
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("ErrorMessage [httpCode=");
-		builder.append(httpCode);
-		builder.append(", httpStatus=");
-		builder.append(httpStatus);
-		builder.append(", appCode=");
-		builder.append(appCode);
-		builder.append(", appError=");
-		builder.append(appError);
-		builder.append(", message=");
-		builder.append(message);
-		builder.append(", exception=");
-		builder.append(exception);
-		builder.append(", callID=");
-		builder.append(callID);
-		builder.append(", time=");
-		builder.append(time);
-		builder.append(", exceptionLines=");
-		builder.append(exceptionLines);
-		builder.append(", hasException=");
-		builder.append(hasException);
-		builder.append("]");
-		return builder.toString();
 	}
 }

--- a/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
@@ -30,6 +30,7 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
+import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.SLF4JAutoLogger;
 import us.kbase.auth2.service.template.TemplateProcessor;
 
@@ -71,7 +72,7 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 		String ret;
 		if (mt.equals(MediaType.APPLICATION_JSON_TYPE)) {
 			final Map<String, Object> err = new HashMap<>();
-			err.put("error", em);
+			err.put(Fields.ERROR, em);
 			try {
 				ret = mapper.writeValueAsString(err);
 			} catch (JsonProcessingException e) {
@@ -81,9 +82,9 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 				LoggerFactory.getLogger(getClass()).error(ret, e);
 			}
 		} else {
-			ret = template.process("error", em);
+			ret = template.process(Fields.ERROR, em);
 		}
-		return Response.status(em.getHttpCode()).entity(ret).type(mt).build();
+		return Response.status(em.getHttpcode()).entity(ret).type(mt).build();
 	}
 	
 	private final static Set<MediaType> MEDIA_SUPPORTED = new HashSet<>(Arrays.asList(

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -194,9 +194,9 @@ public class Admin {
 			build.withSearchOnRole(r);
 		}
 		for (final String key: form.keySet()) {
-			if (key.startsWith("crole_")) {
-				if (!nullOrEmpty(form.getFirst(key))) { //TODO NOW handle crole_
-					build.withSearchOnCustomRole(key.replace("crole_", ""));
+			if (key.startsWith(Fields.CUSTOM_ROLE_FORM_PREFIX)) {
+				if (!nullOrEmpty(form.getFirst(key))) {
+					build.withSearchOnCustomRole(key.replace(Fields.CUSTOM_ROLE_FORM_PREFIX, ""));
 				}
 			}
 		}

--- a/src/us/kbase/auth2/service/ui/CustomRoles.java
+++ b/src/us/kbase/auth2/service/ui/CustomRoles.java
@@ -50,7 +50,8 @@ public class CustomRoles {
 			throws AuthStorageException, NoTokenProvidedException, InvalidTokenException,
 			UnauthorizedException { // can't actually be thrown
 		final IncomingToken token = getTokenFromCookie(headers, cfg.getTokenCookieName());
-		return ImmutableMap.of("roles", customRolesToList(auth.getCustomRoles(token, false)));
+		return ImmutableMap.of(Fields.CUSTOM_ROLES,
+				customRolesToList(auth.getCustomRoles(token, false)));
 	}
 	
 	public static List<Map<String, String>> customRolesToList(final Set<CustomRole> roles) {

--- a/src/us/kbase/auth2/service/ui/CustomRoles.java
+++ b/src/us/kbase/auth2/service/ui/CustomRoles.java
@@ -2,7 +2,10 @@ package us.kbase.auth2.service.ui;
 
 import static us.kbase.auth2.service.ui.UIUtils.getTokenFromCookie;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -15,12 +18,14 @@ import org.glassfish.jersey.server.mvc.Template;
 import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.lib.token.IncomingToken;
 import us.kbase.auth2.service.AuthAPIStaticConfig;
+import us.kbase.auth2.service.common.Fields;
 
 @Path(UIPaths.CUSTOM_ROLES_ROOT)
 public class CustomRoles {
@@ -45,7 +50,17 @@ public class CustomRoles {
 			throws AuthStorageException, NoTokenProvidedException, InvalidTokenException,
 			UnauthorizedException { // can't actually be thrown
 		final IncomingToken token = getTokenFromCookie(headers, cfg.getTokenCookieName());
-		return ImmutableMap.of("roles", auth.getCustomRoles(token, false));
+		return ImmutableMap.of("roles", customRolesToList(auth.getCustomRoles(token, false)));
+	}
+	
+	public static List<Map<String, String>> customRolesToList(final Set<CustomRole> roles) {
+		final List<Map<String, String>> ret = new LinkedList<>();
+		for (final CustomRole cr: roles) {
+			ret.add(ImmutableMap.of(
+					Fields.DESCRIPTION, cr.getDesc(),
+					Fields.ID, cr.getID()));
+		}
+		return ret;
 	}
 
 }

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -96,7 +96,7 @@ public class Link {
 		final AuthUser u = auth.getUser(incToken);
 		final Map<String, Object> ret = new HashMap<>();
 		ret.put(Fields.USER, u.getUserName().getName());
-		ret.put("local", u.isLocal());
+		ret.put(Fields.LOCAL, u.isLocal());
 		final List<Map<String, String>> provs = new LinkedList<>();
 		ret.put(Fields.PROVIDERS, provs);
 		for (final String prov: auth.getIdentityProviders()) {
@@ -104,7 +104,7 @@ public class Link {
 			rep.put(Fields.PROVIDER, prov);
 			provs.add(rep);
 		}
-		ret.put("starturl", relativize(uriInfo, UIPaths.LINK_ROOT_START));
+		ret.put(Fields.URL_START, relativize(uriInfo, UIPaths.LINK_ROOT_START));
 		ret.put(Fields.HAS_PROVIDERS, !provs.isEmpty());
 		return ret;
 	}
@@ -148,8 +148,8 @@ public class Link {
 		//TODO INPUT handle error in params (provider, state)
 		final MultivaluedMap<String, String> qps = uriInfo.getQueryParameters();
 		//TODO ERRHANDLE handle returned OAuth error code in queryparams
-		final String authcode = qps.getFirst("code"); //may need to be configurable
-		final String retstate = qps.getFirst("state"); //may need to be configurable
+		final String authcode = qps.getFirst(Fields.PROVIDER_CODE); //may need to be configurable
+		final String retstate = qps.getFirst(Fields.PROVIDER_STATE); //may need to be configurable
 		checkState(state, retstate);
 		final Optional<IncomingToken> token =
 				getTokenFromCookie(headers, cfg.getTokenCookieName(), false);
@@ -275,9 +275,9 @@ public class Link {
 			s.put(Fields.PROV_USER, ri.getDetails().getUsername());
 			ris.add(s);
 		}
-		ret.put("cancelurl", relativize(uriInfo, UIPaths.LINK_ROOT_CANCEL));
-		ret.put("pickurl", relativize(uriInfo, UIPaths.LINK_ROOT_PICK));
-		ret.put("expires", ids.getExpires().toEpochMilli());
+		ret.put(Fields.URL_CANCEL, relativize(uriInfo, UIPaths.LINK_ROOT_CANCEL));
+		ret.put(Fields.URL_PICK, relativize(uriInfo, UIPaths.LINK_ROOT_PICK));
+		ret.put(Fields.CHOICE_EXPIRES, ids.getExpires().toEpochMilli());
 		return ret;
 	}
 

--- a/src/us/kbase/auth2/service/ui/LocalAccounts.java
+++ b/src/us/kbase/auth2/service/ui/LocalAccounts.java
@@ -63,7 +63,8 @@ public class LocalAccounts {
 	@Template(name = "/locallogin")
 	@Produces(MediaType.TEXT_HTML)
 	public Map<String, String> login(@Context final UriInfo uriInfo) {
-		return ImmutableMap.of("targeturl", relativize(uriInfo, UIPaths.LOCAL_ROOT_LOGIN_RESULT));
+		return ImmutableMap.of(Fields.URL_LOGIN,
+				relativize(uriInfo, UIPaths.LOCAL_ROOT_LOGIN_RESULT));
 	}
 	
 	//TODO UI will need ajax version or at least something in the body that says a reset is required
@@ -73,10 +74,10 @@ public class LocalAccounts {
 	public Response loginResult(
 			@Context final HttpServletRequest req,
 			@FormParam(Fields.USER) final String userName,
-			@FormParam("pwd") String pwd, //char makes Jersey puke
+			@FormParam(Fields.PASSWORD) String pwd, //char makes Jersey puke
 			//checkbox, so "on" = checked, null = not checked
 			@FormParam(Fields.STAY_LOGGED_IN) final String stayLoggedIn,
-			@FormParam("customcontext") final String customContext)
+			@FormParam(Fields.CUSTOM_CONTEXT) final String customContext)
 			throws AuthStorageException, MissingParameterException,
 			AuthenticationException, IllegalParameterException,
 			UnauthorizedException {
@@ -84,7 +85,7 @@ public class LocalAccounts {
 			throw new MissingParameterException(Fields.USER);
 		}
 		if (pwd == null || pwd.trim().isEmpty()) {
-			throw new MissingParameterException("pwd");
+			throw new MissingParameterException(Fields.PASSWORD);
 		}
 		final Password cpwd = new Password(pwd.toCharArray());
 		pwd = null; // try to get pwd GC'd as quickly as possible
@@ -94,7 +95,7 @@ public class LocalAccounts {
 		final LocalLoginResult llr = auth.localLogin(new UserName(userName), cpwd, tcc);
 		//TODO LOG log
 		if (llr.isPwdResetRequired()) {
-			return Response.seeOther(toURI(UIPaths.LOCAL_ROOT_RESET + "?user=" +
+			return Response.seeOther(toURI(UIPaths.LOCAL_ROOT_RESET + "?" + Fields.USER + "=" +
 					llr.getUserName().get().getName())).build();
 		}
 		return Response.seeOther(toURI(UIPaths.ME_ROOT))
@@ -109,7 +110,8 @@ public class LocalAccounts {
 	public Map<String, Object> resetPasswordStart(
 			@QueryParam(Fields.USER) final String user,
 			@Context final UriInfo uriInfo) {
-		return ImmutableMap.of("targeturl", relativize(uriInfo, UIPaths.LOCAL_ROOT_RESET_RESULT),
+		return ImmutableMap.of(Fields.URL_RESET,
+					relativize(uriInfo, UIPaths.LOCAL_ROOT_RESET_RESULT),
 				Fields.USER, user == null ? "" : user);
 	}
 	
@@ -118,8 +120,8 @@ public class LocalAccounts {
 	@Path(UIPaths.LOCAL_RESET_RESULT)
 	public Response resetPassword(
 			@FormParam(Fields.USER) final String userName,
-			@FormParam("pwdold") String pwdold,
-			@FormParam("pwdnew") String pwdnew)
+			@FormParam(Fields.PASSWORD_OLD) String pwdold,
+			@FormParam(Fields.PASSWORD_NEW) String pwdnew)
 			throws MissingParameterException, IllegalParameterException,
 				AuthenticationException, UnauthorizedException, AuthStorageException,
 				IllegalPasswordException {
@@ -127,10 +129,10 @@ public class LocalAccounts {
 			throw new MissingParameterException(Fields.USER);
 		}
 		if (pwdold == null || pwdold.trim().isEmpty()) {
-			throw new MissingParameterException("pwdold");
+			throw new MissingParameterException(Fields.PASSWORD_OLD);
 		}
 		if (pwdnew == null || pwdnew.trim().isEmpty()) {
-			throw new MissingParameterException("pwdnew");
+			throw new MissingParameterException(Fields.PASSWORD_NEW);
 		}
 		final Password cpwdold = new Password(pwdold.toCharArray());
 		final Password cpwdnew = new Password(pwdnew.toCharArray());

--- a/src/us/kbase/auth2/service/ui/Logout.java
+++ b/src/us/kbase/auth2/service/ui/Logout.java
@@ -48,7 +48,7 @@ public class Logout {
 		final StoredToken ht = auth.getToken(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		return ImmutableMap.of(Fields.USER, ht.getUserName().getName(),
-				"logouturl", relativize(uriInfo, UIPaths.LOGOUT_ROOT_RESULT));
+				Fields.URL_LOGOUT, relativize(uriInfo, UIPaths.LOGOUT_ROOT_RESULT));
 	}
 	
 	@POST

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -97,9 +97,9 @@ public class Me {
 			throws InvalidTokenException, AuthStorageException, DisabledUserException {
 		final AuthUser u = auth.getUser(token);
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("userupdateurl", relativize(uriInfo, UIPaths.ME_ROOT));
-		ret.put("unlinkurl", relativize(uriInfo, UIPaths.ME_ROOT_UNLINK));
-		ret.put("rolesurl", relativize(uriInfo, UIPaths.ME_ROOT_ROLES));
+		ret.put(Fields.URL_USER_UPDATE, relativize(uriInfo, UIPaths.ME_ROOT));
+		ret.put(Fields.URL_UNLINK, relativize(uriInfo, UIPaths.ME_ROOT_UNLINK));
+		ret.put(Fields.URL_ROLE, relativize(uriInfo, UIPaths.ME_ROOT_ROLES));
 		ret.put(Fields.USER, u.getUserName().getName());
 		ret.put(Fields.LOCAL, u.isLocal());
 		ret.put(Fields.DISPLAY, u.getDisplayName().getName());
@@ -108,7 +108,7 @@ public class Me {
 		final Optional<Instant> ll = u.getLastLogin();
 		ret.put(Fields.LAST_LOGIN, ll.isPresent() ? ll.get().toEpochMilli() : null);
 		ret.put(Fields.CUSTOM_ROLES, u.getCustomRoles());
-		ret.put("unlink", u.getIdentities().size() > 1);
+		ret.put(Fields.UNLINK, u.getIdentities().size() > 1);
 		final List<Map<String, String>> roles = new LinkedList<>();
 		for (final Role r: u.getRoles()) {
 			final Map<String, String> role = new HashMap<>();

--- a/src/us/kbase/auth2/service/ui/Me.java
+++ b/src/us/kbase/auth2/service/ui/Me.java
@@ -101,22 +101,22 @@ public class Me {
 		ret.put("unlinkurl", relativize(uriInfo, UIPaths.ME_ROOT_UNLINK));
 		ret.put("rolesurl", relativize(uriInfo, UIPaths.ME_ROOT_ROLES));
 		ret.put(Fields.USER, u.getUserName().getName());
-		ret.put("local", u.isLocal());
-		ret.put("display", u.getDisplayName().getName());
-		ret.put("email", u.getEmail().getAddress());
-		ret.put("created", u.getCreated().toEpochMilli());
+		ret.put(Fields.LOCAL, u.isLocal());
+		ret.put(Fields.DISPLAY, u.getDisplayName().getName());
+		ret.put(Fields.EMAIL, u.getEmail().getAddress());
+		ret.put(Fields.CREATED, u.getCreated().toEpochMilli());
 		final Optional<Instant> ll = u.getLastLogin();
-		ret.put("lastlogin", ll.isPresent() ? ll.get().toEpochMilli() : null);
-		ret.put("customroles", u.getCustomRoles());
+		ret.put(Fields.LAST_LOGIN, ll.isPresent() ? ll.get().toEpochMilli() : null);
+		ret.put(Fields.CUSTOM_ROLES, u.getCustomRoles());
 		ret.put("unlink", u.getIdentities().size() > 1);
 		final List<Map<String, String>> roles = new LinkedList<>();
 		for (final Role r: u.getRoles()) {
 			final Map<String, String> role = new HashMap<>();
 			role.put(Fields.ID, r.getID());
-			role.put("desc", r.getDescription());
+			role.put(Fields.DESCRIPTION, r.getDescription());
 			roles.add(role);
 		}
-		ret.put("roles", roles);
+		ret.put(Fields.ROLES, roles);
 		ret.put(Fields.HAS_ROLES, !roles.isEmpty());
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put(Fields.IDENTITIES, idents);
@@ -128,7 +128,7 @@ public class Me {
 			idents.add(i);
 		}
 		ret.put(Fields.POLICY_IDS, u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
-			"id", id.getName(),
+			Fields.ID, id.getName(),
 			Fields.AGREED_ON, u.getPolicyIDs().get(id).toEpochMilli()))
 			.collect(Collectors.toSet()));
 		return ret;
@@ -138,8 +138,8 @@ public class Me {
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	public void update(
 			@Context final HttpHeaders headers,
-			@FormParam("display") final String displayName,
-			@FormParam("email") final String email)
+			@FormParam(Fields.DISPLAY) final String displayName,
+			@FormParam(Fields.EMAIL) final String email)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
 			IllegalParameterException, UnauthorizedException {
 		updateUser(auth, getTokenFromCookie(headers, cfg.getTokenCookieName()),
@@ -153,8 +153,8 @@ public class Me {
 		
 		@JsonCreator
 		public Update(
-				@JsonProperty("display") final String display,
-				@JsonProperty("email") final String email) {
+				@JsonProperty(Fields.DISPLAY) final String display,
+				@JsonProperty(Fields.EMAIL) final String email) {
 			this.display = display;
 			this.email = email;
 		}
@@ -180,7 +180,7 @@ public class Me {
 	public void unlink(
 			@Context final HttpHeaders headers,
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
-			@PathParam("id") final String id)
+			@PathParam(Fields.ID) final String id)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
 			UnLinkFailedException, NoSuchIdentityException, UnauthorizedException,
 			MissingParameterException {
@@ -207,7 +207,7 @@ public class Me {
 		public List<String> roles;
 		
 		@JsonCreator
-		public RolesToRemove(@JsonProperty("roles") final List<String> roles) {
+		public RolesToRemove(@JsonProperty(Fields.ROLES) final List<String> roles) {
 			this.roles = roles;
 		}
 		

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -12,6 +12,8 @@ import org.glassfish.jersey.server.mvc.Template;
 
 import com.google.common.collect.ImmutableMap;
 
+import us.kbase.auth2.service.common.Fields;
+
 @Path(UIPaths.ROOT)
 public class Root {
 	
@@ -38,7 +40,8 @@ public class Root {
 	}
 	
 	private Map<String, Object> root() {
-		return ImmutableMap.of("version", VERSION, "servertime", Instant.now().toEpochMilli());
+		return ImmutableMap.of(Fields.VERSION, VERSION,
+				Fields.SERVER_TIME, Instant.now().toEpochMilli());
 	}
 
 }

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -82,11 +82,11 @@ public class Tokens {
 			NoTokenProvidedException, UnauthorizedException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		t.put(Fields.USER, ((UIToken) t.get("current")).getUser());
-		t.put("createurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
-		t.put("revokeurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
+		t.put(Fields.USER, ((UIToken) t.get(Fields.CURRENT)).getUser());
+		t.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
+		t.put(Fields.URL_REVOKE, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
 				UIPaths.SEP));
-		t.put("revokeallurl", relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE_ALL));
+		t.put(Fields.URL_REVOKE_ALL, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE_ALL));
 		return t;
 	}
 	
@@ -107,9 +107,9 @@ public class Tokens {
 	public NewUIToken createTokenHTML(
 			@Context final HttpServletRequest req,
 			@Context final HttpHeaders headers,
-			@FormParam("name") final String tokenName,
-			@FormParam("type") final String tokenType,
-			@FormParam("customcontext") final String customContext)
+			@FormParam(Fields.TOKEN_NAME) final String tokenName,
+			@FormParam(Fields.TOKEN_TYPE) final String tokenType,
+			@FormParam(Fields.CUSTOM_CONTEXT) final String customContext)
 			throws AuthStorageException, MissingParameterException,
 			NoTokenProvidedException, InvalidTokenException,
 			UnauthorizedException, IllegalParameterException {
@@ -126,9 +126,9 @@ public class Tokens {
 		
 		@JsonCreator
 		private CreateTokenParams(
-				@JsonProperty("name") final String name,
-				@JsonProperty("type") final String type,
-				@JsonProperty("customcontext") final Map<String, String> customContext)
+				@JsonProperty(Fields.TOKEN_NAME) final String name,
+				@JsonProperty(Fields.TOKEN_TYPE) final String type,
+				@JsonProperty(Fields.CUSTOM_CONTEXT) final Map<String, String> customContext)
 				throws MissingParameterException {
 			this.name = name;
 			this.type = type;
@@ -163,7 +163,7 @@ public class Tokens {
 	@Path(UIPaths.TOKENS_REVOKE_ID)
 	public void revokeTokenPOST(
 			@Context final HttpHeaders headers,
-			@PathParam("tokenid") final UUID tokenId)
+			@PathParam(UIPaths.TOKEN_ID) final UUID tokenId)
 			throws AuthStorageException,
 			NoSuchTokenException, NoTokenProvidedException,
 			InvalidTokenException, UnauthorizedException {
@@ -173,7 +173,7 @@ public class Tokens {
 	@DELETE
 	@Path(UIPaths.TOKENS_REVOKE_ID)
 	public void revokeTokenDELETE(
-			@PathParam("tokenid") final UUID tokenId,
+			@PathParam(UIPaths.TOKEN_ID) final UUID tokenId,
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException,
 			NoSuchTokenException, NoTokenProvidedException,
@@ -211,7 +211,7 @@ public class Tokens {
 		final TokenCreationContext tcc = getTokenContext(
 				userAgentParser, req, isIgnoreIPsInHeaders(auth), customContext);
 		return new NewUIToken(auth.createToken(userToken, new TokenName(tokenName),
-				"server".equals(tokenType) ? TokenType.SERV : TokenType.DEV, tcc));
+				Fields.TOKEN_SERVICE.equals(tokenType) ? TokenType.SERV : TokenType.DEV, tcc));
 	}
 
 	private Map<String, Object> getTokens(final IncomingToken token)
@@ -220,13 +220,13 @@ public class Tokens {
 		final AuthUser au = auth.getUser(token);
 		final TokenSet ts = auth.getTokens(token);
 		final Map<String, Object> ret = new HashMap<>();
-		ret.put("current", new UIToken(ts.getCurrentToken()));
+		ret.put(Fields.CURRENT, new UIToken(ts.getCurrentToken()));
 		
 		final List<UIToken> ats = ts.getTokens().stream()
 				.map(t -> new UIToken(t)).collect(Collectors.toList());
-		ret.put("tokens", ats);
-		ret.put("dev", Role.DEV_TOKEN.isSatisfiedBy(au.getRoles()));
-		ret.put("serv", Role.SERV_TOKEN.isSatisfiedBy(au.getRoles()));
+		ret.put(Fields.TOKENS, ats);
+		ret.put(Fields.TOKEN_DEV, Role.DEV_TOKEN.isSatisfiedBy(au.getRoles()));
+		ret.put(Fields.TOKEN_SERVICE, Role.SERV_TOKEN.isSatisfiedBy(au.getRoles()));
 		return ret;
 	}
 }

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -81,22 +81,18 @@ public class Tokens {
 			throws AuthStorageException, InvalidTokenException,
 			NoTokenProvidedException, UnauthorizedException {
 		final Map<String, Object> t = getTokens(
-				getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		t.put(Fields.USER, ((UIToken) t.get(Fields.CURRENT)).getUser());
-		t.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
-		t.put(Fields.URL_REVOKE, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
-				UIPaths.SEP));
-		t.put(Fields.URL_REVOKE_ALL, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE_ALL));
+				getTokenFromCookie(headers, cfg.getTokenCookieName()), uriInfo);
 		return t;
 	}
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> getTokensJSON(
-			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
+			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
+			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
 			NoTokenProvidedException, UnauthorizedException {
-		return getTokens(getToken(headerToken));
+		return getTokens(getToken(headerToken), uriInfo);
 	}
 	
 	@POST
@@ -214,7 +210,7 @@ public class Tokens {
 				Fields.TOKEN_SERVICE.equals(tokenType) ? TokenType.SERV : TokenType.DEV, tcc));
 	}
 
-	private Map<String, Object> getTokens(final IncomingToken token)
+	private Map<String, Object> getTokens(final IncomingToken token, final UriInfo uriInfo)
 			throws AuthStorageException, NoTokenProvidedException,
 			InvalidTokenException, UnauthorizedException {
 		final AuthUser au = auth.getUser(token);
@@ -227,6 +223,11 @@ public class Tokens {
 		ret.put(Fields.TOKENS, ats);
 		ret.put(Fields.TOKEN_DEV, Role.DEV_TOKEN.isSatisfiedBy(au.getRoles()));
 		ret.put(Fields.TOKEN_SERVICE, Role.SERV_TOKEN.isSatisfiedBy(au.getRoles()));
+		ret.put(Fields.USER, au.getUserName().getName());
+		ret.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
+		ret.put(Fields.URL_REVOKE, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
+				UIPaths.SEP));
+		ret.put(Fields.URL_REVOKE_ALL, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE_ALL));
 		return ret;
 	}
 }

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -20,7 +20,6 @@ public class UIPaths {
 	private static final String REVOKE_ALL = "revokeall";
 	private static final String SUGGESTNAME = "suggestname";
 	private static final String NAME_ID = "{name}";
-	private static final String TOKEN_ID = "{tokenid}";
 	private static final String ID = "{id}";
 	private static final String LOGIN = "login";
 	private static final String LOCAL = "localaccount";
@@ -31,6 +30,8 @@ public class UIPaths {
 	private static final String START = "start";
 	private static final String TOKEN = "token";
 	private static final String TOKENS = "tokens";
+	public static final String TOKEN_ID = "tokenid";
+	private static final String TOKEN_ID_PARAM = "{" + TOKEN_ID + "}";
 	private static final String CUSTOM_ROLES = "customroles";
 	
 	/* Root endpoint */
@@ -78,7 +79,7 @@ public class UIPaths {
 	public static final String ADMIN_USER_TOKENS_REVOKE_ALL = ADMIN_USER_TOKENS + SEP + REVOKE_ALL;
 	public static final String ADMIN_USER_TOKENS_REVOKE = REVOKE;
 	public static final String ADMIN_USER_TOKENS_REVOKE_ID = ADMIN_USER_TOKENS + SEP + 
-			ADMIN_USER_TOKENS_REVOKE + SEP + TOKEN_ID;
+			ADMIN_USER_TOKENS_REVOKE + SEP + TOKEN_ID_PARAM;
 	
 	public static final String ADMIN_CUSTOM_ROLES = CUSTOM_ROLES;
 	public static final String ADMIN_USER_CUSTOM_ROLES = ADMIN_USER_PARAM + SEP +
@@ -175,7 +176,7 @@ public class UIPaths {
 	public static final String TOKENS_ROOT_CREATE = TOKENS_ROOT + TOKENS_CREATE;
 	public static final String TOKENS_REVOKE = REVOKE;
 	public static final String TOKENS_ROOT_REVOKE = TOKENS_ROOT + TOKENS_REVOKE;
-	public static final String TOKENS_REVOKE_ID = TOKENS_REVOKE + SEP + TOKEN_ID;
+	public static final String TOKENS_REVOKE_ID = TOKENS_REVOKE + SEP + TOKEN_ID_PARAM;
 	public static final String TOKENS_REVOKE_ALL = REVOKE_ALL;
 	public static final String TOKENS_ROOT_REVOKE_ALL = TOKENS_ROOT + TOKENS_REVOKE_ALL;
 	

--- a/src/us/kbase/test/auth2/cli/AuthCLITest.java
+++ b/src/us/kbase/test/auth2/cli/AuthCLITest.java
@@ -78,7 +78,7 @@ public class AuthCLITest {
 	private static MongoDatabase db;
 	private static MongoStorage storage;
 	
-	//TODO NOW make mongo test manger class that does this stuff
+	//TODO TEST make mongo test manger class that does this stuff
 	
 	@BeforeClass
 	public static void beforeClass() throws Exception {

--- a/templates/admincustomroles.mustache
+++ b/templates/admincustomroles.mustache
@@ -10,14 +10,14 @@
 Description:<br/>
 {{desc}}
 <br/>
-<form action="{{delroleurl}}" method="post">
+<form action="{{deletecustomroleurl}}" method="post">
 	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Delete"/>
 </form>
 </p>
 {{/roles}}
 
-<form action="{{custroleurl}}" method="post" id="custroleform">
+<form action="{{customroleurl}}" method="post" id="custroleform">
 ID: <input type="text" name="id"/><br/>
 Description:<br/>
 <textarea name="desc" form="custroleform" cols="40" rows="5"></textarea><br/>

--- a/templates/admincustomroles.mustache
+++ b/templates/admincustomroles.mustache
@@ -6,12 +6,12 @@
 <h3>Custom roles:</h3>
 {{#roles}}
 <p>
-<h4>ID: {{ID}}</h4>
+<h4>ID: {{id}}</h4>
 Description:<br/>
 {{desc}}
 <br/>
 <form action="{{delroleurl}}" method="post">
-	<input type="hidden" name="id" value="{{ID}}"/>
+	<input type="hidden" name="id" value="{{id}}"/>
 	<input type="submit" value="Delete"/>
 </form>
 </p>

--- a/templates/admingeneral.mustache
+++ b/templates/admingeneral.mustache
@@ -30,9 +30,9 @@
 	<input type="checkbox" name="CreateAdmin" /> Create admin<br/>
 	<br/>
 	Search on custom roles:<br/>
-	{{#croles}}
-	<input type="checkbox" name="crole_{{ID}}" /> {{ID}}<br/>
-	{{/croles}}
+	{{#customroles}}
+	<input type="checkbox" name="crole_{{id}}" /> {{id}}<br/>
+	{{/customroles}}
 	<input type="submit" value="Search"/>
 </body>
 </html>

--- a/templates/adminlocalaccount.mustache
+++ b/templates/adminlocalaccount.mustache
@@ -1,7 +1,7 @@
 <html>
 <body>
 Create a new local user:
-<form action="{{targeturl}}" method="post">
+<form action="{{createurl}}" method="post">
 	User name: <input type="text" name="user"/><br/>
 	Display name: <input type="text" name="display"/><br/>
 	Email: <input type="text" name="email"/></br/>

--- a/templates/adminlocalaccountcreated.mustache
+++ b/templates/adminlocalaccountcreated.mustache
@@ -7,7 +7,7 @@ Account created!</br>
 User name: {{user}}</br>
 Display name: {{display}}</br>
 Email: {{email}}</br>
-Temporary password: {{password}}</br>
+Temporary password: {{pwd}}</br>
 Will require a reset. There is no way to see this password again once you
 navigate away from this page.
 

--- a/templates/adminsearch.mustache
+++ b/templates/adminsearch.mustache
@@ -6,7 +6,7 @@
 No users found.
 {{/hasusers}}
 {{#users}}
-<a href="{{url}}">{{user}} ({{display}})</a><br/>
+<a href="{{userurl}}">{{user}} ({{display}})</a><br/>
 {{/users}}
 </body>
 </html>

--- a/templates/adminuser.mustache
+++ b/templates/adminuser.mustache
@@ -7,11 +7,11 @@
 User name: {{user}}<br/>
 {{#disabled}}
 <p>
-DISABLED by {{enabledtoggledby}} on {{enabletoggledate}}. Reason given:<br/>
+DISABLED by {{enabletoggledby}} on {{enabletoggledate}}. Reason given:<br/>
 {{disabledreason}}
 {{/disabled}}</p>
 {{^disabled}}{{#enabletoggledate}}
-Account re-enabled on {{enabletoggledate}} {{#enabledtoggledby}} by {{enabledtoggledby}}{{/enabledtoggledby}}<br/>
+Account re-enabled on {{enabletoggledate}} {{#enabletoggledby}} by {{enabletoggledby}}{{/enabletoggledby}}<br/>
 {{/enabletoggledate}}{{/disabled}}
 Display name: {{display}}<br/>
 Email: {{email}}<br/>
@@ -43,28 +43,28 @@ Local: {{local}}
 
 <h3>Custom roles:</h3>
 <p>Note that in a proper UI, the role descriptions should be HTML-escaped.</p>
-{{#hascustom}}
+{{#hascustomroles}}
 <form action="{{customroleurl}}" method="post">
-{{/hascustom}}
-{{#custom}}
+{{/hascustomroles}}
+{{#customroles}}
 <p>
 ID: {{id}} <input type="checkbox" name="{{id}}" {{#has}}checked{{/has}}/><br/>
 Description:<br/>
 {{desc}}
 </p>
-{{/custom}}
-{{#hascustom}}
+{{/customroles}}
+{{#hascustomroles}}
 <input type="reset" value="Reset"/>
 <input type="submit" value="Update"/>
 </form>
-{{/hascustom}}
+{{/hascustomroles}}
 
 <p><a href="{{tokenurl}}">Manage user's tokens</a></p>
 
 Note that if all admins are disabled you can reenable the root account from the manage_auth script.
 <form action="{{disableurl}}" method="post" id="disableform">
-	Disabled: <input type="checkbox" name="disable" {{#disabled}}checked{{/disabled}} /><br/>
-	Reason: <textarea name="reason" form="disableform" cols="40" rows="5"></textarea><br/>
+	Disabled: <input type="checkbox" name="disabled" {{#disabled}}checked{{/disabled}} /><br/>
+	Reason: <textarea name="disabledreason" form="disableform" cols="40" rows="5"></textarea><br/>
 	<input type="reset" value="Reset"/>
 	<input type="submit" value="Update"/>
 </form>

--- a/templates/customroles.mustache
+++ b/templates/customroles.mustache
@@ -4,13 +4,13 @@
 <p>Note that in a proper UI, the role descriptions should be HTML-escaped.</p>
 
 <h3>Custom roles:</h3>
-{{#roles}}
+{{#customroles}}
 <p>
 <h4>ID: {{id}}</h4>
 Description:<br/>
 {{desc}}
 </p>
-{{/roles}}
+{{/customroles}}
 
 </html>
 </body>

--- a/templates/customroles.mustache
+++ b/templates/customroles.mustache
@@ -6,7 +6,7 @@
 <h3>Custom roles:</h3>
 {{#roles}}
 <p>
-<h4>ID: {{ID}}</h4>
+<h4>ID: {{id}}</h4>
 Description:<br/>
 {{desc}}
 </p>

--- a/templates/error.mustache
+++ b/templates/error.mustache
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
-    <title>{{httpCode}} {{httpStatus}}</title>
+    <title>{{httpcode}} {{httpstatus}}</title>
   </head>
   <body>
     <p>Note that in a proper UI, the error message and exception should be HTML-escaped.</p>
@@ -10,25 +10,25 @@
     Gee whiz, I sure am sorry, but an error occurred. Gosh!
     </p>
     Timestamp: {{time}}<br/>
-    {{#callID}}
-        Call ID: {{callID}}</br>
-    {{/callID}}
-    Http code: {{httpCode}}<br/>
-    Http status: {{httpStatus}}<br/>
-    {{#appCode}}
-        Application code: {{appCode}}</br>
-    {{/appCode}}
-    {{#appError}}
-        Application error: {{appError}}</br>
-    {{/appError}}
+    {{#callid}}
+        Call ID: {{callid}}</br>
+    {{/callid}}
+    Http code: {{httpcode}}<br/>
+    Http status: {{httpstatus}}<br/>
+    {{#appcode}}
+        Application code: {{appcode}}</br>
+    {{/appcode}}
+    {{#apperror}}
+        Application error: {{apperror}}</br>
+    {{/apperror}}
     Message: {{message}}<br/>
-    {{#hasException}}
+    {{#hasexception}}
     Exception:<br/>
     <pre>
-    {{#exceptionLines}}
+    {{#exceptionlines}}
         {{{.}}}
-    {{/exceptionLines}}
+    {{/exceptionlines}}
     </pre>
-    {{/hasException}}
+    {{/hasexception}}
   </body>
 </html>

--- a/templates/locallogin.mustache
+++ b/templates/locallogin.mustache
@@ -2,7 +2,7 @@
 <body>
 Login with a local account. These accounts are not available to the general
 public or even most developers.</br>
-<form action="{{targeturl}}" method="post">
+<form action="{{loginurl}}" method="post">
 	User name: <input type="text" name="user"/><br/>
 	Password: <input type="password" name="pwd"/><br/>
 	Custom token creation context: <input type="text" name="customcontext"/><br/>

--- a/templates/localreset.mustache
+++ b/templates/localreset.mustache
@@ -1,7 +1,7 @@
 <html>
 <body>
 <p>Reset a password for a local account.</p>
-<form action="{{targeturl}}" method="post">
+<form action="{{reseturl}}" method="post">
 	User name: <input type="text" name="user" value="{{user}}"/><br/>
 	Old password: <input type="password" name="pwdold"/><br/>
 	New password: <input type="password" name="pwdnew"/><br/>

--- a/templates/loginchoice.mustache
+++ b/templates/loginchoice.mustache
@@ -44,7 +44,7 @@ Email is only visible to you, software acting on your behalf, and system adminis
 <p>Create an account linked to {{provusername}}</p>
 
 <form action="{{createurl}}" method="post">
-	User name: <input type="text" name="user" value="{{usernamesugg}}"/><br/>
+	User name: <input type="text" name="user" value="{{availablename}}"/><br/>
 	Display name: <input type="text" name="display" value="{{provfullname}}"/><br/>
 	Email: <input type="text" name="email" value="{{provemail}}"/><br/>
 	Policy IDs: <input type="text" name="policyids"/><br>

--- a/templates/loginstart.mustache
+++ b/templates/loginstart.mustache
@@ -9,7 +9,7 @@
 	<input type="radio" name="provider" value="{{provider}}"/>{{provider}}<br/>
 {{/providers}}
 	<input type="checkbox" name="stayloggedin"/> Keep me logged in<br/>
-	Redirect after login: <input type="text" name="redirect"/><br/>
+	Redirect after login: <input type="text" name="redirecturl"/><br/>
 	<input type="submit" value="Submit"/>
 </form>
 

--- a/templates/me.mustache
+++ b/templates/me.mustache
@@ -10,7 +10,7 @@ Local account<br/>
 {{/local}}
 <h3>Roles:</h3>
 {{#hasroles}}
-<form action="{{rolesurl}}" method="post">
+<form action="{{roleurl}}" method="post">
 {{#roles}}
 	<input type="checkbox" name="{{id}}"/> {{desc}}<br/>
 {{/roles}}

--- a/templates/tokencreate.mustache
+++ b/templates/tokencreate.mustache
@@ -4,7 +4,7 @@
 <p>Note that in a proper UI, the token name should be HTML-escaped.</p>
 
 Created token for {{user}}:<br/>
-Times are in seconds since the epoch.<br/>
+Times are in milliseconds since the epoch.<br/>
 Once you navigate away from this page, you'll never be able to see this token
 again.<br/>
 

--- a/templates/tokens.mustache
+++ b/templates/tokens.mustache
@@ -10,9 +10,9 @@ Expiration and creation dates are in milliseconds from the epoch.
 <form action="{{createurl}}" method="post">
 	Token name: <input type="text" name="name"/><br/>
 	Custom token creation context: <input type="text" name="customcontext"/><br/>
-{{#serv}}
-	<input type="checkbox" name="type" value="server"/>Server token<br/>
-{{/serv}}
+{{#service}}
+	<input type="checkbox" name="type" value="service"/>Server token<br/>
+{{/service}}
 	<input type="submit" value="Submit"/>
 </form>
 {{/dev}}


### PR DESCRIPTION
Also some path parameter strings.

Some keys changed for consistency of style and key names. Key changes that might affect the current ui are listed below (there are other changes, but I don't think they affect the ui).

* The error structure keys have been changed from CamelCase to alllowercase.
* Changed name and usersuggname in /login/suggestname and /login/choice to 'availablename'
* /login/start redirect -> redirecturl like in other places
* /me rolesurl -> roleurl
* /tokens serv/server -> service

Also added the relevant token urls to GET /tokens with JSON. Previously returned with HTML only.
