### PR TITLE
Add tests for common service classes, remove /api/me form input

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ GET /api/V2/me
 See the current user's profile.
 
 PUT /api/V2/me  
-Update the current user's email address and display name. Takes form or JSON encoded data with the
-keys `display` and `email`. Use the `Content-Type` header to specify input type.
+Update the current user's email address and display name. Takes JSON encoded data with the
+keys `display` and `email`.
 
 GET /api/V2/users/?list=&lt;comma separated user names&gt;  
 Validate a set of user names and get the users' display names. Returns a map of username ->

--- a/build.xml
+++ b/build.xml
@@ -325,6 +325,7 @@
         <test name="us.kbase.test.auth2.service.api.APITokenTest"/>
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
         <test name="us.kbase.test.auth2.service.common.ExternalTokenTest"/>
+        <test name="us.kbase.test.auth2.service.common.IncomingJSONTest"/>
         <test name="us.kbase.test.auth2.service.ui.LinkTest"/>
         <test name="us.kbase.test.auth2.service.ui.LoginTest"/>
       </junit>

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,5 @@
-<project name="KBase Authentication Service MKII" default="test" basedir="." xmlns:jacoco="antlib:org.jacoco.ant">
+<project name="KBase Authentication Service MKII" default="test" basedir="."
+  xmlns:jacoco="antlib:org.jacoco.ant">
 
   <description>
       Build file for the second KBase Authentication Service 
@@ -229,7 +230,8 @@
     </fileset>
   </path>
 
-  <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml" classpathref="jacoco.classpath"/>
+  <taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml"
+    classpathref="jacoco.classpath"/>
 	
   <target name="test"
           depends="test_no_mongo_storage,test_mongo_storage"
@@ -263,7 +265,8 @@
           depends="compile"
           description="run tests without the MongoStorage* tests">
     <echo message="starting ${package} tests"/>
-    <jacoco:coverage destfile="${test.reports.dir}/no_mongo_storage_jacoco.exec" excludes="org/*:junit/*">
+    <jacoco:coverage destfile="${test.reports.dir}/no_mongo_storage_jacoco.exec"
+        excludes="org/*:junit/*">
       <junit printsummary="yes" failureproperty="test.failed" fork="yes">
         <classpath refid="test.classpath"/>
         <formatter type="plain" usefile="false" />
@@ -326,6 +329,7 @@
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
         <test name="us.kbase.test.auth2.service.common.ExternalTokenTest"/>
         <test name="us.kbase.test.auth2.service.common.IncomingJSONTest"/>
+        <test name="us.kbase.test.auth2.service.common.ServiceCommonTest"/>
         <test name="us.kbase.test.auth2.service.ui.LinkTest"/>
         <test name="us.kbase.test.auth2.service.ui.LoginTest"/>
       </junit>
@@ -337,7 +341,8 @@
           depends="compile"
           description="run only the MongoStorage* tests">
     <echo message="starting ${package} tests"/>
-    <jacoco:coverage destfile="${test.reports.dir}/mongo_storage_jacoco.exec" excludes="org/*:junit/*">
+    <jacoco:coverage destfile="${test.reports.dir}/mongo_storage_jacoco.exec"
+        excludes="org/*:junit/*">
       <junit failureproperty="test.failed" fork="yes">
         <classpath refid="test.classpath"/>
         <formatter type="plain" usefile="false" />

--- a/devnotes.md
+++ b/devnotes.md
@@ -1,10 +1,7 @@
 Developer notes
 ===============
 
