### PR TITLE
Add an error storage system and use for provider errors.

### DIFF
--- a/src/us/kbase/auth2/lib/exceptions/ErrorType.java
+++ b/src/us/kbase/auth2/lib/exceptions/ErrorType.java
@@ -1,21 +1,29 @@
 package us.kbase.auth2.lib.exceptions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** An enum representing the type of a particular error.
  * @author gaprice@lbl.gov
  *
  */
 public enum ErrorType {
 	
+	// be very careful about changing error type ids as they are stored in the DB with
+	// temporary tokens
+	
 	/** Lack of a required identity or other error. */
 	AUTHENTICATION_FAILED	(10000, "Authentication failed"),
 	/** No token was provided when required */
 	NO_TOKEN				(10010, "No authentication token"),
 	/** The token provided is not valid. */
-	INVALID_TOKEN			(10011, "Invalid token"),
+	INVALID_TOKEN			(10020, "Invalid token"),
 	/** Retrieving identities from a 3rd party provider failed. */
-	ID_RETRIEVAL_FAILED		(10020, "Identity retrieval failed"),
+	ID_RETRIEVAL_FAILED		(10030, "Identity retrieval failed"),
+	/** A 3rd party identity provider reported an error at the conclusion of the OAuth2 flow. */
+	ID_PROVIDER_ERROR		(10040, "Identity provider error"),
 	/** The password and username did not match. */
-	PASSWORD_MISMATCH		(10030, "Password / username mismatch"),
+	PASSWORD_MISMATCH		(10050, "Password / username mismatch"),
 	/** The user is not authorized to perform the requested action. */
 	UNAUTHORIZED			(20000, "Unauthorized"),
 	/** The account to be accessed is disabled. */
@@ -52,6 +60,24 @@ public enum ErrorType {
 	UNLINK_FAILED			(60010, "Account unlink failed"),
 	/** The requested operation is not supported. */
 	UNSUPPORTED_OP			(70000, "Unsupported operation");
+	
+	private static final Map<Integer, ErrorType> ERROR_MAP = new HashMap<>();
+	static {
+		for (final ErrorType t: ErrorType.values()) {
+			ERROR_MAP.put(t.getErrorCode(), t);
+		}
+	}
+	
+	/** Get an ErrorType given the error code.
+	 * @param code the error code.
+	 * @return the ErrorType corresponding to the error code.
+	 */
+	public static ErrorType fromErrorCode(final int code) {
+		if (!ERROR_MAP.containsKey(code)) {
+			throw new IllegalArgumentException("Invalid error code: " + code);
+		}
+		return ERROR_MAP.get(code);
+	}
 	
 	private final int errcode;
 	private final String error;

--- a/src/us/kbase/auth2/lib/exceptions/IdentityProviderErrorException.java
+++ b/src/us/kbase/auth2/lib/exceptions/IdentityProviderErrorException.java
@@ -1,0 +1,12 @@
+package us.kbase.auth2.lib.exceptions;
+
+/** Thrown when a provider reported an error to auth instance when returning from the OAuth2 flow.
+ * @author gaprice@lbl.gov 
+ */
+@SuppressWarnings("serial")
+public class IdentityProviderErrorException extends AuthenticationException {
+	
+	public IdentityProviderErrorException(final String message) {
+		super(ErrorType.ID_PROVIDER_ERROR, message);
+	}
+}

--- a/src/us/kbase/auth2/lib/exceptions/UnauthorizedException.java
+++ b/src/us/kbase/auth2/lib/exceptions/UnauthorizedException.java
@@ -7,6 +7,14 @@ package us.kbase.auth2.lib.exceptions;
 public class UnauthorizedException extends AuthException {
 	
 	
+	public UnauthorizedException() {
+		super(ErrorType.UNAUTHORIZED, null);
+	}
+	
+	public UnauthorizedException(final String message) {
+		super(ErrorType.UNAUTHORIZED, message);
+	}
+	
 	public UnauthorizedException(final ErrorType err) {
 		super(err, null);
 	}

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -20,6 +20,7 @@ import us.kbase.auth2.lib.config.AuthConfigSet;
 import us.kbase.auth2.lib.config.AuthConfigUpdate;
 import us.kbase.auth2.lib.config.ExternalConfig;
 import us.kbase.auth2.lib.config.ExternalConfigMapper;
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
@@ -331,6 +332,16 @@ public interface AuthStorage {
 	void updateCustomRoles(UserName userName, Set<String> addRoles, Set<String> removeRoles)
 			throws NoSuchUserException, AuthStorageException, NoSuchRoleException;
 
+	/** Store an error string associated with a temporary token.
+	 * @param token the temporary token.
+	 * @param error the error.
+	 * @param errorType the type of the error.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 */
+	void storeErrorTemporarily(TemporaryHashedToken token, String error, ErrorType errorType) 
+			throws AuthStorageException;
+	
 	/** Store a temporary token with a set of remote identities.
 	 * Storing an empty set is allowed.
 	 * No checking is done on the validity of the token - passing in tokens with bad data is a

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -145,6 +145,10 @@ public class Fields {
 	public static final String TOKEN_TEMP_CREATION = "create";
 	/** The remote identities associated with the temporary token. */
 	public static final String TOKEN_TEMP_IDENTITIES = "idents";
+	/** The error associated with the temporary token. */
+	public static final String TOKEN_TEMP_ERROR = "err";
+	/** The type of the error associated with the temporary token. */
+	public static final String TOKEN_TEMP_ERROR_TYPE = "errtype";
 	
 	/* ********************
 	 * custom roles fields

--- a/src/us/kbase/test/auth2/lib/TemporaryIdentitiesTest.java
+++ b/src/us/kbase/test/auth2/lib/TemporaryIdentitiesTest.java
@@ -12,8 +12,11 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.TemporaryIdentities;
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
 import us.kbase.auth2.lib.identity.RemoteIdentityID;
@@ -35,7 +38,7 @@ public class TemporaryIdentitiesTest {
 	}
 	
 	@Test
-	public void construct() throws Exception {
+	public void constructWithIDs() throws Exception {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporaryIdentities ti = new TemporaryIdentities(
@@ -44,7 +47,26 @@ public class TemporaryIdentitiesTest {
 		assertThat("incorrect id", ti.getId(), is(id));
 		assertThat("incorrect created", ti.getCreated(), is(now));
 		assertThat("incorrect expires", ti.getExpires(), is(Instant.ofEpochMilli(10000)));
-		assertThat("incorrect idents", ti.getIdentities(), is(set(REMOTE2, REMOTE1)));
+		assertThat("incorrect idents", ti.getIdentities(), is(Optional.of(set(REMOTE2, REMOTE1))));
+		assertThat("incorrect error", ti.getError(), is(Optional.absent()));
+		assertThat("incorrect error type", ti.getErrorType(), is(Optional.absent()));
+		assertThat("incorrect has error", ti.hasError(), is(false));
+	}
+	
+	@Test
+	public void constructWithError() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final Instant now = Instant.now();
+		final TemporaryIdentities ti = new TemporaryIdentities(
+				id, now, Instant.ofEpochMilli(10000), "foo", ErrorType.DISABLED);
+		
+		assertThat("incorrect id", ti.getId(), is(id));
+		assertThat("incorrect created", ti.getCreated(), is(now));
+		assertThat("incorrect expires", ti.getExpires(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect idents", ti.getIdentities(), is(Optional.absent()));
+		assertThat("incorrect error", ti.getError(), is(Optional.of("foo")));
+		assertThat("incorrect error type", ti.getErrorType(), is(Optional.of(ErrorType.DISABLED)));
+		assertThat("incorrect has error", ti.hasError(), is(true));
 	}
 	
 	@Test
@@ -53,7 +75,7 @@ public class TemporaryIdentitiesTest {
 				UUID.randomUUID(), Instant.now(), Instant.now(), set());
 		
 		try {
-			ti.getIdentities().add(REMOTE1);
+			ti.getIdentities().get().add(REMOTE1);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new UnsupportedOperationException());
@@ -61,7 +83,7 @@ public class TemporaryIdentitiesTest {
 	}
 	
 	@Test
-	public void constructFailNulls() throws Exception {
+	public void constructWithIDsFailNulls() throws Exception {
 		final UUID id = UUID.randomUUID();
 		final Instant c = Instant.now();
 		final Instant e = Instant.ofEpochMilli(10000);
@@ -72,7 +94,22 @@ public class TemporaryIdentitiesTest {
 		failConstruct(id, c, e, null, new NullPointerException("identities"));
 		failConstruct(id, c, e, set(REMOTE1, null),
 				new NullPointerException("null item in identities"));
-		
+	}
+	
+	@Test
+	public void constructWithErrorFailNullsAndEmpties() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final Instant c = Instant.now();
+		final Instant e = Instant.ofEpochMilli(10000);
+		final String err = "err";
+		final ErrorType et = ErrorType.DISABLED;
+		failConstruct(null, c, e, err, et, new NullPointerException("id"));
+		failConstruct(id, null, e, err, et, new NullPointerException("created"));
+		failConstruct(id, c, null, err, et, new NullPointerException("expires"));
+		failConstruct(id, c, e, null, et, new IllegalArgumentException("Missing argument: error"));
+		failConstruct(id, c, e, "  \t  ", et,
+				new IllegalArgumentException("Missing argument: error"));
+		failConstruct(id, c, e, err, null, new NullPointerException("errorType"));
 	}
 	
 	private void failConstruct(
@@ -83,6 +120,21 @@ public class TemporaryIdentitiesTest {
 			final Exception e) {
 		try {
 			new TemporaryIdentities(id, created, expires, identities);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private void failConstruct(
+			final UUID id,
+			final Instant created,
+			final Instant expires,
+			final String error,
+			final ErrorType et,
+			final Exception e) {
+		try {
+			new TemporaryIdentities(id, created, expires, error, et);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/lib/exceptions/ExceptionTest.java
+++ b/src/us/kbase/test/auth2/lib/exceptions/ExceptionTest.java
@@ -12,6 +12,7 @@ import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.DisabledUserException;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
+import us.kbase.auth2.lib.exceptions.IdentityProviderErrorException;
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.IllegalPasswordException;
@@ -30,6 +31,7 @@ import us.kbase.auth2.lib.exceptions.PasswordMismatchException;
 import us.kbase.auth2.lib.exceptions.UnLinkFailedException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
+import us.kbase.test.auth2.TestCommon;
 
 public class ExceptionTest {
 	
@@ -44,6 +46,20 @@ public class ExceptionTest {
 		final ErrorType et = ErrorType.DISABLED;
 		assertThat("incorrect error id", et.getErrorCode(), is(20010));
 		assertThat("incorrect error", et.getError(), is("Account disabled"));
+	}
+	
+	@Test
+	public void errorTypeFromCode() throws Exception {
+		// not testing every code here
+		assertThat("incorrect error type", ErrorType.fromErrorCode(10030),
+				is(ErrorType.ID_RETRIEVAL_FAILED));
+		try {
+			ErrorType.fromErrorCode(3);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(
+					got, new IllegalArgumentException("Invalid error code: 3"));
+		}
 	}
 	
 	@Test
@@ -123,6 +139,15 @@ public class ExceptionTest {
 		assertThat("incorrect error code", ae2.getErr(), is(et));
 		assertThat("incorrect message", ae2.getMessage(), is(format(et, "baz")));
 		assertThat("incorrect cause", ae2.getCause(), is(ie));
+	}
+	
+	@Test
+	public void identityProviderError() throws Exception {
+		final ErrorType et = ErrorType.ID_PROVIDER_ERROR;
+		final IdentityProviderErrorException ae = new IdentityProviderErrorException("foo");
+		assertThat("incorrect error code", ae.getErr(), is(et));
+		assertThat("incorrect message", ae.getMessage(), is(format(et, "foo")));
+		assertThat("incorrect cause", ae.getCause(), is((Throwable) null));
 	}
 	
 	@Test
@@ -280,16 +305,26 @@ public class ExceptionTest {
 	@Test
 	public void unauthorizedException() throws Exception {
 		final ErrorType et = ErrorType.UNAUTHORIZED;
-		final UnauthorizedException ae = new UnauthorizedException(et);
+		final UnauthorizedException ae = new UnauthorizedException();
 		assertThat("incorrect error code", ae.getErr(), is(et));
 		assertThat("incorrect message", ae.getMessage(), is(format(et, null)));
 		assertThat("incorrect cause", ae.getCause(), is((Throwable) null));
 		
-		final ErrorType et2 = ErrorType.UNLINK_FAILED;
-		final UnauthorizedException ae2 = new UnauthorizedException(et2, "foo");
-		assertThat("incorrect error code", ae2.getErr(), is(et2));
-		assertThat("incorrect message", ae2.getMessage(), is(format(et2, "foo")));
+		final UnauthorizedException ae2 = new UnauthorizedException(et);
+		assertThat("incorrect error code", ae2.getErr(), is(et));
+		assertThat("incorrect message", ae2.getMessage(), is(format(et, null)));
 		assertThat("incorrect cause", ae2.getCause(), is((Throwable) null));
+		
+		final UnauthorizedException ae3 = new UnauthorizedException("foo");
+		assertThat("incorrect error code", ae3.getErr(), is(et));
+		assertThat("incorrect message", ae3.getMessage(), is(format(et, "foo")));
+		assertThat("incorrect cause", ae3.getCause(), is((Throwable) null));
+		
+		final ErrorType et2 = ErrorType.UNLINK_FAILED;
+		final UnauthorizedException ae4 = new UnauthorizedException(et2, "foo");
+		assertThat("incorrect error code", ae4.getErr(), is(et2));
+		assertThat("incorrect message", ae4.getMessage(), is(format(et2, "foo")));
+		assertThat("incorrect cause", ae4.getCause(), is((Throwable) null));
 	}
 	
 	@Test


### PR DESCRIPTION
Adds the ability to store an error type and error message with a
temporary token in the database instead of a set of identities. This
capability is used to store provider errors returned to the auth server
when the provider redirects to the /(login|link)/complete/<provider>
endpoint. The error is then returned when the client accesses any of
downstream link or login endpoints.

Currently only the provider error type is supported at the
Authentication.java layer. It should be relatively easy to add new error
types in future if needed.

Note that some error codes have changed - see the ErrorTypes file.