### PR TITLE
TASK-577 TASK-741 add tests for remainder of the /api/* endpoints

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -327,6 +327,7 @@
         <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
         <test name="us.kbase.test.auth2.service.api.APITokenTest"/>
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
+        <test name="us.kbase.test.auth2.service.api.UserLookupTest"/>
         <test name="us.kbase.test.auth2.service.common.ExternalTokenTest"/>
         <test name="us.kbase.test.auth2.service.common.IncomingJSONTest"/>
         <test name="us.kbase.test.auth2.service.common.ServiceCommonTest"/>

--- a/build.xml
+++ b/build.xml
@@ -327,7 +327,7 @@
         <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
         <test name="us.kbase.test.auth2.service.api.APITokenTest"/>
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
-        <test name="us.kbase.test.auth2.service.api.UserLookupTest"/>
+        <test name="us.kbase.test.auth2.service.api.UserEndpointTest"/>
         <test name="us.kbase.test.auth2.service.common.ExternalTokenTest"/>
         <test name="us.kbase.test.auth2.service.common.IncomingJSONTest"/>
         <test name="us.kbase.test.auth2.service.common.ServiceCommonTest"/>

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -2096,10 +2096,11 @@ public class Authentication {
 			final UserUpdate update)
 			throws InvalidTokenException, AuthStorageException, UnauthorizedException {
 		nonNull(update, "update");
+		// should check the token before returning even if there's no update
+		final StoredToken ht = getToken(token, set(TokenType.LOGIN));
 		if (!update.hasUpdates()) {
 			return; //noop
 		}
-		final StoredToken ht = getToken(token, set(TokenType.LOGIN));
 		try {
 			storage.updateUser(ht.getUserName(), update);
 		} catch (NoSuchUserException e) {

--- a/src/us/kbase/auth2/lib/Role.java
+++ b/src/us/kbase/auth2/lib/Role.java
@@ -15,16 +15,16 @@ public enum Role {
 	/* first arg is ID, second arg is description. ID CANNOT change
 	 * since that field is stored in the DB.
 	 */
-	/** The root user. */
-	ROOT			("Root", "Root"),
-	/** User can create administrators. */
-	CREATE_ADMIN	("CreateAdmin", "Create administrator"),
 	/** User has administration privileges. */
 	ADMIN			("Admin", "Administrator"),
-	/** User can create server tokens. */
-	SERV_TOKEN		("ServToken", "Create server tokens"),
+	/** User can create administrators. */
+	CREATE_ADMIN	("CreateAdmin", "Create administrator"),
 	/** User can create developer tokens. */
