### PR TITLE
improvements to build file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,23 +3,37 @@
   <description>
       Build file for the second KBase Authentication Service 
   </description>
-	
+
   <!-- TODO ZLATER BUILD switch to gradle or at least ivy -->
 
   <!-- set global properties for this build -->
   <property name="package" value="KBase authentication service"/>
   <property name="src" location="src"/>
   <property name="lib" location="lib"/>
-  <property name="dist" location="dist"/>
-  <property name="jardir" location="../jars/lib/jars/"/>
-  <property name="classes" location="classes"/>
-  <property name="doc" location="docs/javadoc"/>
+  <property name="dist.dir" location="dist"/>
+  <property name="jar.dir" location="../jars/lib/jars/"/>
+  <property name="classes.dir" location="classes"/>
+  <property name="doc.dir" location="docs/javadoc"/>
   <property name="testjar.file" value="KBaseAuth2Test.jar"/>
   <property name="jar.file" value="KBaseAuth2.jar"/>
   <property name="war.file" value="KBaseAuth2.war"/>
   <property name="war.dir" value="war"/>
+  <property name="script.file" value="manage_auth"/>
 
-  <fileset dir="${jardir}" id="lib">
+  <target name="help">
+    <echo message="build    - Generates a new files as specified by 'compile', 'buildwar', 'script' and 'javadoc'."/>
+    <echo message="buildwar - Generates a new war file ${war.dir}/${war.file}."/>
+    <echo message="clean    - Removes all generated files and directories."/>
+    <echo message="compile  - Generates a new set of classes in ${classes.dir}, ${line.separator}
+         and a new set of jar files in ${dist.dir}."/>
+    <echo message="init     - Creates a new set of empty directories where generated files are to be written. ${line.separator}
+         Deletes any existing directories before creating new ones."/>
+    <echo message="javadoc  - Generates javadoc documentation at ${doc.dir}."/>
+    <echo message="script   - Generates a new CLI script ./${script.file}."/>
+    <echo message="test     - Executes unit tests."/>
+  </target>
+
+  <fileset dir="${jar.dir}" id="lib">
     <include name="apache_commons/commons-codec-1.8.jar"/>
     <include name="apache_commons/commons-validator-1.5.1.jar"/>
     <include name="google/guava-18.0.jar"/>
@@ -30,7 +44,7 @@
     <include name="nulab-inc/zxcvbn-1.2.2.jar"/>
   </fileset>
 
-  <fileset dir="${jardir}" id="logging">
+  <fileset dir="${jar.dir}" id="logging">
     <include name="kbase/common/kbase-common-0.0.22.jar"/>
     <include name="jna/jna-3.4.0.jar"/>
     <include name="logback/logback-core-1.1.2.jar"/>
@@ -39,7 +53,7 @@
     <include name="syslog4j/syslog4j-0.9.46.jar"/>
   </fileset>
 	
-  <fileset dir="${jardir}" id="yauaa">
+  <fileset dir="${jar.dir}" id="yauaa">
     <include name="yauaa/yauaa-1.3.jar"/>
     <include name="apache_commons/commons-lang3-3.5.jar"/>
     <include name="apache_commons/commons-collections4-4.1.jar"/>
@@ -48,7 +62,7 @@
     <include name="snakeyaml/snakeyaml-1.18.jar"/>
   </fileset>
 
-  <fileset dir="${jardir}" id="jackson">
+  <fileset dir="${jar.dir}" id="jackson">
     <include name="jackson/jackson-annotations-2.5.4.jar"/>
     <include name="jackson/jackson-core-2.5.4.jar"/>
     <include name="jackson/jackson-databind-2.5.4.jar"/>
@@ -57,7 +71,7 @@
     <include name="jackson/jackson-module-jaxb-annotations-2.5.4.jar"/>
   </fileset>
 	
-  <fileset dir="${jardir}" id="jersey">
+  <fileset dir="${jar.dir}" id="jersey">
     <include name="jersey/entity-filtering/jersey-entity-filtering-2.23.2.jar"/>
     <include name="jersey/entity-filtering/jersey-media-json-jackson-2.23.2.jar"/>
     <include name="jersey/mvc/jersey-mvc-2.23.2.jar"/>
