### PR TITLE
Remove redundant travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
     - oraclejdk8
 
 env:
-  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test_no_mongo_storage WIRED_TIGER=false
+  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test               WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.0.14 ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.0.14 ANT_TEST=test_mongo_storage WIRED_TIGER=true
@@ -17,7 +17,6 @@ env:
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test_mongo_storage WIRED_TIGER=true
-  - MONGODB_VER=mongodb-linux-x86_64-3.4.2  ANT_TEST=test WIRED_TIGER=true
 
 before_install:
     # get and install mongodb


### PR DESCRIPTION
No reason to run the full test suite for coverage and the no mongo test suite as well, redundant tests.