### PR TITLE
Speed up travis builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,30 +9,17 @@ jdk:
     - oraclejdk8
 
 env:
-  global:
-    - MONGODB_VER_26=mongodb-linux-x86_64-2.6.12
-    - MONGODB_VER_30=mongodb-linux-x86_64-3.0.14
-    - MONGODB_VER_32=mongodb-linux-x86_64-3.2.12
-    - MONGODB_VER_34=mongodb-linux-x86_64-3.4.2
+  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test_no_mongo_storage
+  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test_mongo_storage
+  - MONGODB_VER=mongodb-linux-x86_64-3.0.14 ANT_TEST=test_mongo_storage
+  - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage
+  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage
 
 before_install:
-    # get and install various mongodb versions
-    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER_26.tgz
-    - tar xfz $MONGODB_VER_26.tgz
-    - export MONGOD26=`pwd`/$MONGODB_VER_26/bin/mongod
-
-    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER_30.tgz
-    - tar xfz $MONGODB_VER_30.tgz
-    - export MONGOD30=`pwd`/$MONGODB_VER_30/bin/mongod
-
-    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER_32.tgz
-    - tar xfz $MONGODB_VER_32.tgz
-    - export MONGOD32=`pwd`/$MONGODB_VER_32/bin/mongod
-
-    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER_34.tgz
-    - tar xfz $MONGODB_VER_34.tgz
-    - export MONGOD34=`pwd`/$MONGODB_VER_34/bin/mongod
-
+    # get and install mongodb
+    - wget http://fastdl.mongodb.org/linux/$MONGODB_VER.tgz
+    - tar xfz $MONGODB_VER.tgz
+    - export MONGOD=`pwd`/$MONGODB_VER/bin/mongod
 
 install:
     - cd ..
@@ -47,23 +34,7 @@ script:
     # If there are # in the mongod path, this will fail.
     - sed -i "s#^test.temp.dir=.*#test.temp.dir=temp_test_dir#" test.cfg
 
-    # Test against MONGO 2.6
-    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD26#" test.cfg
+    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD#" test.cfg
     - cat test.cfg
-    - ant test
-
-    # Test against MONGO 3.0
-    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD30#" test.cfg
-    - cat test.cfg
-    - ant test
-    
-    # Test against MONGO 3.2
-    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD32#" test.cfg
-    - cat test.cfg
-    - ant test
-    
-    # Test against MONGO 3.4
-    - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD34#" test.cfg
-    - cat test.cfg
-    - ant test
+    - ant $ANT_TEST
 

--- a/build.xml
+++ b/build.xml
@@ -14,6 +14,7 @@
   <property name="jardir" location="../jars/lib/jars/"/>
   <property name="classes" location="classes"/>
   <property name="doc" location="docs/javadoc"/>
+  <property name="testcfg" location="./test.cfg"/>
   <property name="testjar.file" value="KBaseAuth2Test.jar"/>
   <property name="jar.file" value="KBaseAuth2.jar"/>
   <property name="war.file" value="KBaseAuth2.war"/>
@@ -140,7 +141,6 @@
     <!-- Compile class files-->
     <javac srcdir="${src}"
            destdir="${classes}"
-           excludes="**/StartAuthServer.java"
            includeantruntime="false"
            debug="true"
            classpathref="compile.classpath"
@@ -216,12 +216,18 @@
     </javadoc>
   </target>
 	
-  <target name="test" depends="compile" description="run tests">
+  <target name="test"
+          depends="test_no_mongo_storage,test_mongo_storage"
+          description="run all tests"/>
+	
+  <target name="test_no_mongo_storage"
+          depends="compile"
+          description="run tests without the MongoStorage* tests">
     <echo message="starting ${package} tests"/>
     <junit failureproperty="test.failed" fork="yes">
       <classpath refid="test.classpath"/>
       <formatter type="plain" usefile="false" />
-      <sysproperty key="AUTH2_TEST_CONFIG" value="./test.cfg" />
+      <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
       <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
       <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
       <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
@@ -269,6 +275,26 @@
       <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
       <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
       <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
+      <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
+      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
+      <test name="us.kbase.test.auth2.ui.LoginTest"/>
+      <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
+      <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
+      <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
+      <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
+      <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
+    </junit>
+    <fail message="Test failure detected, check test results." if="test.failed" />
+  </target>
+	
+  <target name="test_mongo_storage"
+          depends="compile"
+          description="run only the MongoStorage* tests">
+    <echo message="starting ${package} tests"/>
+    <junit failureproperty="test.failed" fork="yes">
+      <classpath refid="test.classpath"/>
+      <formatter type="plain" usefile="false" />
+      <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
@@ -283,14 +309,6 @@
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
       <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
-      <test name="us.kbase.test.auth2.ui.LoginTest"/>
-      <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
-      <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>


### PR DESCRIPTION
Split tests into tests for the MongoStorage class and all other tests.

Only run the other tests against one version of mongo (most of the tests don't use mongo anyway).
Parallelize the MongoStorage tests on a per mongod version basis.