@@ -71,7 +85,7 @@
     <include name="jersey/jersey-server-2.23.2.jar"/>
   </fileset>
 
-  <fileset dir="${jardir}" id="jerseydeps">
+  <fileset dir="${jar.dir}" id="jerseydeps">
     <include name="annotation/javax.annotation-api-1.2.jar"/>
     <include name="asm/asm-debug-all-5.0.4.jar"/>
     <include name="inject/javax.inject-2.5.0-b05.jar"/>
@@ -84,7 +98,7 @@
     <include name="validationapi/validation-api-1.1.0.Final.jar"/>
   </fileset>
 
-  <fileset dir="${jardir}" id="jerseydep_hk2">
+  <fileset dir="${jar.dir}" id="jerseydep_hk2">
     <include name="hk2/aopalliance-repackaged-2.5.0-b05.jar"/>
     <include name="hk2/hk2-api-2.5.0-b05.jar"/>
     <include name="hk2/hk2-locator-2.5.0-b05.jar"/>
@@ -92,7 +106,7 @@
     <include name="hk2/osgi-resource-locator-1.0.1.jar"/>
   </fileset>
 	
-  <fileset dir="${jardir}" id="testlibs">
+  <fileset dir="${jar.dir}" id="testlibs">
     <include name="equalsverifier/equalsverifier-2.2.2.jar"/>
     <include name="jsemver/java-semver-0.9.0.jar"/>
     <include name="junit/junit-4.12.jar"/>
@@ -121,8 +135,8 @@
 
   <path id="test.classpath">
     <path refid="compile.classpath"/>
-    <fileset file="${dist}/${jar.file}"/>
-    <fileset file="${dist}/${testjar.file}"/>
+    <fileset file="${dist.dir}/${jar.file}"/>
+    <fileset file="${dist.dir}/${testjar.file}"/>
   </path>
 	
   <target name="build" depends="compile,buildwar,script,javadoc"
@@ -130,14 +144,14 @@
 
   <target name="init" description="make directories">
     <!-- Create the output directory structure-->
-    <mkdir dir="${classes}"/>
-    <mkdir dir="${dist}"/>
+    <mkdir dir="${classes.dir}"/>
+    <mkdir dir="${dist.dir}"/>
   </target>
 
   <target name="compile" depends="init" description="compile the source">
     <!-- Compile class files-->
     <javac srcdir="${src}"
-           destdir="${classes}"
+           destdir="${classes.dir}"
            excludes="**/StartAuthServer.java"
            includeantruntime="false"
            debug="true"
@@ -147,13 +161,13 @@
       <compilerarg line="-encoding utf-8"/>
     </javac>
     <!-- Make main jar file-->
-    <jar destfile="${dist}/${jar.file}"
-         basedir="${classes}"
+    <jar destfile="${dist.dir}/${jar.file}"
+         basedir="${classes.dir}"
          includes="us/kbase/auth2/**"
     />
     <!-- Make test jar file-->
-    <jar destfile="${dist}/${testjar.file}"
-         basedir="${classes}"
+    <jar destfile="${dist.dir}/${testjar.file}"
+         basedir="${classes.dir}"
          includes="us/kbase/test/**"
     />
   </target>
@@ -164,14 +178,14 @@
     <copy todir="${war.dir}/lib/" flatten="true">
       <union refid="applicationjars"/>
     </copy>
-    <war destfile="${dist}/${war.file}" webxml="${war.dir}/web.xml">
-      <classes dir="${classes}" includes="us/kbase/auth2/**"/>
+    <war destfile="${dist.dir}/${war.file}" webxml="${war.dir}/web.xml">
+      <classes dir="${classes.dir}" includes="us/kbase/auth2/**"/>
       <lib dir="${war.dir}/lib/"/>
     </war>
     <!-- Remove uncompressed class files and libs-->
     <delete dir="${war.dir}/lib"/>
     <!-- copy war to jettybase -->
