### PR TITLE
/login/choice tests

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -68,5 +68,6 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/jars/lib/jars/diff/java-diff-utils-2.1.1-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="/jars/lib/jars/diff/java-object-diff/java-object-diff-0.94.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
 script:
     - cp -n test.cfg.example test.cfg
 
-    - mkdir temp_test_dir
     # Note: using # as delimiter instead of / since / is in the mongod path
     # If there are # in the mongod path, this will fail.
     - sed -i "s#^test.temp.dir=.*#test.temp.dir=temp_test_dir#" test.cfg

--- a/build.xml
+++ b/build.xml
@@ -100,6 +100,7 @@
     <include name="mockserver/mockserver-netty-3.10.4-jar-with-dependencies.jar"/>
     <include name="jetty/jetty-all-9.3.11.v20160721-uber.jar"/>
     <include name="diff/java-diff-utils-2.1.1.jar"/>
+    <include name="diff/java-object-diff/java-object-diff-0.94.jar"/>
     <!-- mockito dependencies -->
     <include name="mockito/mockito-core-2.7.10.jar"/>
     <include name="bytebuddy/byte-buddy-1.6.8.jar"/>

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -124,6 +124,7 @@ public class Authentication {
 	//TODO CODE code analysis https://www.codacy.com/
 	//TODO CODE code analysis https://find-sec-bugs.github.io/
 	//TODO ZLATER POLICYIDS maintain admin settable list of required policy IDs, check on login & force choice page if missing. fail login or create if missing. Return missing with choice data
+	//TODO TEST test with gzip compression in header
 	
 	private static final int LINK_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
 	private static final int LOGIN_TOKEN_LIFETIME_MS = 30 * 60 * 1000;

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -124,7 +124,6 @@ public class Authentication {
 	//TODO CODE code analysis https://www.codacy.com/
 	//TODO CODE code analysis https://find-sec-bugs.github.io/
 	//TODO ZLATER POLICYIDS maintain admin settable list of required policy IDs, check on login & force choice page if missing. fail login or create if missing. Return missing with choice data
-	//TODO ZLATER SCOPES use token types as scopes for some activities - for example admin actions should require a login token.
 	
 	private static final int LINK_TOKEN_LIFETIME_MS = 10 * 60 * 1000;
 	private static final int LOGIN_TOKEN_LIFETIME_MS = 30 * 60 * 1000;

--- a/src/us/kbase/auth2/lib/EmailAddress.java
+++ b/src/us/kbase/auth2/lib/EmailAddress.java
@@ -14,7 +14,8 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  */
 public class EmailAddress {
 
-	private static final EmailValidator validator = EmailValidator.getInstance(false);
+	// is a singleton, so it better be threadsafe
+	private static final EmailValidator VALIDATOR = EmailValidator.getInstance(false);
 	
 	/** An unknown email address. Always returns null for the address. */
 	public final static EmailAddress UNKNOWN = new EmailAddress(); // maybe want a specific class rather than just returning null
@@ -36,7 +37,7 @@ public class EmailAddress {
 	public EmailAddress(final String email)
 			throws MissingParameterException, IllegalParameterException {
 		checkString(email, "email address", MAX_EMAIL_LENGTH);
-		if (!validator.isValid(email)) {
+		if (!VALIDATOR.isValid(email)) {
 			throw new IllegalParameterException(ErrorType.ILLEGAL_EMAIL_ADDRESS, email);
 		}
 		this.email = email.trim();

--- a/src/us/kbase/auth2/lib/LoginState.java
+++ b/src/us/kbase/auth2/lib/LoginState.java
@@ -86,7 +86,7 @@ public class LoginState {
 	/** Get the set of identities that are not associated with a user account.
 	 * @return the set of identities that are not associated with a user account.
 	 */
-	public Set<RemoteIdentity> getIdentities() { //TODO NOW Test sorted
+	public Set<RemoteIdentity> getIdentities() {
 		return noUser;
 	}
 	
@@ -94,7 +94,7 @@ public class LoginState {
 	 * identities provided by the identity provider.
 	 * @return the user names.
 	 */
-	public Set<UserName> getUsers() { //TODO NOW test sorted
+	public Set<UserName> getUsers() {
 		return users.keySet();
 	}
 	
@@ -121,7 +121,7 @@ public class LoginState {
 	 * @param name the user name of the user account.
 	 * @return the set of remote identities.
 	 */
-	public Set<RemoteIdentity> getIdentities(final UserName name) { // TODO NOW test sorted
+	public Set<RemoteIdentity> getIdentities(final UserName name) {
 		checkUser(name);
 		return Collections.unmodifiableSet(userIDs.get(name));
 	}

--- a/src/us/kbase/auth2/lib/LoginState.java
+++ b/src/us/kbase/auth2/lib/LoginState.java
@@ -4,10 +4,12 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.user.AuthUser;
@@ -84,7 +86,7 @@ public class LoginState {
 	/** Get the set of identities that are not associated with a user account.
 	 * @return the set of identities that are not associated with a user account.
 	 */
-	public Set<RemoteIdentity> getIdentities() {
+	public Set<RemoteIdentity> getIdentities() { //TODO NOW Test sorted
 		return noUser;
 	}
 	
@@ -92,7 +94,7 @@ public class LoginState {
 	 * identities provided by the identity provider.
 	 * @return the user names.
 	 */
-	public Set<UserName> getUsers() {
+	public Set<UserName> getUsers() { //TODO NOW test sorted
 		return users.keySet();
 	}
 	
@@ -119,7 +121,7 @@ public class LoginState {
 	 * @param name the user name of the user account.
 	 * @return the set of remote identities.
 	 */
-	public Set<RemoteIdentity> getIdentities(final UserName name) {
+	public Set<RemoteIdentity> getIdentities(final UserName name) { // TODO NOW test sorted
 		checkUser(name);
 		return Collections.unmodifiableSet(userIDs.get(name));
 	}
@@ -210,9 +212,18 @@ public class LoginState {
 	 */
 	public static class Builder {
 		
+		private final Comparator<RemoteIdentity> REMOTE_IDENTITY_COMPARATOR =
+				new Comparator<RemoteIdentity>() {
+			
+			@Override
+			public int compare(final RemoteIdentity ri1, final RemoteIdentity ri2) {
+				return ri1.getRemoteID().getID().compareTo(ri2.getRemoteID().getID());
+			}
+		};
+
 		private final Map<UserName, Set<RemoteIdentity>> userIDs = new HashMap<>();
-		private final Map<UserName, AuthUser> users = new HashMap<>();
-		private final Set<RemoteIdentity> noUser = new HashSet<>();
+		private final Map<UserName, AuthUser> users = new TreeMap<>();
+		private final Set<RemoteIdentity> noUser = new TreeSet<>(REMOTE_IDENTITY_COMPARATOR);
 		private final Instant expires;
 		private final String provider;
 		private final boolean nonAdminLoginAllowed;
@@ -267,7 +278,7 @@ public class LoginState {
 			final UserName name = user.getUserName();
 			users.put(name, user);
 			if (!userIDs.containsKey(name)) {
-				userIDs.put(name, new HashSet<>());
+				userIDs.put(name, new TreeSet<>(REMOTE_IDENTITY_COMPARATOR));
 			}
 			userIDs.get(name).add(remoteID);
 			return this;

--- a/src/us/kbase/auth2/lib/Name.java
+++ b/src/us/kbase/auth2/lib/Name.java
@@ -10,7 +10,7 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  * @author gaprice@lbl.gov
  *
  */
-public class Name {
+public class Name implements Comparable<Name> {
 	
 	private final String name;
 	
@@ -69,6 +69,14 @@ public class Name {
 	 */
 	public String getName() {
 		return name;
+	}
+
+	@Override // TODO NOW test
+	public int compareTo(final Name userName) {
+		if (userName == null) {
+			throw new NullPointerException("userName");
+		}
+		return getName().compareTo(userName.getName());
 	}
 
 	@Override

--- a/src/us/kbase/auth2/lib/Name.java
+++ b/src/us/kbase/auth2/lib/Name.java
@@ -2,6 +2,7 @@ package us.kbase.auth2.lib;
 
 import static us.kbase.auth2.lib.Utils.checkString;
 import static us.kbase.auth2.lib.Utils.checkStringNoCheckedException;
+import static us.kbase.auth2.lib.Utils.nonNull;
 
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -71,11 +72,9 @@ public class Name implements Comparable<Name> {
 		return name;
 	}
 
-	@Override // TODO NOW test
+	@Override
 	public int compareTo(final Name userName) {
-		if (userName == null) {
-			throw new NullPointerException("userName");
-		}
+		nonNull(userName, "name");
 		return getName().compareTo(userName.getName());
 	}
 

--- a/src/us/kbase/auth2/lib/UserName.java
+++ b/src/us/kbase/auth2/lib/UserName.java
@@ -20,7 +20,7 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  * @author gaprice@lbl.gov
  *
  */
-public class UserName extends Name implements Comparable<UserName>{
+public class UserName extends Name {
 
 	// this must never be a valid username 
 	private final static String ROOT_NAME = "***ROOT***";
@@ -68,17 +68,7 @@ public class UserName extends Name implements Comparable<UserName>{
 	public boolean isRoot() {
 		return getName().equals(ROOT_NAME);
 	}
-	
 
-	@Override
-	public int compareTo(final UserName userName) {
-		if (userName == null) {
-			throw new NullPointerException("userName");
-		}
-		return getName().compareTo(userName.getName());
-	}
-
-	// returns the null if the name contains no lowercase letters.
 	/** Given a string, returns a new name based on that string that is a legal user name. If
 	 * it is not possible construct a valid user name, absent is returned.
 	 * @param suggestedUserName the user name to mutate into a legal user name.

--- a/src/us/kbase/auth2/lib/user/AuthUser.java
+++ b/src/us/kbase/auth2/lib/user/AuthUser.java
@@ -4,11 +4,11 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
@@ -143,7 +143,7 @@ public class AuthUser {
 	/** Get the set of policyIDs associated with this user.
 	 * @return the policy IDs mapped to the time the user agreed to the policy.
 	 */
-	public Map<PolicyID, Instant> getPolicyIDs() {
+	public Map<PolicyID, Instant> getPolicyIDs() { //TODO NOW test sorted
 		return policyIDs;
 	}
 	
@@ -411,7 +411,7 @@ public class AuthUser {
 		EmailAddress email = EmailAddress.UNKNOWN;
 		final Set<Role> roles = new HashSet<>();
 		final Set<String> customRoles = new HashSet<>();
-		final Map<PolicyID, Instant> policyIDs = new HashMap<>();
+		final Map<PolicyID, Instant> policyIDs = new TreeMap<>();
 		Optional<Instant> lastLogin = Optional.absent();
 		UserDisabledState disabledState = new UserDisabledState();
 		

--- a/src/us/kbase/auth2/lib/user/AuthUser.java
+++ b/src/us/kbase/auth2/lib/user/AuthUser.java
@@ -143,7 +143,7 @@ public class AuthUser {
 	/** Get the set of policyIDs associated with this user.
 	 * @return the policy IDs mapped to the time the user agreed to the policy.
 	 */
-	public Map<PolicyID, Instant> getPolicyIDs() { //TODO NOW test sorted
+	public Map<PolicyID, Instant> getPolicyIDs() {
 		return policyIDs;
 	}
 	

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -49,7 +49,8 @@ public class LoggingFilter implements ContainerRequestFilter,
 					"An error occurred in the logger when attempting " +
 					"to get the server configuration", e); 
 		}
-		logger.setCallInfo(reqcon.getMethod(), ("" + Math.random()).substring(2),
+		logger.setCallInfo(reqcon.getMethod(), (String.format("%.20f", Math.random()))
+				.substring(2), // leaves trailing zeros but meh
 				getIpAddress(reqcon, ignoreIPheaders));
 	}
 	

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -49,8 +49,8 @@ public class LoggingFilter implements ContainerRequestFilter,
 					"An error occurred in the logger when attempting " +
 					"to get the server configuration", e); 
 		}
-		logger.setCallInfo(reqcon.getMethod(), (String.format("%.20f", Math.random()))
-				.substring(2), // leaves trailing zeros but meh
+		logger.setCallInfo(reqcon.getMethod(), (String.format("%.16f", Math.random()))
+				.substring(2),
 				getIpAddress(reqcon, ignoreIPheaders));
 	}
 	

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -408,10 +408,19 @@ public class Login {
 			final String suggestedUserName = id.getDetails().getUsername().split("@")[0];
 			final Optional<UserName> availName = auth.getAvailableUserName(suggestedUserName);
 			c.put(Fields.AVAILABLE_NAME, availName.isPresent() ? availName.get().getName() : null);
-			//TODO UI return null for full name & email if they're not valid by our rules
 			c.put(Fields.PROV_USER, id.getDetails().getUsername());
-			c.put(Fields.PROV_FULL, id.getDetails().getFullname());
-			c.put(Fields.PROV_EMAIL, id.getDetails().getEmail());
+			try {
+				new DisplayName(id.getDetails().getFullname()); //TODO ZLATER CODE isvalid() method
+				c.put(Fields.PROV_FULL, id.getDetails().getFullname());
+			} catch (MissingParameterException | IllegalParameterException e) {
+				c.put(Fields.PROV_FULL, null);
+			}
+			try {
+				new EmailAddress(id.getDetails().getEmail()); //TODO ZLATER CODE isvalid() method
+				c.put(Fields.PROV_EMAIL, id.getDetails().getEmail());
+			} catch (MissingParameterException | IllegalParameterException e) {
+				c.put(Fields.PROV_EMAIL, null);
+			}
 			create.add(c);
 		}
 		final boolean adminOnly = !loginState.isNonAdminLoginAllowed();

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -385,6 +385,7 @@ public class Login {
 			final String redirect)
 			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException,
 			IllegalParameterException, IdentityProviderErrorException {
+		final URL redirectURL = getRedirectURL(redirect); // fail early
 		final LoginState loginState = auth.getLoginState(getLoginInProcessToken(token));
 		
 		final Map<String, Object> ret = new HashMap<>();
@@ -392,7 +393,7 @@ public class Login {
 		ret.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.LOGIN_ROOT_CREATE));
 		ret.put(Fields.URL_PICK, relativize(uriInfo, UIPaths.LOGIN_ROOT_PICK));
 		ret.put(Fields.URL_SUGGESTNAME, relativize(uriInfo, UIPaths.LOGIN_ROOT_SUGGESTNAME));
-		ret.put(Fields.URL_REDIRECT, getRedirectURL(redirect));
+		ret.put(Fields.URL_REDIRECT, redirectURL);
 		ret.put(Fields.PROVIDER, loginState.getProvider());
 		ret.put(Fields.CREATION_ALLOWED, loginState.isNonAdminLoginAllowed());
 		ret.put(Fields.CHOICE_EXPIRES, loginState.getExpires().toEpochMilli());

--- a/src/us/kbase/test/auth2/MapBuilder.java
+++ b/src/us/kbase/test/auth2/MapBuilder.java
@@ -1,0 +1,28 @@
+package us.kbase.test.auth2;
+
+import java.util.HashMap;
+import java.util.Map;
+
+// http://stackoverflow.com/a/8879328/643675
+public class MapBuilder<K,V> {
+
+	private Map<K,V> map;
+
+	public static <K,V> MapBuilder<K,V> newHashMap(){
+		return new MapBuilder<K,V>(new HashMap<K,V>());
+	}
+
+	public MapBuilder(Map<K,V> map) {
+		this.map = map;
+	}
+
+	public MapBuilder<K,V> with(K key, V value){
+		map.put(key, value);
+		return this;
+	}
+
+	public Map<K,V> build(){
+		return map;
+	}
+
+}

--- a/src/us/kbase/test/auth2/cli/AuthCLITest.java
+++ b/src/us/kbase/test/auth2/cli/AuthCLITest.java
@@ -80,7 +80,9 @@ public class AuthCLITest {
 	
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		manager.destroy();
+		if (manager != null) {
+			manager.destroy();
+		}
 	}
 	
 	@Before

--- a/src/us/kbase/test/auth2/lib/NameTest.java
+++ b/src/us/kbase/test/auth2/lib/NameTest.java
@@ -80,6 +80,24 @@ public class NameTest {
 				new IllegalParameterException("thing contains control characters"));
 	}
 	
+	@Test
+	public void compareTo() throws Exception {
+		assertThat("incorrect compare for < ",
+				new Name("bar", "n", 5).compareTo(new Name("foo", "n", 5)) < 0, is(true));
+		
+		assertThat("incorrect compare for < ",
+				new Name("bar", "n", 5).compareTo(new Name("bar", "n", 5)), is(0));
+		assertThat("incorrect compare for < ",
+				new Name("foo", "n", 5).compareTo(new Name("bar", "n", 5)) > 0, is(true));
+		
+		try {
+			new Name("bar", "n", 5).compareTo(null);
+			fail("expected exception");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, new NullPointerException("name"));
+		}
+	}
+	
 	private void failConstruct(
 			final String name,
 			final String type,

--- a/src/us/kbase/test/auth2/lib/UserNameTest.java
+++ b/src/us/kbase/test/auth2/lib/UserNameTest.java
@@ -93,7 +93,7 @@ public class UserNameTest {
 			new UserName("foo").compareTo(null);
 			fail("expected exception");
 		} catch (Exception got) {
-			TestCommon.assertExceptionCorrect(got, new NullPointerException("userName"));
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("name"));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
+++ b/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import org.junit.Test;
 
@@ -448,5 +449,22 @@ public class AuthUserTest {
 		} catch (UnsupportedOperationException e) {
 			// test passed
 		}
+	}
+	
+	@Test
+	public void sortedPolicyIDs() throws Exception {
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+				Instant.ofEpochMilli(10000))
+				.withPolicyID(new PolicyID("zoo"), Instant.ofEpochMilli(10000))
+				.withPolicyID(new PolicyID("mid2"), Instant.ofEpochMilli(15000))
+				.withPolicyID(new PolicyID("aard"), Instant.ofEpochMilli(20000))
+				.withPolicyID(new PolicyID("mid"), Instant.ofEpochMilli(30000))
+				.build();
+		
+		assertThat("policy ids not sorted", new LinkedList<>(u.getPolicyIDs().keySet()),
+				is(Arrays.asList(new PolicyID("aard"), new PolicyID("mid"), new PolicyID("mid2"),
+						new PolicyID("zoo"))));
+		
+				
 	}
 }

--- a/src/us/kbase/test/auth2/ui/LoginTest.java
+++ b/src/us/kbase/test/auth2/ui/LoginTest.java
@@ -74,8 +74,6 @@ import us.kbase.test.auth2.StandaloneAuthServer.ServerThread;
 
 public class LoginTest {
 	
-	//TODO NOW configure travis and build.xml so these tests don't run for each mongo version, just once
-	
 	private static final String DB_NAME = "test_login_ui";
 	private static final String COOKIE_NAME = "login-cookie";
 	

--- a/src/us/kbase/test/auth2/ui/LoginTest.java
+++ b/src/us/kbase/test/auth2/ui/LoginTest.java
@@ -1011,7 +1011,8 @@ public class LoginTest {
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1a", "full1a", "e1a@g.com")))
 				.withPolicyID(new PolicyID("foo"), Instant.ofEpochMilli(60000))
-				.withPolicyID(new PolicyID("bar"), Instant.ofEpochMilli(70000)).build());
+				.withPolicyID(new PolicyID("bar"), Instant.ofEpochMilli(70000))
+				.build());
 		manager.storage.link(new UserName("ruser1"),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("user2a", "full2a", "e2a@g.com")));
@@ -1063,10 +1064,10 @@ public class LoginTest {
 						"id", "4a3cd1ac3f1ffd5d2fecabcfc1856485",
 						"provemail", "e4@g.com"),
 				MapBuilder.newHashMap()
-						.with("provusername", "user@at@bleah.com")
+						.with("provusername", "user&at@bleah.com")
 						.with("availablename", "userat2")
 						.with("provfullname", null)
-						.with("id", "78f2c2dbc07bfc9838c45f601a92762")
+						.with("id", "78f2c2dbc07bfc9838c45f601a92762d")
 						.with("provemail", null)
 						.build(),
 				MapBuilder.newHashMap()
@@ -1100,14 +1101,19 @@ public class LoginTest {
 						.put("provusernames", Arrays.asList("user3"))
 						.build()
 				));
-						
 		
-		
-		
-		System.out.println(json);
+		UITestUtils.assertObjectsEqual(json, expectedJson);
 		
 		// TODO NOW with redirect
 		// TODO NOW with login disabled
 		//TODO NOW with failing cases
+		//TODO NOW with only logins and only creates
+	}
+
+	@Test
+	public void loginChoice2LoginWithRedirectAndLoginDisabled() throws Exception {
+		// tests with redirect cookie
+		// tests with login disabled and admin user
+		// tests with trailing slash on target
 	}
 }

--- a/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2CreateAndLoginDisabled.testdata
+++ b/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2CreateAndLoginDisabled.testdata
@@ -1,0 +1,30 @@
+<html>
+<body>
+
+<p>Note that in a proper UI, the provider usernames, the display name, and email address should be HTML-escaped.</p>
+
+Choices expire: 11493000000000<br/>
+
+<form action="../cancel" method="post">
+	<input type="submit" value="Cancel login"/>
+</form>
+
+<h2>Provider: prov</h2>
+
+<h3>Login</h3>
+<p>The login information from the provider allows you to access these
+accounts:</p>
+
+<h3>Create account</h3>
+<p>
+User name is public.<br/>
+Display name is public to other system users.<br/>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
+Provider username: user2<br/>
+Sorry, account creation is currently disabled.<br/>
+Provider username: user1<br/>
+Sorry, account creation is currently disabled.<br/>
+
+</body>
+</html>

--- a/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2CreateWithRedirectURL.testdata
+++ b/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2CreateWithRedirectURL.testdata
@@ -1,0 +1,50 @@
+<html>
+<body>
+
+<p>Note that in a proper UI, the provider usernames, the display name, and email address should be HTML-escaped.</p>
+
+Choices expire: 11493000000000<br/>
+
+<form action="cancel" method="post">
+	<input type="submit" value="Cancel login"/>
+</form>
+
+<h2>Provider: prov</h2>
+
+<h3>Login</h3>
+<p>The login information from the provider allows you to access these
+accounts:</p>
+
+<h3>Create account</h3>
+<p>
+User name is public.<br/>
+Display name is public to other system users.<br/>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
+<p>Create an account linked to user2</p>
+
+<form action="create" method="post">
+	User name: <input type="text" name="user" value="user2"/><br/>
+	Display name: <input type="text" name="display" value="full2"/><br/>
+	Email: <input type="text" name="email" value="e2@g.com"/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="hidden" name="id" value="5fbea2e6ce3d02f7cdbde0bc31be8059"/>
+	<input type="submit" value="Create"/>
+</form>
+<p>Create an account linked to user1</p>
+
+<form action="create" method="post">
+	User name: <input type="text" name="user" value="user1"/><br/>
+	Display name: <input type="text" name="display" value="full1"/><br/>
+	Email: <input type="text" name="email" value="e1@g.com"/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="hidden" name="id" value="ef0518c79af70ed979907969c6d0a0f7"/>
+	<input type="submit" value="Create"/>
+</form>
+
+</body>
+</html>

--- a/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2LoginWithRedirectAndLoginDisabled.testdata
+++ b/src/us/kbase/test/auth2/ui/LoginTest_loginChoice2LoginWithRedirectAndLoginDisabled.testdata
@@ -1,0 +1,41 @@
+<html>
+<body>
+
+<p>Note that in a proper UI, the provider usernames, the display name, and email address should be HTML-escaped.</p>
+
+Choices expire: 11493000000000<br/>
+
+<form action="../cancel" method="post">
+	<input type="submit" value="Cancel login"/>
+</form>
+
+<h2>Provider: prov</h2>
+
+<h3>Login</h3>
+<p>The login information from the provider allows you to access these
+accounts:</p>
+Username: ruser1  ***Currently only admin accounts can log in***<br/>
+Provider usernames: [user1]<br/>
+Policy IDs:<br/>
+<br/>
+Username: ruser2  <br/>
+Provider usernames: [user2]<br/>
+Policy IDs:<br/>
+<form action="../pick" method="post">
+	<input type="hidden" name="id" value="5fbea2e6ce3d02f7cdbde0bc31be8059"/>
+	Add policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="submit" value="Login"/>
+</form>
+<br/>
+
+<h3>Create account</h3>
+<p>
+User name is public.<br/>
+Display name is public to other system users.<br/>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
+
+</body>
+</html>

--- a/src/us/kbase/test/auth2/ui/LoginTest_loginChoice3Create2Login.testdata
+++ b/src/us/kbase/test/auth2/ui/LoginTest_loginChoice3Create2Login.testdata
@@ -1,0 +1,79 @@
+<html>
+<body>
+
+<p>Note that in a proper UI, the provider usernames, the display name, and email address should be HTML-escaped.</p>
+
+Choices expire: 11493000000000<br/>
+
+<form action="cancel" method="post">
+	<input type="submit" value="Cancel login"/>
+</form>
+
+<h2>Provider: prov</h2>
+
+<h3>Login</h3>
+<p>The login information from the provider allows you to access these
+accounts:</p>
+Username: ruser1  <br/>
+Provider usernames: [user2, user1]<br/>
+Policy IDs:<br/>
+bar: 70000<br/>
+foo: 60000<br/>
+<form action="pick" method="post">
+	<input type="hidden" name="id" value="5fbea2e6ce3d02f7cdbde0bc31be8059"/>
+	Add policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="submit" value="Login"/>
+</form>
+<br/>
+Username: ruser2 DISABLED <br/>
+Provider usernames: [user3]<br/>
+Policy IDs:<br/>
+<br/>
+
+<h3>Create account</h3>
+<p>
+User name is public.<br/>
+Display name is public to other system users.<br/>
+Email is only visible to you, software acting on your behalf, and system administrators.
+</p>
+<p>Create an account linked to user4</p>
+
+<form action="create" method="post">
+	User name: <input type="text" name="user" value="user4"/><br/>
+	Display name: <input type="text" name="display" value="full4"/><br/>
+	Email: <input type="text" name="email" value="e4@g.com"/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="hidden" name="id" value="4a3cd1ac3f1ffd5d2fecabcfc1856485"/>
+	<input type="submit" value="Create"/>
+</form>
+<p>Create an account linked to user&amp;at@bleah.com</p>
+
+<form action="create" method="post">
+	User name: <input type="text" name="user" value="userat2"/><br/>
+	Display name: <input type="text" name="display" value=""/><br/>
+	Email: <input type="text" name="email" value=""/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="hidden" name="id" value="78f2c2dbc07bfc9838c45f601a92762d"/>
+	<input type="submit" value="Create"/>
+</form>
+<p>Create an account linked to whee</p>
+
+<form action="create" method="post">
+	User name: <input type="text" name="user" value="whee"/><br/>
+	Display name: <input type="text" name="display" value=""/><br/>
+	Email: <input type="text" name="email" value=""/><br/>
+	Policy IDs: <input type="text" name="policyids"/><br>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	Link all unlinked identities to this account: <input type="checkbox" name="linkall" value="checked" checked/><br/>
+	<input type="hidden" name="id" value="ccf1ab20b4b412c515182c16f6176b3f"/>
+	<input type="submit" value="Create"/>
+</form>
+
+</body>
+</html>

--- a/src/us/kbase/test/auth2/ui/UITestUtils.java
+++ b/src/us/kbase/test/auth2/ui/UITestUtils.java
@@ -12,6 +12,10 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 
+import de.danielbechler.diff.ObjectDifferBuilder;
+import de.danielbechler.diff.node.DiffNode;
+import de.danielbechler.diff.node.ToMapPrintingVisitor;
+import de.danielbechler.diff.path.NodePath;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
@@ -87,9 +91,20 @@ public class UITestUtils {
 		inner.remove("callid");
 		inner.remove("time");
 		
+		
 		assertThat("incorrect error structure less callid and time", error, is(expected));
-		assertThat("incorrect call id", callid, RegexMatcher.matches("\\d{1,20}"));
+		assertThat("incorrect call id", callid, RegexMatcher.matches("\\d{20}"));
 		TestCommon.assertCloseToNow(time);
+	}
+	
+	// note ObjectDiffer does NOT check sorted lists are sorted
+	public static void assertObjectsEqual(final Object got, final Object expected) {
+		final DiffNode diff = ObjectDifferBuilder.buildDefault().compare(got, expected);
+		final ToMapPrintingVisitor visitor = new ToMapPrintingVisitor(got, expected);
+		diff.visit(visitor);
+		
+		assertThat("non empty structure diff", visitor.getMessages(),
+				is(ImmutableMap.of(NodePath.withRoot(), "Property at path '/' has not changed")));
 	}
 
 }

--- a/src/us/kbase/test/auth2/ui/UITestUtils.java
+++ b/src/us/kbase/test/auth2/ui/UITestUtils.java
@@ -98,6 +98,8 @@ public class UITestUtils {
 	}
 	
 	// note ObjectDiffer does NOT check sorted lists are sorted
+	// this really kind of sucks, but it's better for large shallow objects
+	// easy enough to do a straight equals if needed
 	public static void assertObjectsEqual(final Object got, final Object expected) {
 		final DiffNode diff = ObjectDifferBuilder.buildDefault().compare(got, expected);
 		final ToMapPrintingVisitor visitor = new ToMapPrintingVisitor(got, expected);

--- a/src/us/kbase/test/auth2/ui/UITestUtils.java
+++ b/src/us/kbase/test/auth2/ui/UITestUtils.java
@@ -93,7 +93,7 @@ public class UITestUtils {
 		
 		
 		assertThat("incorrect error structure less callid and time", error, is(expected));
-		assertThat("incorrect call id", callid, RegexMatcher.matches("\\d{20}"));
+		assertThat("incorrect call id", callid, RegexMatcher.matches("\\d{16}"));
 		TestCommon.assertCloseToNow(time);
 	}
 	


### PR DESCRIPTION
Also checks that full name & email for new users extracted from their remote accounts are valid by our rules, and if not substitutes null.