-Returned data structures should not include a top level 'error' field. This is
-reserved for returning errors in JSON.
-
-Templates are mustache templates.
+Templates are [mustache](https://mustache.github.io/) templates.
 
 Exception mapping
 -----------------

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -62,13 +62,14 @@ public class LoggingFilter implements ContainerRequestFilter,
 		final String realIP = request.getHeaderString(X_REAL_IP);
 
 		if (!ignoreIPsInHeaders) {
-			if (xFF != null && !xFF.isEmpty()) {
+			if (xFF != null && !xFF.trim().isEmpty()) {
 				return xFF.split(",")[0].trim();
 			}
-			if (realIP != null && !realIP.isEmpty()) {
+			if (realIP != null && !realIP.trim().isEmpty()) {
 				return realIP.trim();
 			}
 		}
+		//TODO LOG always log xff, real ip, and request ip
 		return servletRequest.getRemoteAddr();
 	}
 

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
@@ -40,7 +39,7 @@ import us.kbase.auth2.service.common.Fields;
 public class Me {
 	
 	//TODO TEST
-	//TODO JAVADOC
+	//TODO JAVADOC or swagger
 	
 	@Inject
 	private Authentication auth;
@@ -83,17 +82,6 @@ public class Me {
 			Fields.AGREED_ON, u.getPolicyIDs().get(id).toEpochMilli()))
 			.collect(Collectors.toSet()));
 		return ret;
-	}
-	
-	@PUT
-	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-	public void updateForm(
-			@HeaderParam(APIConstants.HEADER_TOKEN) final String token,
-			@FormParam(Fields.DISPLAY) final String displayName,
-			@FormParam(Fields.EMAIL) final String email)
-			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			IllegalParameterException, UnauthorizedException {
-		updateUser(auth, getToken(token), displayName, email);
 	}
 	
 	@PUT

--- a/src/us/kbase/auth2/service/common/IncomingJSON.java
+++ b/src/us/kbase/auth2/service/common/IncomingJSON.java
@@ -33,18 +33,18 @@ public class IncomingJSON {
 		if (nullOrEmpty(string)) {
 			return Optional.absent();
 		}
-		return Optional.of(string);
+		return Optional.of(string.trim());
 	}
 
 	protected boolean getBoolean(final Object b, final String fieldName)
 			throws IllegalParameterException {
+		// may need to configure response for null
 		if (b == null) {
 			return false;
 		}
 		if (!(b instanceof Boolean)) {
 			throw new IllegalParameterException(fieldName + " must be a boolean");
 		}
-		// may need to configure response for null
 		return Boolean.TRUE.equals(b) ? true : false;
 	}
 

