### PR TITLE
Login / link cookie review

### DIFF
--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -49,8 +49,7 @@ public class LoggingFilter implements ContainerRequestFilter,
 					"An error occurred in the logger when attempting " +
 					"to get the server configuration", e); 
 		}
-		logger.setCallInfo(reqcon.getMethod(),
-				("" + Math.random()).substring(2),
+		logger.setCallInfo(reqcon.getMethod(), ("" + Math.random()).substring(2),
 				getIpAddress(reqcon, ignoreIPheaders));
 	}
 	

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -61,6 +61,7 @@ public class Fields {
 	public static final String PASSWORD_NEW = "pwdnew";
 	
 	/* suggested names */
+	
 	public static final String AVAILABLE_NAME = "availablename";
 	
 	/* roles */

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -159,13 +159,13 @@ public class Login {
 		final String state = auth.getBareToken();
 		final URI target = toURI(auth.getIdentityProviderURL(provider, state, false));
 		
-		final ResponseBuilder r = Response.seeOther(target).cookie(getStateCookie(state))
+		return Response.seeOther(target)
+				.cookie(getStateCookie(state))
 				.cookie(getSessionChoiceCookie(stayLoggedIn == null,
-						PROVIDER_RETURN_EXPIRATION_SEC));
-		if (redirect != null && !redirect.trim().isEmpty()) {
-			r.cookie(getRedirectCookie(redirect, PROVIDER_RETURN_EXPIRATION_SEC));
-		}
-		return r.build();
+						PROVIDER_RETURN_EXPIRATION_SEC))
+				// will remove redirect cookie if redirect isn't set and one exists
+				.cookie(getRedirectCookie(redirect, PROVIDER_RETURN_EXPIRATION_SEC))
+				.build();
 	}
 
 	private URL getRedirectURL(final String redirect)
@@ -199,10 +199,9 @@ public class Login {
 	}
 
 	private NewCookie getRedirectCookie(final String redirect, final int expirationTimeSec) {
-		final boolean noRedir = redirect == null || redirect.isEmpty();
+		final boolean noRedir = redirect == null || redirect.trim().isEmpty();
 		return new NewCookie(new Cookie(REDIRECT_COOKIE,
-				noRedir ? "no redirect" : redirect,
-						UIPaths.LOGIN_ROOT, null),
+				noRedir ? "no redirect" : redirect, UIPaths.LOGIN_ROOT, null),
 				"redirect url",
 				noRedir ? 0 : expirationTimeSec,
 				UIConstants.SECURE_COOKIES);


### PR DESCRIPTION
Ensure that cookies aren't hanging around or used when they shouldn't
be.

Change is to remove the redirect cookie at /login/start if no redirect
is set.

4 non-session login cookies:
in process login token
session choice
redirect
state

/login/start
state is set / overwritten
redirect is set / removed
session choice is set /overwritten
in process is unused

/login/complete/provider
in process is set / overwritten
redirect is refreshed or removed
state is removed
session choice is refreshed

/login/choice
no cookie actions

/login/pick and /login/choice
all cookies are removed

2 link cookies:
in process link token
state token

/link/start:
state is set / overwritten
in process is unused

/link/complete/provider
in process is set / overwritten
state is removed

/link/choice
no cookie actions

/link/pick
in process is removed