-    <copy tofile="./jettybase/webapps/ROOT.war" file="${dist}/${war.file}" />
+    <copy tofile="./jettybase/webapps/ROOT.war" file="${dist.dir}/${war.file}" />
     <!-- probably a better way to do this -->
     <delete dir="./jettybase/templates"/>
     <mkdir dir="./jettybase/templates"/>
@@ -184,7 +198,7 @@
     <javadoc access="protected"
              author="false"
              classpathref="compile.classpath"
-             destdir="${doc}"
+             destdir="${doc.dir}"
              sourcepath="${src}"
              excludepackagenames="us.kbase.test.*"
              nodeprecated="false"
@@ -282,16 +296,16 @@
 	
   <target name="script" depends="compile" description="create cli script">
     <pathconvert targetos="unix" property="lib.classpath" refid="applicationjars"/>
-    <echo file="./manage_auth">#!/bin/sh
-java -cp ${dist}/${jar.file}:${lib.classpath} us.kbase.auth2.cli.AuthCLI $@
+    <echo file="./{$script.file}">#!/bin/sh
+java -cp ${dist.dir}/${jar.file}:${lib.classpath} us.kbase.auth2.cli.AuthCLI $@
     </echo>
-    <chmod file="./manage_auth" perm="a+x"/>
+    <chmod file="./{script.file}" perm="a+x"/>
   </target>
 	
   <target name="clean" description="clean up" >
     <!-- Clean up internal temporary files and folders-->
-    <delete dir="${classes}"/>
-    <delete dir="${dist}"/>
+    <delete dir="${classes.dir}"/>
+    <delete dir="${dist.dir}"/>
   </target>
 </project>
 

--- a/build.xml
+++ b/build.xml
@@ -18,18 +18,19 @@
   <property name="jar.file" value="KBaseAuth2.jar"/>
   <property name="war.file" value="KBaseAuth2.war"/>
   <property name="war.dir" value="war"/>
-  <property name="script.file" value="manage_auth"/>
+  <property name="script.file" value="./manage_auth"/>
+  <property name="deploy.dir" value="./jettybase"/>
 
   <target name="help">
     <echo message="build    - Generates a new files as specified by 'compile', 'buildwar', 'script' and 'javadoc'."/>
-    <echo message="buildwar - Generates a new war file ${war.dir}/${war.file}."/>
+    <echo message="buildwar - Generates a new war file ${war.dir}/${war.file} and deploys it to ${deploy.dir}."/>
     <echo message="clean    - Removes all generated files and directories."/>
     <echo message="compile  - Generates a new set of classes in ${classes.dir}, ${line.separator}
          and a new set of jar files in ${dist.dir}."/>
     <echo message="init     - Creates a new set of empty directories where generated files are to be written. ${line.separator}
          Deletes any existing directories before creating new ones."/>
     <echo message="javadoc  - Generates javadoc documentation at ${doc.dir}."/>
-    <echo message="script   - Generates a new CLI script ./${script.file}."/>
+    <echo message="script   - Generates a new CLI script ${script.file}."/>
     <echo message="test     - Executes unit tests."/>
   </target>
 
@@ -142,10 +143,11 @@
   <target name="build" depends="compile,buildwar,script,javadoc"
     description="build everything"/>
 
-  <target name="init" description="make directories">
+  <target name="init" depends="clean" description="make directories">
     <!-- Create the output directory structure-->
     <mkdir dir="${classes.dir}"/>
     <mkdir dir="${dist.dir}"/>
+    <mkdir dir="${doc.dir}"/>
   </target>
 
   <target name="compile" depends="init" description="compile the source">
@@ -185,11 +187,11 @@
     <!-- Remove uncompressed class files and libs-->
     <delete dir="${war.dir}/lib"/>
     <!-- copy war to jettybase -->
-    <copy tofile="./jettybase/webapps/ROOT.war" file="${dist.dir}/${war.file}" />
+    <copy tofile="${deploy.dir}/webapps/ROOT.war" file="${dist.dir}/${war.file}" />
     <!-- probably a better way to do this -->