--- a/src/us/kbase/auth2/service/common/ServiceCommon.java
+++ b/src/us/kbase/auth2/service/common/ServiceCommon.java
@@ -57,10 +57,10 @@ public class ServiceCommon {
 				UnauthorizedException {
 		final UserUpdate.Builder uu = UserUpdate.getBuilder();
 		try {
-			if (displayName != null && !displayName.isEmpty()) {
+			if (displayName != null && !displayName.trim().isEmpty()) {
 				uu.withDisplayName(new DisplayName(displayName));
 			}
-			if (email != null && !email.isEmpty()) {
+			if (email != null && !email.trim().isEmpty()) {
 				uu.withEmail(new EmailAddress(email));
 			}
 		} catch (MissingParameterException mpe) {

--- a/src/us/kbase/test/auth2/service/common/FailOnInstantiation.java
+++ b/src/us/kbase/test/auth2/service/common/FailOnInstantiation.java
@@ -1,0 +1,19 @@
+package us.kbase.test.auth2.service.common;
+
+import us.kbase.auth2.lib.identity.IdentityProvider;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+
+public class FailOnInstantiation implements IdentityProviderFactory {
+
+	public FailOnInstantiation() {
+		throw new IllegalArgumentException("foo");
+	}
+	
+	@Override
+	public IdentityProvider configure(IdentityProviderConfig cfg) {
+		return null;
+	}
+
+	
+}

--- a/src/us/kbase/test/auth2/service/common/FailOnInstantiationNoNullaryConstructor.java
+++ b/src/us/kbase/test/auth2/service/common/FailOnInstantiationNoNullaryConstructor.java
@@ -1,0 +1,17 @@
+package us.kbase.test.auth2.service.common;
+
+import us.kbase.auth2.lib.identity.IdentityProvider;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+
+public class FailOnInstantiationNoNullaryConstructor implements IdentityProviderFactory {
+
+	public FailOnInstantiationNoNullaryConstructor(final String foo) {}
+	
+	@Override
+	public IdentityProvider configure(IdentityProviderConfig cfg) {
+		return null;
+	}
+
+	
+}

--- a/src/us/kbase/test/auth2/service/common/FailOnInstantiationPrivateConstructor.java
+++ b/src/us/kbase/test/auth2/service/common/FailOnInstantiationPrivateConstructor.java
@@ -1,0 +1,17 @@
+package us.kbase.test.auth2.service.common;
+
+import us.kbase.auth2.lib.identity.IdentityProvider;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+
+public class FailOnInstantiationPrivateConstructor implements IdentityProviderFactory {
+
+	private FailOnInstantiationPrivateConstructor() {}
+	
+	@Override
+	public IdentityProvider configure(IdentityProviderConfig cfg) {
+		return null;
+	}
+
+	
+}

--- a/src/us/kbase/test/auth2/service/common/IncomingJSONTest.java
+++ b/src/us/kbase/test/auth2/service/common/IncomingJSONTest.java
@@ -1,0 +1,125 @@
+package us.kbase.test.auth2.service.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.auth2.service.common.IncomingJSON;
+import us.kbase.test.auth2.TestCommon;
+
+public class IncomingJSONTest {
+	
+	@Test
+	public void getString() throws Exception {
+		final String res = IncomingJSON.getString("  \t    fooo  \n  ", "foo");
+		assertThat("incorrect string", res, is("fooo"));
+	}
+	
+	@Test
+	public void getStringFailNullOrEmpty() throws Exception {
+		failGetString(null, "foobar", "foobar");
+		failGetString("  \t   \n   ", "foobar", "foobar");
+	}
+	
+	
+	private void failGetString(final String s, final String field, final String exception) {
+		try {
+			IncomingJSON.getString(s, field);
+			fail("expected exception");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, new MissingParameterException(field));
+		}
+	}
+	
+	private class IncomingJSONSub extends IncomingJSON {
+		
+		public IncomingJSONSub() {}
+		
+		@Override
+		public Optional<String> getOptionalString(final String s) {
+			return super.getOptionalString(s);
+		}
+		
+		@Override
+		public boolean getBoolean(final Object bool, final String fieldName)
+				throws IllegalParameterException {
+			return super.getBoolean(bool, fieldName);
+		}
+	}
+	
+	@Test
+	public void getOptionalStringPresent() throws Exception {
+		final Optional<String> res = new IncomingJSONSub().getOptionalString("   \t    foo\n ");
+		assertThat("incorrect string", res, is(Optional.of("foo")));
+	}
+	
+	@Test
+	public void getOptionalStringAbsent() throws Exception {
+		final Optional<String> res = new IncomingJSONSub().getOptionalString(null);
+		assertThat("incorrect string", res, is(Optional.absent()));
+		
+		final Optional<String> res2 = new IncomingJSONSub().getOptionalString("   \t    \n   ");
+		assertThat("incorrect string", res2, is(Optional.absent()));
+	}
+	
+	@Test
+	public void getBooleanTrue() throws Exception {
+		final boolean b = new IncomingJSONSub().getBoolean(Boolean.TRUE, "foo");
+		assertThat("incorrect boolean", b, is(true));
+		
+		final boolean b2 = new IncomingJSONSub().getBoolean(true, "foo");
+		assertThat("incorrect boolean", b2, is(true));
+	}
+	
+	@Test
+	public void getBooleanFalse() throws Exception {
+		final boolean b = new IncomingJSONSub().getBoolean(Boolean.FALSE, "foo");
+		assertThat("incorrect boolean", b, is(false));
+		
+		final boolean b2 = new IncomingJSONSub().getBoolean(false, "foo");
+		assertThat("incorrect boolean", b2, is(false));
+		
+		final boolean b3 = new IncomingJSONSub().getBoolean(null, "foo");
+		assertThat("incorrect boolean", b3, is(false));
+	}
+	
+	@Test
+	public void getBooleanFail() {
+		try {
+			new IncomingJSONSub().getBoolean("s", "foo");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e,
+					new IllegalParameterException("foo must be a boolean"));
+		}
+	}
+	
+	@Test
+	public void setAndGetAdditionalProps() {
+		final IncomingJSON ij = new IncomingJSONSub();
+		ij.setAdditionalProperties("foo", "bar");
+		ij.setAdditionalProperties("baz", "bat");
+		assertThat("incorrect addt'l props", ij.getAdditionalProperties(),
+				is(ImmutableMap.of("foo", "bar", "baz", "bat")));
+	}
+	
+	@Test
+	public void exceptOnAdditionalProps() throws Exception {
+		final IncomingJSON ij = new IncomingJSONSub();
+		ij.exceptOnAdditionalProperties(); // shouldn't except
+		ij.setAdditionalProperties("foo", "bar");
+		try {
+			ij.exceptOnAdditionalProperties();
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e,
+					new IllegalParameterException("Unexpected parameters in request: foo"));
+		}
+	}
+
+}

--- a/src/us/kbase/test/auth2/service/common/IncomingJSONTest.java
+++ b/src/us/kbase/test/auth2/service/common/IncomingJSONTest.java
@@ -94,6 +94,7 @@ public class IncomingJSONTest {
 	public void getBooleanFail() {
 		try {
 			new IncomingJSONSub().getBoolean("s", "foo");
+			fail("expected exception");
 		} catch (Exception e) {
 			TestCommon.assertExceptionCorrect(e,
 					new IllegalParameterException("foo must be a boolean"));
@@ -116,6 +117,7 @@ public class IncomingJSONTest {
 		ij.setAdditionalProperties("foo", "bar");
 		try {
 			ij.exceptOnAdditionalProperties();
+			fail("expected exception");
 		} catch (Exception e) {
 			TestCommon.assertExceptionCorrect(e,
 					new IllegalParameterException("Unexpected parameters in request: foo"));

--- a/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -1,0 +1,387 @@
+package us.kbase.test.auth2.service.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.TokenCreationContext;
+import us.kbase.auth2.lib.UserUpdate;
+import us.kbase.auth2.lib.config.ConfigItem;
+import us.kbase.auth2.lib.exceptions.ErrorType;
+import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.identity.IdentityProviderFactory;
+import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.providers.GoogleIdentityProviderFactory;
+import us.kbase.auth2.service.AuthExternalConfig;
+import us.kbase.auth2.service.UserAgentParser;
+import us.kbase.auth2.service.common.ServiceCommon;
+import us.kbase.auth2.service.exceptions.AuthConfigurationException;
+import us.kbase.test.auth2.TestCommon;
+
+public class ServiceCommonTest {
+	
+	@Test
+	public void getToken() throws Exception {
+		final IncomingToken t = ServiceCommon.getToken("  \t    fooo   \n ");
+		assertThat("incorrect token", t.getToken(), is("fooo"));
+	}
+	
+	@Test
+	public void getTokenFail() throws Exception {
+		failGetToken(null);
+		failGetToken("   \t   \n   ");
+	}
+
+	private void failGetToken(final String s) {
+		try {
+			ServiceCommon.getToken(s);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got,
+					new NoTokenProvidedException("No user token provided"));
+		}
+	}
+	
+	@Test
+	public void updateUserNulls() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		ServiceCommon.updateUser(auth, new IncomingToken("foo"), null, null);
+		verify(auth).updateUser(new IncomingToken("foo"), UserUpdate.getBuilder().build());
+	}
+	
+	@Test
+	public void updateUserEmpty() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		ServiceCommon.updateUser(auth, new IncomingToken("foo"), " \t \n  ", " \t \n  ");
+		verify(auth).updateUser(new IncomingToken("foo"), UserUpdate.getBuilder().build());
+	}
+	
+	@Test
+	public void updateUserValidInput() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		ServiceCommon.updateUser(auth, new IncomingToken("foo"), "my name", "f@g.com");
+		verify(auth).updateUser(new IncomingToken("foo"), UserUpdate.getBuilder()
+				.withDisplayName(new DisplayName("my name"))
+				.withEmail(new EmailAddress("f@g.com"))
+				.build());
+	}
+	
+	@Test
+	public void updateUserFailNulls() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		final IncomingToken token = new IncomingToken("foo");
+		final String displayName = "foo";
+		final String email = "f@g.com";
+		failUpdateUser(null, token, displayName, email, new NullPointerException("auth"));
+		failUpdateUser(auth, null, displayName, email, new NullPointerException("token"));
+		failUpdateUser(auth, token, "foo\nbar", email,
+				new IllegalParameterException("display name contains control characters"));
+		failUpdateUser(auth, token, displayName, "notanemail",
+				new IllegalParameterException(ErrorType.ILLEGAL_EMAIL_ADDRESS, "notanemail"));
+	}
+	
+	private void failUpdateUser(
+			final Authentication auth,
+			final IncomingToken token,
+			final String displayName,
+			final String email,
+			final Exception e)
+			throws Exception {
+		try {
+			ServiceCommon.updateUser(auth, token, displayName, email);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void loadClassWithInterface() throws Exception {
+		final IdentityProviderFactory fac = ServiceCommon.loadClassWithInterface(
+				GoogleIdentityProviderFactory.class.getName(), IdentityProviderFactory.class);
+		assertThat("incorrect class loaded", fac, instanceOf(GoogleIdentityProviderFactory.class));
+	}
+	
+	@Test
+	public void loadClassWithInterfaceFailNoSuchClass() throws Exception {
+		failLoadClassWithInterface(GoogleIdentityProviderFactory.class.getName() + "a",
+				IdentityProviderFactory.class, new AuthConfigurationException(
+						"Cannot load class us.kbase.auth2.providers." +
+						"GoogleIdentityProviderFactorya: us.kbase.auth2.providers." +
+								"GoogleIdentityProviderFactorya"));
+	}
+	
+	@Test
+	public void loadClassWithInterfaceFailIncorrectInterface() throws Exception {
+		failLoadClassWithInterface(Map.class.getName(), IdentityProviderFactory.class, 
+				new AuthConfigurationException("Module java.util.Map must implement " +
+						"us.kbase.auth2.lib.identity.IdentityProviderFactory interface"));
+	}
+	
+	@Test
+	public void loadClassWithInterfaceFailOnConstruct() throws Exception {
+		failLoadClassWithInterface(FailOnInstantiation.class.getName(),
+				IdentityProviderFactory.class, new IllegalArgumentException("foo"));
+	}
+	
+	@Test
+	public void loadClassWithInterfaceFailNoNullaryConstructor() throws Exception {
+		failLoadClassWithInterface(FailOnInstantiationNoNullaryConstructor.class.getName(),
+				IdentityProviderFactory.class, new AuthConfigurationException(
+						"Module us.kbase.test.auth2.service.common.FailOnInstantiation" +
+						"NoNullaryConstructor could not be instantiated: us.kbase.test.auth2." +
+						"service.common.FailOnInstantiationNoNullaryConstructor"));
+	}
+	
+	@Test
+	public void loadClassWithInterfaceFailPrivateConstructor() throws Exception {
+		failLoadClassWithInterface(FailOnInstantiationPrivateConstructor.class.getName(),
+				IdentityProviderFactory.class, new AuthConfigurationException(
+						"Module us.kbase.test.auth2.service.common.FailOnInstantiation" +
+						"PrivateConstructor could not be instantiated: Class us.kbase.auth2." +
+						"service.common.ServiceCommon can not access a member of class us." +
+						"kbase.test.auth2.service.common.FailOnInstantiationPrivateConstructor " +
+						"with modifiers \"private\""));
+	}
+	
+	private void failLoadClassWithInterface(
+			final String className,
+			final Class<?> interfce,
+			final Exception e)
+			throws Exception {
+		try {
+			ServiceCommon.loadClassWithInterface(className, interfce);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private final String TEST_USER_AGENT =
+			"Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0";
+	
+	@Test
+	public void getTokenContextMinimalInputIgnoreIPHeaders() throws Exception {
+		getTokenContextTestIPHeaders(true, "127.0.0.7", null, null, "127.0.0.7");
+	}
+	
+	@Test
+	public void getTokenContextWithCustomContextAndBadIP() throws Exception {
+		final HttpServletRequest req = mock(HttpServletRequest.class);
+		// mocked because creation takes multiple seconds
+		final UserAgentParser parser = mock(UserAgentParser.class);
+		when(req.getRemoteAddr()).thenReturn("fakeip");
+		when(req.getHeader("user-agent")).thenReturn(TEST_USER_AGENT);
+		when(req.getHeader("x-forwarded-for")).thenReturn(null);
+		when(req.getHeader("x-real-ip")).thenReturn(null);
+		when(parser.getTokenContextFromUserAgent(TEST_USER_AGENT)).thenReturn(
+				TokenCreationContext.getBuilder()
+						.withNullableAgent("Firefox", "47.0")
+						.withNullableOS("Windows NT", "6.1"));
+		final TokenCreationContext res = ServiceCommon.getTokenContext(
+				parser, req, true, ImmutableMap.of("foo", "bar", "baz", "bat"));
+		final TokenCreationContext expected = TokenCreationContext.getBuilder()
+				.withNullableAgent("Firefox", "47.0")
+				.withNullableOS("Windows NT", "6.1")
+				.withCustomContext("baz", "bat")
+				.withCustomContext("foo", "bar")
+				.build();
+		
+		assertThat("incorrect context", res, is(expected));
+	}
+	
+	@Test
+	public void getTokenContextNoIP() throws Exception {
+		final HttpServletRequest req = mock(HttpServletRequest.class);
+		// mocked because creation takes multiple seconds
+		final UserAgentParser parser = mock(UserAgentParser.class);
+		when(req.getRemoteAddr()).thenReturn("   \t  ");
+		when(req.getHeader("user-agent")).thenReturn(TEST_USER_AGENT);
+		when(req.getHeader("x-forwarded-for")).thenReturn(null);
+		when(req.getHeader("x-real-ip")).thenReturn(null);
+		when(parser.getTokenContextFromUserAgent(TEST_USER_AGENT)).thenReturn(
+				TokenCreationContext.getBuilder()
+						.withNullableAgent("Firefox", "47.0")
+						.withNullableOS("Windows NT", "6.1"));
+		final TokenCreationContext res = ServiceCommon.getTokenContext(
+				parser, req, true, Collections.emptyMap());
+		final TokenCreationContext expected = TokenCreationContext.getBuilder()
+				.withNullableAgent("Firefox", "47.0")
+				.withNullableOS("Windows NT", "6.1")
+				.build();
+		
+		assertThat("incorrect context", res, is(expected));
+	}
+	
+	@Test
+	public void getTokenContextXFFHeader() throws Exception {
+		getTokenContextTestIPHeaders(false, "127.0.0.7", "127.0.0.2, 127.0.0.3", "127.0.0.4",
+				"127.0.0.2");
+	}
+	
+	@Test
+	public void getTokenContextRealIPHeader() throws Exception {
+		getTokenContextTestIPHeaders(false, "127.0.0.7", null, "127.0.0.4", "127.0.0.4");
+	}
+	
+	@Test
+	public void getTokenContextRealIPEmptyXFFHeader() throws Exception {
+		getTokenContextTestIPHeaders(false, "127.0.0.7", "  \t   ", "127.0.0.4", "127.0.0.4");
+	}
+	
+	@Test
+	public void getTokenContextNullHeaders() throws Exception {
+		getTokenContextTestIPHeaders(false, "127.0.0.7", null, null, "127.0.0.7");
+	}
+	
+	@Test
+	public void getTokenContextEmptyRealIPHeader() throws Exception {
+		getTokenContextTestIPHeaders(false, "127.0.0.7", null, "  \t   ", "127.0.0.7");
+	}
+	
+	private void getTokenContextTestIPHeaders(
+			final boolean ignoreIpHeaders,
+			final String ip,
+			final String xff,
+			final String xrealip,
+			final String expectedIp)
+			throws Exception {
+		final HttpServletRequest req = mock(HttpServletRequest.class);
+		when(req.getRemoteAddr()).thenReturn(ip);
+		when(req.getHeader("user-agent")).thenReturn(TEST_USER_AGENT);
+		when(req.getHeader("X-Forwarded-For")).thenReturn(xff);
+		when(req.getHeader("X-Real-IP")).thenReturn(xrealip);
+		final UserAgentParser parser = mock(UserAgentParser.class);
+		// mocked because creation takes multiple seconds
+		when(parser.getTokenContextFromUserAgent(TEST_USER_AGENT)).thenReturn(
+				TokenCreationContext.getBuilder()
+						.withNullableAgent("Firefox", "47.0")
+						.withNullableOS("Windows NT", "6.1"));
+		final TokenCreationContext res = ServiceCommon.getTokenContext(
+				parser, req, ignoreIpHeaders, Collections.emptyMap());
+		final TokenCreationContext expected = TokenCreationContext.getBuilder()
+				.withIpAddress(InetAddress.getByName(expectedIp))
+				.withNullableAgent("Firefox", "47.0")
+				.withNullableOS("Windows NT", "6.1")
+				.build();
+		
+		assertThat("incorrect context", res, is(expected));
+	}
+	
+	@Test
+	public void getTokenContectFailNulls() throws Exception {
+		final UserAgentParser parser = mock(UserAgentParser.class);
+		final HttpServletRequest req = mock(HttpServletRequest.class);
+		final Map<String, String> customContext = Collections.emptyMap();
+		failGetTokenContext(null, req, customContext, new NullPointerException("userAgentParser"));
+		failGetTokenContext(parser, null, customContext, new NullPointerException("request"));
+		failGetTokenContext(parser, req, null, new NullPointerException("customContext"));
+		
+	}
+	
+	private void failGetTokenContext(
+			final UserAgentParser parser,
+			final HttpServletRequest req,
+			final Map<String, String> customContext,
+			final Exception e)
+			throws Exception {
+		try {
+			ServiceCommon.getTokenContext(parser, req, true, customContext);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void isIgnoreIPsInHeaders() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
+				.thenReturn(new AuthExternalConfig<>(ConfigItem.emptyState(),
+						ConfigItem.emptyState(), ConfigItem.emptyState(), ConfigItem.emptyState(),
+						ConfigItem.state(false), ConfigItem.state(false)));
+		assertThat("incorrect ignore IPs setting", ServiceCommon.isIgnoreIPsInHeaders(auth),
+				is(false));
+	}
+	
+	@Test
+	public void isIgnoreIPsInHeadersFail() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
+				.thenThrow(new ExternalConfigMappingException("foo"));
+		try {
+			ServiceCommon.isIgnoreIPsInHeaders(auth);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got,
+					new RuntimeException("There appears to be a programming error here..."));
+		}
+	}
+	
+	@Test
+	public void getCustomContext() throws Exception {
+		final Map<String, String> cc = ServiceCommon.getCustomContextFromString(
+				"   \t  foo   , \n  bar; baz,bat;  \t \n ;");
+		assertThat("incorrect custom context", cc,
+				is(ImmutableMap.of("foo", "bar", "baz", "bat")));
+	}
+	
+	@Test
+	public void getCustomContextNull() throws Exception {
+		final Map<String, String> cc = ServiceCommon.getCustomContextFromString(null);
+		assertThat("incorrect custom context", cc, is(Collections.emptyMap()));
+	}
+	
+	@Test
+	public void getCustomContextEmpty() throws Exception {
+		final Map<String, String> cc = ServiceCommon.getCustomContextFromString("  \t \n  ");
+		assertThat("incorrect custom context", cc, is(Collections.emptyMap()));
+	}
+	
+	@Test
+	public void getCustomContextFail() throws Exception {
+		try {
+			ServiceCommon.getCustomContextFromString("  foo, bar, baz  ");
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalParameterException(
+					"Bad key/value pair in custom context: foo, bar, baz"));
+		}
+	}
+
+	@Test
+	public void nullOrEmptyNeither() {
+		assertThat("incorrect nullOrEmpty response", ServiceCommon.nullOrEmpty("s"), is(false));
+	}
+	
+	@Test
+	public void nullOrEmptyNull() {
+		assertThat("incorrect nullOrEmpty response", ServiceCommon.nullOrEmpty(null), is(true));
+	}
+	
+	@Test
+	public void nullOrEmptyEmpty() {
+		assertThat("incorrect nullOrEmpty response", ServiceCommon.nullOrEmpty("  \t "), is(true));
+	}
+	
+}


### PR DESCRIPTION
No need for form input for /api/me endpoint, JSON works fine.