### PR TITLE
Task-705 Implement Java code coverage reporting on Auth2 repo for travis CI

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: no
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,9 @@ script:
     - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD#" test.cfg
     - sed -i "s#^test.mongo.wired_tiger.*#test.mongo.wired_tiger=$WIRED_TIGER#" test.cfg
     - cat test.cfg
-    - ant $ANT_TEST
+    - ant test-report
+
+after_success:
+    - ls docs/test-reports
+    - bash <(curl -s https://codecov.io/bash) -t d0459879-5330-46e8-af6b-547c06630ea8 -f docs/test-reports/coverage-report.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=true
+  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_report WIRED_TIGER=false
 
 before_install:
     # get and install mongodb
@@ -39,7 +40,7 @@ script:
     - sed -i "s#^test.mongo.exe.*#test.mongo.exe=$MONGOD#" test.cfg
     - sed -i "s#^test.mongo.wired_tiger.*#test.mongo.wired_tiger=$WIRED_TIGER#" test.cfg
     - cat test.cfg
-    - ant test-report
+    - ant $ANT_TEST
 
 after_success:
     - ls docs/test-reports

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=true
+  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test WIRED_TIGER=true
 
 before_install:
     # get and install mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,5 @@ script:
 
 after_success:
     - ls docs/test-reports
-    - bash <(curl -s https://codecov.io/bash) -t d0459879-5330-46e8-af6b-547c06630ea8 -f docs/test-reports/coverage-report.xml
+    - bash <(curl -s https://codecov.io/bash) -t d0459879-5330-46e8-af6b-547c06630ea8 -f test-reports/coverage-report.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=true
-  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_report WIRED_TIGER=false
+  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test-report WIRED_TIGER=false
 
 before_install:
     # get and install mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=true
-  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test-report WIRED_TIGER=false
 
 before_install:
     # get and install mongodb

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo contains the second iteration of the KBase authentication server.
 Build status (master):
 [![Build Status](https://travis-ci.org/kbase/auth2.svg?branch=master)](https://travis-ci.org/kbase/auth2)
 
+[![codecov](https://codecov.io/gh/arfathpasha/auth2/branch/master/graph/badge.svg)](https://codecov.io/gh/arfathpasha/auth2)
 
 Current endpoints
 -----------------

--- a/build.xml
+++ b/build.xml
@@ -20,7 +20,7 @@
   <property name="war.file" value="KBaseAuth2.war"/>
   <property name="war.dir" value="war"/>
   <property name="test.dir" location="${src}/us/kbase/test"/>
-  <property name="test.reports.dir" location="docs/test-reports"/>
+  <property name="test.reports.dir" location="test-reports"/>
 
   <fileset dir="${jardir}" id="lib">
     <include name="apache_commons/commons-codec-1.8.jar"/>
@@ -136,7 +136,7 @@
   <target name="build" depends="compile,buildwar,script,javadoc"
     description="build everything"/>
 
-  <target name="init" depends="clean" description="make directories">
+  <target name="init" description="make directories">
     <!-- Create the output directory structure-->
     <mkdir dir="${classes}"/>
     <mkdir dir="${dist}"/>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,4 @@
-<project name="KBase Authentication Service MKII" default="test" basedir=".">
+<project name="KBase Authentication Service MKII" default="test" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
 
   <description>
       Build file for the second KBase Authentication Service 
@@ -19,6 +19,8 @@
   <property name="jar.file" value="KBaseAuth2.jar"/>
   <property name="war.file" value="KBaseAuth2.war"/>
   <property name="war.dir" value="war"/>
+  <property name="test.dir" location="${src}/us/kbase/test"/>
+  <property name="test.reports.dir" location="docs/test-reports"/>
 
   <fileset dir="${jardir}" id="lib">
     <include name="apache_commons/commons-codec-1.8.jar"/>
@@ -107,6 +109,7 @@
     <include name="bytebuddy/byte-buddy-1.6.8.jar"/>
     <include name="bytebuddy/byte-buddy-agent-1.6.8.jar"/>
     <include name="objenesis/objenesis-2.5.1.jar"/>
+    <include name="jacoco/jacocoant.jar"/>
   </fileset>
 	
   <union id="applicationjars">
@@ -133,7 +136,7 @@
   <target name="build" depends="compile,buildwar,script,javadoc"
     description="build everything"/>
 
-  <target name="init" description="make directories">
+  <target name="init" depends="clean" description="make directories">
     <!-- Create the output directory structure-->
     <mkdir dir="${classes}"/>
     <mkdir dir="${dist}"/>
@@ -315,7 +318,126 @@
     </junit>
     <fail message="Test failure detected, check test results." if="test.failed" />
   </target>
-	
+
+  <path id="jacoco.classpath">
+    <fileset dir="${jardir}">
+      <include name="jacoco/jacocoant.jar"/>
+    </fileset>
+  </path>
+
+  <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="jacoco.classpath"/>
+
+  <target name="test-report" depends="compile" description="create test script">
+    <delete dir="${test.reports.dir}"/>
+    <mkdir dir="${test.reports.dir}"/>
+    <mkdir dir="${test.reports.dir}/html"/>
+    <!-- Define absolute path to main jar file-->
+    <jacoco:coverage destfile="${test.reports.dir}/jacoco.exec" excludes="org/*:junit/*">
+      <junit printsummary="yes" failureproperty="test.failed" fork="true">
+        <classpath>
+          <path refid="compile.classpath"/>
+        </classpath>
+        <formatter type="plain" usefile="false"/>
+        <formatter type="xml" usefile="true" if="env.JENKINS_REPORT_DIR"/>
+          <classpath refid="test.classpath"/>
+          <formatter type="plain" usefile="false" />
+          <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
+          <!-- test no mongo storage -->
+          <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
+          <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
+          <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationConfigTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationConstructorTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationCustomRoleTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationDisableUserTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationGetAvailableUserNameTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationIdentityProviderTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationImportUserTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationLinkTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationLoginTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationPolicyIDTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationRoleTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
+          <test name="us.kbase.test.auth2.lib.AuthenticationUserUpdateTest"/>
+          <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>
+          <test name="us.kbase.test.auth2.lib.DisplayNameTest"/>
+          <test name="us.kbase.test.auth2.lib.EmailAddressTest"/>
+          <test name="us.kbase.test.auth2.lib.LinkIdentitiesTest"/>
+          <test name="us.kbase.test.auth2.lib.LinkTokenTest"/>
+          <test name="us.kbase.test.auth2.lib.LocalLoginResultTest"/>
+          <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
+          <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
+          <test name="us.kbase.test.auth2.lib.NameTest"/>
+          <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
+          <test name="us.kbase.test.auth2.lib.PasswordTest"/>
+          <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
+          <test name="us.kbase.test.auth2.lib.RoleTest"/>
+          <test name="us.kbase.test.auth2.lib.TemporaryIdentitiesTest"/>
+          <test name="us.kbase.test.auth2.lib.TokenCreationContextTest"/>
+          <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
+          <test name="us.kbase.test.auth2.lib.UserNameTest"/>
+          <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
+          <test name="us.kbase.test.auth2.lib.UserUpdateTest"/>
+          <test name="us.kbase.test.auth2.lib.UtilsTest"/>
+          <test name="us.kbase.test.auth2.lib.ViewableUserTest"/>
+          <test name="us.kbase.test.auth2.lib.config.AuthConfigTest"/>
+          <test name="us.kbase.test.auth2.lib.config.CollectingExternalConfigTest"/>
+          <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
+          <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
+          <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
+          <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
+          <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
+          <test name="us.kbase.test.auth2.ui.LoginTest"/>
+          <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
+          <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
+          <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
+          <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
+          <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
+          <!-- test mongo storage -->
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDisableAccountTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageGetDisplayNamesTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageInvalidDBDataTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageLinkTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStoragePasswordTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageRolesTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageStartUpTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTempIdentitiesTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
+          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
+      </junit>
+    </jacoco:coverage>
+    <fail message="Test failure detected, check test results." if="test.failed" />
+    <jacoco:report>
+      <executiondata>
+        <file file="${test.reports.dir}/jacoco.exec"/>
+      </executiondata>
+      <structure name="Auth2 Unit Tests">
+        <classfiles>
+          <fileset dir="${classes}">
+            <exclude name="**/test/**" />
+          </fileset>
+        </classfiles>
+        <sourcefiles encoding="UTF-8">
+          <fileset dir="${src}">
+            <exclude name="**/test/**" />
+          </fileset>
+        </sourcefiles>
+      </structure>
+      <html destdir="${test.reports.dir}/html"/>
+      <csv destfile="${test.reports.dir}/coverage-report.csv"/>
+      <xml destfile="${test.reports.dir}/coverage-report.xml"/>
+    </jacoco:report>
+  </target>
+
   <target name="script" depends="compile" description="create cli script">
     <pathconvert targetos="unix" property="lib.classpath" refid="applicationjars"/>
     <echo file="./manage_auth">#!/bin/sh
@@ -327,6 +449,7 @@ java -cp ${dist}/${jar.file}:${lib.classpath} us.kbase.auth2.cli.AuthCLI $@
   <target name="clean" description="clean up" >
     <!-- Clean up internal temporary files and folders-->
     <delete dir="${classes}"/>
+    <delete dir="${test.reports.dir}"/>
     <delete dir="${dist}"/>
   </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -140,6 +140,8 @@
     <!-- Create the output directory structure-->
     <mkdir dir="${classes}"/>
     <mkdir dir="${dist}"/>
+    <mkdir dir="${test.reports.dir}"/>
+    <mkdir dir="${test.reports.dir}/html"/>
   </target>
 
   <target name="compile" depends="init" description="compile the source">
@@ -220,104 +222,6 @@
       <link href="https://google.github.io/guava/releases/18.0/api/docs/"/>
     </javadoc>
   </target>
-	
-  <target name="test"
-          depends="test_no_mongo_storage,test_mongo_storage"
-          description="run all tests"/>
-	
-  <target name="test_no_mongo_storage"
-          depends="compile"
-          description="run tests without the MongoStorage* tests">
-    <echo message="starting ${package} tests"/>
-    <junit failureproperty="test.failed" fork="yes">
-      <classpath refid="test.classpath"/>
-      <formatter type="plain" usefile="false" />
-      <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
-      <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
-      <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
-      <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationConstructorTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationCustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationDisableUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetAvailableUserNameTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationImportUserTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationLinkTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationLoginTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationPolicyIDTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.AuthenticationUserUpdateTest"/>
-      <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.DisplayNameTest"/>
-      <test name="us.kbase.test.auth2.lib.EmailAddressTest"/>
-      <test name="us.kbase.test.auth2.lib.LinkIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.LinkTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.LocalLoginResultTest"/>
-      <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
-      <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
-      <test name="us.kbase.test.auth2.lib.NameTest"/>
-      <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
-      <test name="us.kbase.test.auth2.lib.PasswordTest"/>
-      <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
-      <test name="us.kbase.test.auth2.lib.RoleTest"/>
-      <test name="us.kbase.test.auth2.lib.TemporaryIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.TokenCreationContextTest"/>
-      <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
-      <test name="us.kbase.test.auth2.lib.UserNameTest"/>
-      <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
-      <test name="us.kbase.test.auth2.lib.UserUpdateTest"/>
-      <test name="us.kbase.test.auth2.lib.UtilsTest"/>
-      <test name="us.kbase.test.auth2.lib.ViewableUserTest"/>
-      <test name="us.kbase.test.auth2.lib.config.AuthConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.config.CollectingExternalConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
-      <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
-      <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
-      <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
-      <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
-      <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
-      <test name="us.kbase.test.auth2.ui.LinkTest"/>
-      <test name="us.kbase.test.auth2.ui.LoginTest"/>
-    </junit>
-    <fail message="Test failure detected, check test results." if="test.failed" />
-  </target>
-	
-  <target name="test_mongo_storage"
-          depends="compile"
-          description="run only the MongoStorage* tests">
-    <echo message="starting ${package} tests"/>
-    <junit failureproperty="test.failed" fork="yes">
-      <classpath refid="test.classpath"/>
-      <formatter type="plain" usefile="false" />
-      <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDisableAccountTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageGetDisplayNamesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageInvalidDBDataTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageLinkTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStoragePasswordTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageRolesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageStartUpTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTempIdentitiesTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
-      <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
-    </junit>
-    <fail message="Test failure detected, check test results." if="test.failed" />
-  </target>
 
   <path id="jacoco.classpath">
     <fileset dir="${jardir}">
@@ -326,99 +230,16 @@
   </path>
 
   <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="jacoco.classpath"/>
-
-  <target name="test-report" depends="compile" description="create test script">
-    <delete dir="${test.reports.dir}"/>
-    <mkdir dir="${test.reports.dir}"/>
-    <mkdir dir="${test.reports.dir}/html"/>
-    <!-- Define absolute path to main jar file-->
-    <jacoco:coverage destfile="${test.reports.dir}/jacoco.exec" excludes="org/*:junit/*">
-      <junit printsummary="yes" failureproperty="test.failed" fork="true">
-        <classpath>
-          <path refid="compile.classpath"/>
-        </classpath>
-        <formatter type="plain" usefile="false"/>
-        <formatter type="xml" usefile="true" if="env.JENKINS_REPORT_DIR"/>
-          <classpath refid="test.classpath"/>
-          <formatter type="plain" usefile="false" />
-          <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
-          <!-- test no mongo storage -->
-          <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
-          <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
-          <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationConfigTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationConstructorTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationCustomRoleTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationDisableUserTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationGetAvailableUserNameTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationIdentityProviderTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationImportUserTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationLinkTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationLoginTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationPolicyIDTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationRoleTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
-          <test name="us.kbase.test.auth2.lib.AuthenticationUserUpdateTest"/>
-          <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>
-          <test name="us.kbase.test.auth2.lib.DisplayNameTest"/>
-          <test name="us.kbase.test.auth2.lib.EmailAddressTest"/>
-          <test name="us.kbase.test.auth2.lib.LinkIdentitiesTest"/>
-          <test name="us.kbase.test.auth2.lib.LinkTokenTest"/>
-          <test name="us.kbase.test.auth2.lib.LocalLoginResultTest"/>
-          <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
-          <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
-          <test name="us.kbase.test.auth2.lib.NameTest"/>
-          <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
-          <test name="us.kbase.test.auth2.lib.PasswordTest"/>
-          <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
-          <test name="us.kbase.test.auth2.lib.RoleTest"/>
-          <test name="us.kbase.test.auth2.lib.TemporaryIdentitiesTest"/>
-          <test name="us.kbase.test.auth2.lib.TokenCreationContextTest"/>
-          <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
-          <test name="us.kbase.test.auth2.lib.UserNameTest"/>
-          <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
-          <test name="us.kbase.test.auth2.lib.UserUpdateTest"/>
-          <test name="us.kbase.test.auth2.lib.UtilsTest"/>
-          <test name="us.kbase.test.auth2.lib.ViewableUserTest"/>
-          <test name="us.kbase.test.auth2.lib.config.AuthConfigTest"/>
-          <test name="us.kbase.test.auth2.lib.config.CollectingExternalConfigTest"/>
-          <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
-          <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
-          <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
-          <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
-          <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
-          <test name="us.kbase.test.auth2.ui.LoginTest"/>
-          <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
-          <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
-          <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
-          <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
-          <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
-          <!-- test mongo storage -->
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDisableAccountTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageGetDisplayNamesTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageInvalidDBDataTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageLinkTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStoragePasswordTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageRolesTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageStartUpTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTempIdentitiesTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
-          <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
-      </junit>
-    </jacoco:coverage>
-    <fail message="Test failure detected, check test results." if="test.failed" />
+	
+  <target name="test"
+          depends="clean,test_no_mongo_storage,test_mongo_storage"
+          description="run all tests and generate test report">
+    <jacoco:merge destfile="${test.reports.dir}/merged_jacoco.exec">
+      <fileset dir="${test.reports.dir}" includes="*.exec"/>
+    </jacoco:merge>
     <jacoco:report>
       <executiondata>
-        <file file="${test.reports.dir}/jacoco.exec"/>
+        <file file="${test.reports.dir}/merged_jacoco.exec"/>
       </executiondata>
       <structure name="Auth2 Unit Tests">
         <classfiles>
@@ -436,6 +257,104 @@
       <csv destfile="${test.reports.dir}/coverage-report.csv"/>
       <xml destfile="${test.reports.dir}/coverage-report.xml"/>
     </jacoco:report>
+  </target>
+	
+  <target name="test_no_mongo_storage"
+          depends="compile"
+          description="run tests without the MongoStorage* tests">
+    <echo message="starting ${package} tests"/>
+    <jacoco:coverage destfile="${test.reports.dir}/no_mongo_storage_jacoco.exec" excludes="org/*:junit/*">
+      <junit printsummary="yes" failureproperty="test.failed" fork="yes">
+        <classpath refid="test.classpath"/>
+        <formatter type="plain" usefile="false" />
+        <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
+        <test name="us.kbase.test.auth2.cli.AuthCLITest"/>
+        <test name="us.kbase.test.auth2.cryptutils.CryptUtilsTest"/>
+        <test name="us.kbase.test.auth2.cryptutils.SHA1RandomDataGeneratorTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationConfigTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationConstructorTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationCreateLocalUserTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationCreateRootTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationCustomRoleTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationDisableUserTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationGetAvailableUserNameTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationGetUserTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationGetUserDisplayNamesTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationIdentityProviderTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationImportUserTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationLinkTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationLoginTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationPasswordLoginTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationPolicyIDTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationRoleTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationTokenTest"/>
+        <test name="us.kbase.test.auth2.lib.AuthenticationUserUpdateTest"/>
+        <test name="us.kbase.test.auth2.lib.CustomRoleTest"/>
+        <test name="us.kbase.test.auth2.lib.DisplayNameTest"/>
+        <test name="us.kbase.test.auth2.lib.EmailAddressTest"/>
+        <test name="us.kbase.test.auth2.lib.LinkIdentitiesTest"/>
+        <test name="us.kbase.test.auth2.lib.LinkTokenTest"/>
+        <test name="us.kbase.test.auth2.lib.LocalLoginResultTest"/>
+        <test name="us.kbase.test.auth2.lib.LoginTokenTest"/>
+        <test name="us.kbase.test.auth2.lib.LoginStateTest"/>
+        <test name="us.kbase.test.auth2.lib.NameTest"/>
+        <test name="us.kbase.test.auth2.lib.PasswordHashAndSaltTest"/>
+        <test name="us.kbase.test.auth2.lib.PasswordTest"/>
+        <test name="us.kbase.test.auth2.lib.PolicyIDTest"/>
+        <test name="us.kbase.test.auth2.lib.RoleTest"/>
+        <test name="us.kbase.test.auth2.lib.TemporaryIdentitiesTest"/>
+        <test name="us.kbase.test.auth2.lib.TokenCreationContextTest"/>
+        <test name="us.kbase.test.auth2.lib.UserDisabledStateTest"/>
+        <test name="us.kbase.test.auth2.lib.UserNameTest"/>
+        <test name="us.kbase.test.auth2.lib.UserSearchSpecTest"/>
+        <test name="us.kbase.test.auth2.lib.UserUpdateTest"/>
+        <test name="us.kbase.test.auth2.lib.UtilsTest"/>
+        <test name="us.kbase.test.auth2.lib.ViewableUserTest"/>
+        <test name="us.kbase.test.auth2.lib.config.AuthConfigTest"/>
+        <test name="us.kbase.test.auth2.lib.config.CollectingExternalConfigTest"/>
+        <test name="us.kbase.test.auth2.lib.exceptions.ExceptionTest"/>
+        <test name="us.kbase.test.auth2.lib.identity.IdentityProviderConfigTest"/>
+        <test name="us.kbase.test.auth2.lib.identity.RemoteIdentityTest"/>
+        <test name="us.kbase.test.auth2.lib.token.TokenNameTest"/>
+        <test name="us.kbase.test.auth2.lib.token.TokenTest"/>
+        <test name="us.kbase.test.auth2.lib.user.AuthUserTest"/>
+        <test name="us.kbase.test.auth2.lib.user.LocalUserTest"/>
+        <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
+        <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
+        <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
+        <test name="us.kbase.test.auth2.ui.LinkTest"/>
+        <test name="us.kbase.test.auth2.ui.LoginTest"/>
+      </junit>
+    </jacoco:coverage>
+    <fail message="Test failure detected, check test results." if="test.failed" />
+  </target>
+	
+  <target name="test_mongo_storage"
+          depends="compile"
+          description="run only the MongoStorage* tests">
+    <echo message="starting ${package} tests"/>
+    <jacoco:coverage destfile="${test.reports.dir}/mongo_storage_jacoco.exec" excludes="org/*:junit/*">
+      <junit failureproperty="test.failed" fork="yes">
+        <classpath refid="test.classpath"/>
+        <formatter type="plain" usefile="false" />
+        <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDuplicateKeyCheckerTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageDisableAccountTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageGetDisplayNamesTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageInvalidDBDataTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageLinkTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStoragePasswordTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageRolesTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageStartUpTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTempIdentitiesTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTokensTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
+      </junit>
+    </jacoco:coverage>
+    <fail message="Test failure detected, check test results." if="test.failed" />
   </target>
 
   <target name="script" depends="compile" description="create cli script">


### PR DESCRIPTION
To get it all to work in your repo, you will need to make the following changes. 

- In .travis.yml will need to change the token in the curl call to codecov. The token is obtained from your equivalent url to https://codecov.io/gh/arfathpasha/auth2/settings
- Get badge from your equivalent url to https://codecov.io/gh/arfathpasha/auth2/settings/badge and replace in readme.md
- The test-report target in build.xml has a repeated list of tests. I think test should be removed and test-report renamed to test (travis call then updated). But I'll leave it to you to decide if you want to maintain two separate targets or one.