-    <delete dir="./jettybase/templates"/>
-    <mkdir dir="./jettybase/templates"/>
-    <copy todir="./jettybase/templates">
+    <delete dir="${deploy.dir}/templates"/>
+    <mkdir dir="${deploy.dir}/templates"/>
+    <copy todir="${deploy.dir}/templates">
       <fileset dir="./templates" includes="**"/>  
     </copy>
   </target>
@@ -296,16 +298,19 @@
 	
   <target name="script" depends="compile" description="create cli script">
     <pathconvert targetos="unix" property="lib.classpath" refid="applicationjars"/>
-    <echo file="./{$script.file}">#!/bin/sh
+    <echo file="${script.file}">#!/bin/sh
 java -cp ${dist.dir}/${jar.file}:${lib.classpath} us.kbase.auth2.cli.AuthCLI $@
     </echo>
-    <chmod file="./{script.file}" perm="a+x"/>
+    <chmod file="${script.file}" perm="a+x"/>
   </target>
 	
   <target name="clean" description="clean up" >
     <!-- Clean up internal temporary files and folders-->
     <delete dir="${classes.dir}"/>
     <delete dir="${dist.dir}"/>
+    <delete file="${war.file}"/>
+    <delete dir="${doc.dir}"/>
+    <delete file="${script.file}"/>
   </target>
 </project>
 

--- a/build.xml
+++ b/build.xml
@@ -8,7 +8,8 @@
 
   <!-- set global properties for this build -->
   <property name="package" value="KBase authentication service"/>
-  <property name="src" location="src"/>
+  <property name="src.dir" location="src"/>
+  <property name="src.tests.dir" location="src"/>
   <property name="lib" location="lib"/>
   <property name="dist.dir" location="dist"/>
   <property name="jar.dir" location="../jars/lib/jars/"/>
@@ -152,7 +153,7 @@
 
   <target name="compile" depends="init" description="compile the source">
     <!-- Compile class files-->
-    <javac srcdir="${src}"
+    <javac srcdir="${src.dir}"
            destdir="${classes.dir}"
            excludes="**/StartAuthServer.java"
            includeantruntime="false"
@@ -220,78 +221,15 @@
 	
   <target name="test" depends="compile" description="run tests">
     <echo message="starting ${package} tests"/>
-    <junit failureproperty="test.failed" fork="yes">
+    <junit failureproperty="test.failed" fork="no" printsummary="on">
       <classpath refid="test.classpath"/>
       <formatter type="plain" usefile="false" />
       <sysproperty key="AUTH2_TEST_CONFIG" value="./test.cfg" />
-      <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
-      <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
-      <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationConstructorTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationDisableUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetAvailableUserNameTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationImportUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationLinkTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationLoginTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationPolicyIDTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationUserUpdateTest"/>
-      <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.DisplayNameTest"/>
-      <test name="us.kbase.test.auth2.lib.EmailAddressTest"/>
-      <test name="us.kbase.test.auth2.lib.LinkIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.LinkTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.LocalLoginResultTest"/>
-      <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
-      <test name="us.kbase.test.auth2.lib.NameTest"/>
-      <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
-      <test name="us.kbase.test.auth2.lib.PasswordTest"/>
-      <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
-      <test name="us.kbase.test.auth2.lib.RoleTest"/>
-      <test name="us.kbase.test.auth2.lib.TemporaryIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.TokenCreationContextTest"/>
-      <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
-      <test name="us.kbase.test.auth2.lib.UserNameTest"/>
-      <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
-      <test name="us.kbase.test.auth2.lib.UserUpdateTest"/>
-      <test name="us.kbase.test.auth2.lib.UtilsTest"/>
-      <test name="us.kbase.test.auth2.lib.ViewableUserTest"/>
-      <test name="us.kbase.test.auth2.lib.config.AuthConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.config.CollectingExternalConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
-      <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDisableAccountTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageGetDisplayNamesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageInvalidDBDataTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageLinkTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStoragePasswordTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageRolesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageStartUpTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTempIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
-      <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
-      <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
+      <batchtest>
+        <fileset dir="${src.tests.dir}">
+          <include name="**/*Test*.java"/>
+        </fileset>
+      </batchtest>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>