-	DEV_TOKEN		("DevToken", "Create developer tokens");
+	DEV_TOKEN		("DevToken", "Create developer tokens"),
+	/** The root user. */
+	ROOT			("Root", "Root"),
+	/** User can create server tokens. */
+	SERV_TOKEN		("ServToken", "Create server tokens");
 	
 	private static final Map<String, Role> ROLE_MAP = new HashMap<>();
 	static {

--- a/src/us/kbase/auth2/lib/user/AuthUser.java
+++ b/src/us/kbase/auth2/lib/user/AuthUser.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Optional;
@@ -409,8 +410,8 @@ public class AuthUser {
 		final DisplayName displayName;
 		final Instant created;
 		EmailAddress email = EmailAddress.UNKNOWN;
-		final Set<Role> roles = new HashSet<>();
-		final Set<String> customRoles = new HashSet<>();
+		final Set<Role> roles = new TreeSet<>();
+		final Set<String> customRoles = new TreeSet<>();
 		final Map<PolicyID, Instant> policyIDs = new TreeMap<>();
 		Optional<Instant> lastLogin = Optional.absent();
 		UserDisabledState disabledState = new UserDisabledState();

--- a/src/us/kbase/auth2/service/api/LegacyGlobus.java
+++ b/src/us/kbase/auth2/service/api/LegacyGlobus.java
@@ -98,8 +98,6 @@ public class LegacyGlobus {
 		return (long) Math.floor(date.toEpochMilli() / 1000.0);
 	}
 	
-	//TODO TEST user part
-	
 	// note does not return identity_id
 	// note error structure is completely different
 	@GET

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -42,7 +42,6 @@ import us.kbase.auth2.service.common.IncomingJSON;
 @Path(APIPaths.API_V2_ME)
 public class Me {
 	
-	//TODO TEST
 	//TODO JAVADOC or swagger
 	
 	@Inject

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -52,7 +52,7 @@ public class Me {
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> me(@HeaderParam(APIConstants.HEADER_TOKEN) final String token)
 			throws NoTokenProvidedException, InvalidTokenException, AuthStorageException,
-			DisabledUserException {
+				DisabledUserException {
 		// this code is almost identical to ui.Me but I don't want to couple the API and UI outputs
 		final AuthUser u = auth.getUser(getToken(token));
 		final Map<String, Object> ret = new HashMap<String, Object>();

--- a/src/us/kbase/auth2/service/api/Me.java
+++ b/src/us/kbase/auth2/service/api/Me.java
@@ -80,7 +80,7 @@ public class Me {
 		ret.put(Fields.POLICY_IDS, u.getPolicyIDs().keySet().stream().map(id -> ImmutableMap.of(
 			Fields.ID, id.getName(),
 			Fields.AGREED_ON, u.getPolicyIDs().get(id).toEpochMilli()))
-			.collect(Collectors.toSet()));
+			.collect(Collectors.toList()));
 		return ret;
 	}
 	

--- a/src/us/kbase/auth2/service/api/Users.java
+++ b/src/us/kbase/auth2/service/api/Users.java
@@ -34,7 +34,6 @@ import us.kbase.auth2.service.common.Fields;
 @Path(APIPaths.API_V2_USERS)
 public class Users {
 	
-	//TODO TEST
 	//TODO JAVADOC or swagger
 
 	@Inject

--- a/src/us/kbase/test/auth2/lib/AuthenticationUserUpdateTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationUserUpdateTest.java
@@ -66,7 +66,17 @@ public class AuthenticationUserUpdateTest {
 	
 	@Test
 	public void updateUserNoop() throws Exception {
-		final Authentication auth = initTestMocks().auth;
+		final TestMocks testauth = initTestMocks();
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		final StoredToken htoken = StoredToken.getBuilder(
+				TokenType.LOGIN, UUID.randomUUID(), new UserName("foo"))
+			.withLifeTime(Instant.now(), 10000).build();
+
+		when(storage.getToken(token.getHashedToken())).thenReturn(htoken);
 		
 		auth.updateUser(new IncomingToken("foobar"), UserUpdate.getBuilder().build()); //noop
 	}

--- a/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
+++ b/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
@@ -452,6 +452,34 @@ public class AuthUserTest {
 	}
 	
 	@Test
+	public void sortedCustomRoles() throws Exception {
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+				Instant.ofEpochMilli(10000))
+				.withCustomRole("zoo")
+				.withCustomRole("foo")
+				.withCustomRole("goo")
+				.withCustomRole("moo")
+				.build();
+		
+		assertThat("custom roles not sorted", new LinkedList<>(u.getCustomRoles()),
+				is(Arrays.asList("foo", "goo", "moo", "zoo")));
+	}
+	
+	@Test
+	public void sortedRoles() throws Exception {
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+				Instant.ofEpochMilli(10000))
+				.withRole(Role.SERV_TOKEN)
+				.withRole(Role.ADMIN)
+				.withRole(Role.CREATE_ADMIN)
+				.withRole(Role.DEV_TOKEN)
+				.build();
+		
+		assertThat("roles not sorted", new LinkedList<>(u.getRoles()),
+				is(Arrays.asList(Role.ADMIN, Role.CREATE_ADMIN, Role.DEV_TOKEN, Role.SERV_TOKEN)));
+	}
+	
+	@Test
 	public void sortedPolicyIDs() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
 				Instant.ofEpochMilli(10000))

--- a/src/us/kbase/test/auth2/service/api/TokenEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/TokenEndpointTest.java
@@ -59,7 +59,7 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
  */
 public class TokenEndpointTest {
 
-	private static final String DB_NAME = "test_link_ui";
+	private static final String DB_NAME = "test_token_api";
 	private static final String COOKIE_NAME = "login-cookie";
 	
 	private static final Client CLI = ClientBuilder.newClient();

--- a/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -63,7 +63,7 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 /* tests the various user lookup methods, including legacy globus, the /me endpoint, and the
  * /users endpoints
  */
-public class UserLookupTest {
+public class UserEndpointTest {
 
 	private static final String DB_NAME = "test_user_api";
 	private static final String COOKIE_NAME = "login-cookie";

--- a/src/us/kbase/test/auth2/service/api/UserLookupTest.java
+++ b/src/us/kbase/test/auth2/service/api/UserLookupTest.java
@@ -1,0 +1,240 @@
+package us.kbase.test.auth2.service.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.kbase.KBaseAuthConfig;
+import us.kbase.auth2.lib.CustomRole;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.PasswordHashAndSalt;
+import us.kbase.auth2.lib.PolicyID;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.identity.RemoteIdentity;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.StoredToken;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.auth2.lib.user.LocalUser;
+import us.kbase.auth2.lib.user.NewUser;
+import us.kbase.test.auth2.MapBuilder;
+import us.kbase.test.auth2.MongoStorageTestManager;
+import us.kbase.test.auth2.StandaloneAuthServer;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.StandaloneAuthServer.ServerThread;
+import us.kbase.test.auth2.service.ServiceTestUtils;
+
+/* tests the various user lookup methods, including legacy globus, the /me endpoint, and the
+ * /users endpoints
+ */
+public class UserLookupTest {
+
+	private static final String DB_NAME = "test_user_api";
+	private static final String COOKIE_NAME = "login-cookie";
+	
+	private static final Client CLI = ClientBuilder.newClient();
+	
+	private static MongoStorageTestManager manager = null;
+	private static StandaloneAuthServer server = null;
+	private static int port = -1;
+	private static String host = null;
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		TestCommon.stfuLoggers();
+		manager = new MongoStorageTestManager(DB_NAME);
+		final Path cfgfile = ServiceTestUtils.generateTempConfigFile(manager, DB_NAME, COOKIE_NAME);
+		TestCommon.getenv().put("KB_DEPLOYMENT_CONFIG", cfgfile.toString());
+		server = new StandaloneAuthServer(KBaseAuthConfig.class.getName());
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getPort() == null) {
+			Thread.sleep(1000);
+		}
+		port = server.getPort();
+		host = "http://localhost:" + port;
+	}
+	
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (server != null) {
+			server.stop();
+		}
+		if (manager != null) {
+			manager.destroy();
+		}
+	}
+	
+	@Before
+	public void beforeTest() throws Exception {
+		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+	}
+	
+	@Test
+	public void getMeMinimalInput() throws Exception {
+		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
+				new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
+				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
+		final IncomingToken token = new IncomingToken("whee");
+		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
+				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
+						Instant.ofEpochMilli(1000000000000000L)).build(),
+				token.getHashedToken().getTokenHash());
+		
+		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				.header("authorization", token.getToken());
+
+		final Response res = req.get();
+		
+		assertThat("incorrect response code", res.getStatus(), is(200));
+		
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> response = res.readEntity(Map.class);
+		
+		final Map<String, Object> expected = MapBuilder.<String, Object>newHashMap()
+				.with("user", "foobar")
+				.with("local", true)
+				.with("display", "bleah")
+				.with("email", null)
+				.with("created", 20000)
+				.with("lastlogin", null)
+				.with("customroles", Collections.emptyList())
+				.with("roles", Collections.emptyList())
+				.with("idents", Collections.emptyList())
+				.with("policyids", Collections.emptyList())
+				.build();
+		
+		assertThat("incorrect user structure", response, is(expected));
+	}
+	
+	@Test
+	public void getMeMaximalInput() throws Exception {
+		manager.storage.setCustomRole(new CustomRole("whoo", "a"));
+		manager.storage.setCustomRole(new CustomRole("whee", "b"));
+		manager.storage.createUser(NewUser.getBuilder(new UserName("foobar"),
+				new DisplayName("bleah"), Instant.ofEpochMilli(20000),
+				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
+						new RemoteIdentityDetails("user1", "full1", "f@g.com")))
+				.withCustomRole("whoo")
+				.withCustomRole("whee")
+				.withEmailAddress(new EmailAddress("a@g.com"))
+				.withLastLogin(Instant.ofEpochMilli(30000))
+				.withRole(Role.ADMIN)
+				.withRole(Role.DEV_TOKEN)
+				.withPolicyID(new PolicyID("wugga"), Instant.ofEpochMilli(40000))
+				.withPolicyID(new PolicyID("wubba"), Instant.ofEpochMilli(50000))
+				.build());
+		manager.storage.link(new UserName("foobar"), new RemoteIdentity(
+				new RemoteIdentityID("prov2", "id2"),
+				new RemoteIdentityDetails("user2", "full2", "f2@g.com")));
+		final IncomingToken token = new IncomingToken("whee");
+		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
+				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
+						Instant.ofEpochMilli(1000000000000000L)).build(),
+				token.getHashedToken().getTokenHash());
+		
+		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				.header("authorization", token.getToken());
+
+		final Response res = req.get();
+		
+		assertThat("incorrect response code", res.getStatus(), is(200));
+		
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> response = res.readEntity(Map.class);
+		
+		final Map<String, Object> expected = MapBuilder.<String, Object>newHashMap()
+				.with("user", "foobar")
+				.with("local", false)
+				.with("display", "bleah")
+				.with("email", "a@g.com")
+				.with("created", 20000)
+				.with("lastlogin", 30000)
+				.with("customroles", Arrays.asList("whee", "whoo"))
+				.with("roles", Arrays.asList(
+						ImmutableMap.of("id", "Admin", "desc", "Administrator"),
+						ImmutableMap.of("id", "DevToken", "desc", "Create developer tokens")))
+				.with("idents", Arrays.asList(
+						ImmutableMap.of(
+								"provider", "prov2",
+								"provusername", "user2",
+								"id", "57980b7a3440a4342567e060c3e47666"),
+						ImmutableMap.of(
+								"provider", "prov",
+								"provusername", "user1",
+								"id", "c20a5e632833ab26d99906fc9cb07d6b")))
+				.with("policyids", Arrays.asList(
+						ImmutableMap.of("id", "wubba", "agreedon", 50000),
+						ImmutableMap.of("id", "wugga", "agreedon", 40000)))
+				.build();
+		
+		assertThat("incorrect user structure", response, is(expected));
+	}
+	
+	@Test
+	public void getMeFailNoToken() throws Exception {
+		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				// GDI, Jersey adds a default accept header and I can't figure out how to stop it
+				// http://stackoverflow.com/questions/40900870/how-do-i-get-jersey-test-client-to-not-fill-in-a-default-accept-header
+				.header("accept", MediaType.APPLICATION_JSON);
+
+		final Response res = req.get();
+		
+		failRequestJSON(res, 400, "Bad Request",
+				new NoTokenProvidedException("No user token provided"));
+	}
+	
+	@Test
+	public void getMeFailBadToken() throws Exception {
+		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				.header("authorization", "foobarbaz")
+				// GDI, Jersey adds a default accept header and I can't figure out how to stop it
+				// http://stackoverflow.com/questions/40900870/how-do-i-get-jersey-test-client-to-not-fill-in-a-default-accept-header
+				.header("accept", MediaType.APPLICATION_JSON);
+
+		final Response res = req.get();
+		
+		failRequestJSON(res, 401, "Unauthorized", new InvalidTokenException());
+	}
+	
+}


### PR DESCRIPTION
Adds tests for the various user lookup endpoint and the user update endpoint in the /api tree.

Still some TODOs left for documentation, but I wan to take another crack at swagger so I'm leaving them for now.