--- a/build.xml
+++ b/build.xml
@@ -10,7 +10,6 @@
   <property name="package" value="KBase authentication service"/>
   <property name="src.dir" location="src"/>
   <property name="src.tests.dir" location="src"/>
-  <property name="lib" location="lib"/>
   <property name="dist.dir" location="dist"/>
   <property name="jar.dir" location="../jars/lib/jars/"/>
   <property name="classes.dir" location="classes"/>
@@ -202,7 +201,7 @@
              author="false"
              classpathref="compile.classpath"
              destdir="${doc.dir}"
-             sourcepath="${src}"
+             sourcepath="${src.dir}"
              excludepackagenames="us.kbase.test.*"
              nodeprecated="false"
              nodeprecatedlist="false"

--- a/src/us/kbase/auth2/cryptutils/RandomDataGenerator.java
+++ b/src/us/kbase/auth2/cryptutils/RandomDataGenerator.java
@@ -15,7 +15,7 @@ public interface RandomDataGenerator {
 
 	/** Generate a random password consisting of upper and lower case ascii letters excluding
 	 * lower case l and o and uppercase I and O, digits excluding one and zero, and the symbols
-	 * +, !, @, $, %, &, and *.
+	 * {@literal +, !, @, $, %, &, and *} .
 	 * @param length the length of the password to generate, minimum 8.
 	 * @return a temporary password.
 	 */

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -80,7 +80,7 @@ import us.kbase.auth2.lib.token.IncomingToken;
 
 /** The main class for the Authentication application.
  * 
- * Handles creating accounts, login & un/linking accounts via OAuth2 flow, creating, deleting, and
+ * Handles creating accounts, login and un/linking accounts via OAuth2 flow, creating, deleting, and
  * validating tokens, handling internal and external configuration, managing user roles and
  * passwords, and searching for users.
  * 

--- a/src/us/kbase/auth2/lib/CustomRole.java
+++ b/src/us/kbase/auth2/lib/CustomRole.java
@@ -10,8 +10,8 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
 
 /** An admin defined role that can be assigned to a user.
  * 
- * A role consists of an ID that is a < 100 character string consisting of ASCII letters, digits,
- * and the underscore, and a description that is a < 1000 character string.
+ * A role consists of an ID that is {@literal a < 100} character string consisting of ASCII letters, digits,
+ * and the underscore, and a description that is {@literal a < 1000} character string.
  * @author gaprice@lbl.gov
  *
  */

--- a/src/us/kbase/auth2/lib/user/AuthUser.java
+++ b/src/us/kbase/auth2/lib/user/AuthUser.java
@@ -356,14 +356,19 @@ public class AuthUser {
 	
 	/** An AuthUser builder. This builder can be used to build either local users
 	 * or standard users, but the local users will not include password related information.
-	 * @param userName the user's user name.
 	 * @author gaprice@lbl.gov
 	 *
 	 */
 	public static class Builder extends AbstractBuilder<Builder> {
 		
 		private final Set<RemoteIdentity> identities = new HashSet<>();
-		
+
+		/**
+		 *
+		 * @param userName the user's user name.
+		 * @param displayName
+		 * @param creationDate
+		 */
 		private Builder(
 				final UserName userName,
 				final DisplayName displayName,


### PR DESCRIPTION
- clean target deletes all generated files and is called by init. This eliminates the chance of caching errors in the build process (a best practice that saved me time in the past).
- test target uses batch test instead of list of classes. This eliminates the chance of accidentally omitting a test class (us.kbase.test.auth2.lib.AuthenticationTester was left out). 
- made property names consistent
- fixed javadoc errors so I can review through dochtml (low hanging fruit)
- added ant help target (low hanging fruit)