### PR TITLE
TASK-766 /tokens endoint minor changes & tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -334,6 +334,7 @@
         <test name="us.kbase.test.auth2.service.ui.LinkTest"/>
         <test name="us.kbase.test.auth2.service.ui.LoginTest"/>
         <test name="us.kbase.test.auth2.service.ui.MeTest"/>
+        <test name="us.kbase.test.auth2.service.ui.UITokensTest"/>
         <test name="us.kbase.test.auth2.service.ui.UIUtilsTest"/>
       </junit>
     </jacoco:coverage>

--- a/build.xml
+++ b/build.xml
@@ -335,6 +335,7 @@
         <test name="us.kbase.test.auth2.service.ui.LinkTest"/>
         <test name="us.kbase.test.auth2.service.ui.LoginTest"/>
         <test name="us.kbase.test.auth2.service.ui.MeTest"/>
+        <test name="us.kbase.test.auth2.service.ui.TokensTest"/>
         <test name="us.kbase.test.auth2.service.ui.UITokensTest"/>
         <test name="us.kbase.test.auth2.service.ui.UIUtilsTest"/>
       </junit>

--- a/build.xml
+++ b/build.xml
@@ -266,6 +266,7 @@
           depends="compile"
           description="run tests without the MongoStorage* tests">
     <echo message="starting ${package} tests"/>
+    <delete file="${test.reports.dir}/no_mongo_storage_jacoco.exec"/>
     <jacoco:coverage destfile="${test.reports.dir}/no_mongo_storage_jacoco.exec"
         excludes="org/*:junit/*">
       <junit printsummary="yes" failureproperty="test.failed" fork="yes">
@@ -347,6 +348,7 @@
           depends="compile"
           description="run only the MongoStorage* tests">
     <echo message="starting ${package} tests"/>
+    <delete file="${test.reports.dir}/mongo_storage_jacoco.exec"/>
     <jacoco:coverage destfile="${test.reports.dir}/mongo_storage_jacoco.exec"
         excludes="org/*:junit/*">
       <junit failureproperty="test.failed" fork="yes">

--- a/build.xml
+++ b/build.xml
@@ -236,6 +236,7 @@
   <target name="test"
           depends="test_no_mongo_storage,test_mongo_storage"
           description="run all tests and generate test report">
+    <delete file="${test.reports.dir}/merged_jacoco.exec"/>
     <jacoco:merge destfile="${test.reports.dir}/merged_jacoco.exec">
       <fileset dir="${test.reports.dir}" includes="*.exec"/>
     </jacoco:merge>

--- a/src/us/kbase/auth2/lib/token/TokenSet.java
+++ b/src/us/kbase/auth2/lib/token/TokenSet.java
@@ -3,22 +3,33 @@ package us.kbase.auth2.lib.token;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.TreeSet;
 
 /** A set of tokens, including one current token for a user.
  * @author gaprice@lbl.gov
  *
  */
 public class TokenSet {
+	
+	private static class TokenComparator implements Comparator<StoredToken> {
+
+		@Override
+		public int compare(final StoredToken t1, final StoredToken t2) {
+			return t1.getId().toString().compareTo(t2.getId().toString());
+		}
+		
+	}
 
 	private final StoredToken currentToken;
 	private final Set<StoredToken> tokens;
 	
 	/** Create a new token set.
 	 * @param current the current token for the user associated with this token set.
-	 * @param tokens other tokens. If the current token matches on of the tokens in this set,
+	 * @param tokens other tokens. If the current token matches one of the tokens in this set,
 	 * the token is removed from the set.
 	 */
 	public TokenSet(
@@ -27,8 +38,9 @@ public class TokenSet {
 		nonNull(current, "current");
 		nonNull(tokens, "tokens");
 		this.currentToken = current;
-		final Set<StoredToken> nt = new HashSet<>(tokens);
-		final Iterator<StoredToken> i = nt.iterator();
+		// in case incoming set is unmodifiable
+		final Set<StoredToken> putative = new HashSet<>(tokens);
+		final Iterator<StoredToken> i = putative.iterator();
 		while (i.hasNext()) {
 			final StoredToken ht = i.next();
 			nonNull(ht, "One of the tokens in the incoming set is null");
@@ -40,6 +52,8 @@ public class TokenSet {
 				i.remove();
 			}
 		}
+		final Set<StoredToken> nt = new TreeSet<>(new TokenComparator());
+		nt.addAll(putative);
 		this.tokens = Collections.unmodifiableSet(nt);
 	}
 

--- a/src/us/kbase/auth2/service/common/ExternalToken.java
+++ b/src/us/kbase/auth2/service/common/ExternalToken.java
@@ -1,5 +1,7 @@
 package us.kbase.auth2.service.common;
 
+import static us.kbase.auth2.lib.Utils.nonNull;
+
 import java.util.Map;
 
 import us.kbase.auth2.lib.token.StoredToken;
@@ -16,14 +18,16 @@ public class ExternalToken {
 	private final String user;
 	private final Map<String, String> custom;
 
-	public ExternalToken(final StoredToken st) {
-		type = st.getTokenType().getDescription();
-		id = st.getId().toString();
-		name = st.getTokenName().isPresent() ? st.getTokenName().get().getName() : null;
-		user = st.getUserName().getName();
-		expires = st.getExpirationDate().toEpochMilli();
-		created = st.getCreationDate().toEpochMilli();
-		custom = st.getContext().getCustomContext();
+	public ExternalToken(final StoredToken storedToken) {
+		nonNull(storedToken, "storedToken");
+		type = storedToken.getTokenType().getDescription();
+		id = storedToken.getId().toString();
+		name = storedToken.getTokenName().isPresent() ?
+				storedToken.getTokenName().get().getName() : null;
+		user = storedToken.getUserName().getName();
+		expires = storedToken.getExpirationDate().toEpochMilli();
+		created = storedToken.getCreationDate().toEpochMilli();
+		custom = storedToken.getContext().getCustomContext();
 	}
 
 	public String getType() {

--- a/src/us/kbase/auth2/service/ui/CustomRoles.java
+++ b/src/us/kbase/auth2/service/ui/CustomRoles.java
@@ -31,7 +31,7 @@ import us.kbase.auth2.service.common.Fields;
 public class CustomRoles {
 
 	//TODO TEST
-	//TODO JAVADOC
+	//TODO JAVADOC or swagger
 	
 	/* May need to make a ViewRoles role in the future so that viewing roles can be restricted to
 	 * a subset of users, but a larger subset than just Admins.

--- a/src/us/kbase/auth2/service/ui/LocalAccounts.java
+++ b/src/us/kbase/auth2/service/ui/LocalAccounts.java
@@ -48,7 +48,7 @@ import us.kbase.auth2.service.common.Fields;
 public class LocalAccounts {
 	
 	//TODO TEST
-	//TODO JAVADOC
+	//TODO JAVADOC or swagger
 
 	@Inject
 	private Authentication auth;

--- a/src/us/kbase/auth2/service/ui/Logout.java
+++ b/src/us/kbase/auth2/service/ui/Logout.java
@@ -31,6 +31,9 @@ import us.kbase.auth2.service.common.Fields;
 
 @Path(UIPaths.LOGOUT_ROOT)
 public class Logout {
+	
+	//TODO TEST
+	//TODO JAVADOC or swagger
 
 	@Inject
 	private Authentication auth;

--- a/src/us/kbase/auth2/service/ui/NewUIToken.java
+++ b/src/us/kbase/auth2/service/ui/NewUIToken.java
@@ -5,7 +5,7 @@ import us.kbase.auth2.lib.token.NewToken;
 public class NewUIToken extends UIToken {
 
 	//TODO TEST
-	//TODO JAVADOC
+	//TODO JAVADOC or swagger
 	
 	private final String token;
 	

--- a/src/us/kbase/auth2/service/ui/NewUIToken.java
+++ b/src/us/kbase/auth2/service/ui/NewUIToken.java
@@ -1,17 +1,24 @@
 package us.kbase.auth2.service.ui;
 
+import static us.kbase.auth2.lib.Utils.nonNull;
+
 import us.kbase.auth2.lib.token.NewToken;
+import us.kbase.auth2.lib.token.StoredToken;
 
 public class NewUIToken extends UIToken {
 
-	//TODO TEST
 	//TODO JAVADOC or swagger
 	
 	private final String token;
 	
 	public NewUIToken(final NewToken token) {
-		super(token.getStoredToken());
+		super(getStoredToken(token));
 		this.token = token.getToken();
+	}
+
+	private static StoredToken getStoredToken(final NewToken token) {
+		nonNull(token, "token");
+		return token.getStoredToken();
 	}
 
 	public String getToken() {

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -23,6 +23,9 @@ public class Root {
 	//TODO ZLATER ROOT add configurable contact email or link
 	//TODO ZLATER ROOT move version to file?
 	
+	//TODO JAVADOC or swagger
+	//TODO TEST
+	
 	private static final String VERSION = "0.1.0-prerelease";
 	
 	@GET

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -79,7 +79,7 @@ public class Tokens {
 			@Context final HttpHeaders headers,
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException, UnauthorizedException {
+				NoTokenProvidedException, UnauthorizedException {
 		final Map<String, Object> t = getTokens(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()), uriInfo);
 		return t;
@@ -91,7 +91,7 @@ public class Tokens {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
-			NoTokenProvidedException, UnauthorizedException {
+				NoTokenProvidedException, UnauthorizedException {
 		return getTokens(getToken(headerToken), uriInfo);
 	}
 	
@@ -107,8 +107,8 @@ public class Tokens {
 			@FormParam(Fields.TOKEN_TYPE) final String tokenType,
 			@FormParam(Fields.CUSTOM_CONTEXT) final String customContext)
 			throws AuthStorageException, MissingParameterException,
-			NoTokenProvidedException, InvalidTokenException,
-			UnauthorizedException, IllegalParameterException {
+				NoTokenProvidedException, InvalidTokenException,
+				UnauthorizedException, IllegalParameterException {
 		return createtoken(req, tokenName, tokenType,
 				getTokenFromCookie(headers, cfg.getTokenCookieName()),
 				getCustomContextFromString(customContext));
@@ -148,8 +148,8 @@ public class Tokens {
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken,
 			final CreateTokenParams input)
 			throws AuthStorageException, MissingParameterException,
-			InvalidTokenException, NoTokenProvidedException,
-			UnauthorizedException, IllegalParameterException {
+				InvalidTokenException, NoTokenProvidedException,
+				UnauthorizedException, IllegalParameterException {
 		input.exceptOnAdditionalProperties();
 		return createtoken(req, input.name, input.type, getToken(headerToken),
 				input.getCustomContext());
@@ -161,8 +161,8 @@ public class Tokens {
 			@Context final HttpHeaders headers,
 			@PathParam(UIPaths.TOKEN_ID) final UUID tokenId)
 			throws AuthStorageException,
-			NoSuchTokenException, NoTokenProvidedException,
-			InvalidTokenException, UnauthorizedException {
+				NoSuchTokenException, NoTokenProvidedException,
+				InvalidTokenException, UnauthorizedException {
 		auth.revokeToken(getTokenFromCookie(headers, cfg.getTokenCookieName()), tokenId);
 	}
 	
@@ -172,8 +172,8 @@ public class Tokens {
 			@PathParam(UIPaths.TOKEN_ID) final UUID tokenId,
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException,
-			NoSuchTokenException, NoTokenProvidedException,
-			InvalidTokenException, UnauthorizedException {
+				NoSuchTokenException, NoTokenProvidedException,
+				InvalidTokenException, UnauthorizedException {
 		auth.revokeToken(getToken(headerToken), tokenId);
 	}
 	
@@ -181,7 +181,7 @@ public class Tokens {
 	@Path(UIPaths.TOKENS_REVOKE_ALL)
 	public Response revokeAllAndLogout(@Context final HttpHeaders headers)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException, UnauthorizedException {
+				InvalidTokenException, UnauthorizedException {
 		auth.revokeTokens(getTokenFromCookie(headers, cfg.getTokenCookieName()));
 		return Response.ok().cookie(removeLoginCookie(cfg.getTokenCookieName())).build();
 	}
@@ -191,7 +191,7 @@ public class Tokens {
 	public void revokeAll(
 			@HeaderParam(UIConstants.HEADER_TOKEN) final String headerToken)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException, UnauthorizedException {
+				InvalidTokenException, UnauthorizedException {
 		auth.revokeTokens(getToken(headerToken));
 	}
 
@@ -202,8 +202,8 @@ public class Tokens {
 			final IncomingToken userToken,
 			final Map<String, String> customContext)
 			throws AuthStorageException, MissingParameterException,
-			NoTokenProvidedException, InvalidTokenException,
-			UnauthorizedException, IllegalParameterException {
+				NoTokenProvidedException, InvalidTokenException,
+				UnauthorizedException, IllegalParameterException {
 		final TokenCreationContext tcc = getTokenContext(
 				userAgentParser, req, isIgnoreIPsInHeaders(auth), customContext);
 		return new NewUIToken(auth.createToken(userToken, new TokenName(tokenName),

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -60,7 +60,6 @@ import us.kbase.auth2.service.common.IncomingJSON;
 @Path(UIPaths.TOKENS_ROOT)
 public class Tokens {
 	
-	//TODO TEST
 	//TODO JAVADOC or swagger
 
 	@Inject
@@ -182,7 +181,7 @@ public class Tokens {
 			throws AuthStorageException, NoTokenProvidedException,
 				InvalidTokenException, UnauthorizedException {
 		auth.revokeTokens(getTokenFromCookie(headers, cfg.getTokenCookieName()));
-		return Response.ok().cookie(removeLoginCookie(cfg.getTokenCookieName())).build();
+		return Response.noContent().cookie(removeLoginCookie(cfg.getTokenCookieName())).build();
 	}
 	
 	@DELETE

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -94,7 +94,6 @@ public class Tokens {
 	}
 	
 	@POST
-	@Path(UIPaths.TOKENS_CREATE)
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Produces(MediaType.TEXT_HTML)
 	@Template(name = "/tokencreate")
@@ -138,7 +137,6 @@ public class Tokens {
 	}
 	
 	@POST
-	@Path(UIPaths.TOKENS_CREATE)
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	public NewUIToken createTokenJSON(
@@ -148,6 +146,9 @@ public class Tokens {
 			throws AuthStorageException, MissingParameterException,
 				InvalidTokenException, NoTokenProvidedException,
 				UnauthorizedException, IllegalParameterException {
+		if (input == null) {
+			throw new MissingParameterException("JSON body missing");
+		}
 		input.exceptOnAdditionalProperties();
 		return createtoken(req, input.name, input.type, getToken(headerToken),
 				input.getCustomContext());
@@ -222,7 +223,7 @@ public class Tokens {
 		ret.put(Fields.TOKEN_DEV, Role.DEV_TOKEN.isSatisfiedBy(au.getRoles()));
 		ret.put(Fields.TOKEN_SERVICE, Role.SERV_TOKEN.isSatisfiedBy(au.getRoles()));
 		ret.put(Fields.USER, au.getUserName().getName());
-		ret.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.TOKENS_ROOT_CREATE));
+		ret.put(Fields.URL_CREATE, relativize(uriInfo, UIPaths.TOKENS_ROOT));
 		ret.put(Fields.URL_REVOKE, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE +
 				UIPaths.SEP));
 		ret.put(Fields.URL_REVOKE_ALL, relativize(uriInfo, UIPaths.TOKENS_ROOT_REVOKE_ALL));

--- a/src/us/kbase/auth2/service/ui/Tokens.java
+++ b/src/us/kbase/auth2/service/ui/Tokens.java
@@ -80,9 +80,7 @@ public class Tokens {
 			@Context final UriInfo uriInfo)
 			throws AuthStorageException, InvalidTokenException,
 				NoTokenProvidedException, UnauthorizedException {
-		final Map<String, Object> t = getTokens(
-				getTokenFromCookie(headers, cfg.getTokenCookieName()), uriInfo);
-		return t;
+		return getTokens(getTokenFromCookie(headers, cfg.getTokenCookieName()), uriInfo);
 	}
 	
 	@GET
@@ -212,7 +210,7 @@ public class Tokens {
 
 	private Map<String, Object> getTokens(final IncomingToken token, final UriInfo uriInfo)
 			throws AuthStorageException, NoTokenProvidedException,
-			InvalidTokenException, UnauthorizedException {
+				InvalidTokenException, UnauthorizedException {
 		final AuthUser au = auth.getUser(token);
 		final TokenSet ts = auth.getTokens(token);
 		final Map<String, Object> ret = new HashMap<>();

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -301,10 +301,6 @@ public class UIPaths {
 	/** The token endpoint root location. */
 	public static final String TOKENS_ROOT = SEP + TOKENS;
 	
-	/** A portion of a path designating the creation of a token. */
-	public static final String TOKENS_CREATE = CREATE;
-	/** The token creation endpoint location. */
-	public static final String TOKENS_ROOT_CREATE = TOKENS_ROOT + SEP + TOKENS_CREATE;
 	/** A portion of a path designating the revocation of a token. */
 	public static final String TOKENS_REVOKE = REVOKE;
 	/** The token revocation endpoint location. */

--- a/src/us/kbase/auth2/service/ui/UIPaths.java
+++ b/src/us/kbase/auth2/service/ui/UIPaths.java
@@ -1,11 +1,14 @@
 package us.kbase.auth2.service.ui;
 
+/** Resource paths for the UI endpoints.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class UIPaths {
-
-	//TODO JAVADOC
 	
 	/* general strings */
-	
+
+	/** The URL path separator. */
 	public static final String SEP = "/";
 	private static final String COMPLETE = "complete";
 	private static final String COMPLETE_PROVIDER = COMPLETE + SEP + "{provider}";
@@ -22,167 +25,301 @@ public class UIPaths {
 	private static final String LOGIN = "login";
 	private static final String LOCAL = "localaccount";
 	private static final String RESET = "reset";
+	/** A portion of a path designating a user. */
 	public static final String USER = "user";
 	private static final String USER_PARAM = "{" + USER + "}";
 	private static final String ROLES = "roles";
 	private static final String START = "start";
 	private static final String TOKEN = "token";
+	private static final String UNLINK = "unlink";
 	private static final String TOKENS = "tokens";
+	/** A portion of a path designating a token ID. */
 	public static final String TOKEN_ID = "tokenid";
 	private static final String TOKEN_ID_PARAM = "{" + TOKEN_ID + "}";
 	private static final String CUSTOM_ROLES = "customroles";
 	
 	/* Root endpoint */
 
+	/** The root endpoint location. */
 	public static final String ROOT = SEP;
 	
 	/* Admin endpoint */
 	
+	/** The admin endpoint root location. */
 	public static final String ADMIN_ROOT = "/admin";
 
+	/** A portion of a path designating the administration of a local account. */
 	public static final String ADMIN_LOCALACCOUNT = LOCAL;
+	/** A portion of a path designating the creation of a local account. */
 	public static final String ADMIN_LOCAL_CREATE = LOCAL + SEP + CREATE;
+	/** The local account creation endpoint location. */
 	public static final String ADMIN_ROOT_LOCAL_CREATE = ADMIN_ROOT + SEP + ADMIN_LOCAL_CREATE;
 
+	/** The user administration endpoint location. */
 	public static final String ADMIN_ROOT_USER = ADMIN_ROOT + SEP + USER;
+	/** A portion of a path designating the administration of a particular user, including the
+	 * user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_PARAM = USER + SEP + USER_PARAM;
 
+	/** A portion of a path designating the disabling of a user. */
 	public static final String ADMIN_DISABLE = "disable";
+	/** A portion of a path designating the disabling of a particular user, including the user's
+	 * account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_DISABLE = ADMIN_USER_PARAM + SEP + ADMIN_DISABLE;
 
+	/** A portion of a path designating the administration of a user's roles. */
 	public static final String ADMIN_ROLES = ROLES;
+	/** A portion of a path designating the administration of a particular users's roles, including
+	 * the user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_ROLES = ADMIN_USER_PARAM + SEP + ADMIN_ROLES;
 	
+	/** A portion of a path designating setting that a user or users should be required to reset
+	 * their password on the next login. 
+	 */
 	public static final String ADMIN_FORCE_RESET_PWD = "force" + RESET;
+	/** The force reset all passwords endpoint location. */
 	public static final String ADMIN_ROOT_FORCE_RESET_PWD = ADMIN_ROOT + SEP +
 			ADMIN_FORCE_RESET_PWD;
+	/** A portion of a path designating setting that a particular user should be required to reset
+	 * their password on the next login, including the user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_FORCE_RESET_PWD = ADMIN_USER_PARAM + SEP +
 			ADMIN_FORCE_RESET_PWD;
 	
+	/** A portion of a path designating the resetting of a password. */
 	public static final String ADMIN_RESET_PWD = RESET;
+	/** A portion of a path designating the resetting of a password for a particular user,
+	 * including the user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_RESET_PWD = ADMIN_USER_PARAM + SEP + ADMIN_RESET_PWD;
-	
+
+	/** A portion of a path indicating that all tokens should be revoked. */
 	public static final String ADMIN_REVOKE_ALL = REVOKE_ALL;
+	/** The revoke all tokens endpoint location. */
 	public static final String ADMIN_ROOT_REVOKE_ALL = ADMIN_ROOT + SEP + ADMIN_REVOKE_ALL;
 	
+	/** A portion of a path indicating the administration of a policy ID. */
 	public static final String ADMIN_POLICY_ID = "policyid";
+	/** The administrate a policy ID endpoint location. */
 	public static final String ADMIN_ROOT_POLICY_ID = ADMIN_ROOT + SEP + ADMIN_POLICY_ID;
 	
+	/** A portion of a path designating an administrator user search. */
 	public static final String ADMIN_SEARCH = "search";
+	/** The administrator user search endpoint location. */
 	public static final String ADMIN_ROOT_SEARCH = ADMIN_ROOT + SEP + ADMIN_SEARCH;
 	
+	/** A portion of a path designating an administration operation on a token. */
 	public static final String ADMIN_TOKEN = TOKEN;
+	/** The administrator token introspection endpoint. */
 	public static final String ADMIN_ROOT_TOKEN = ADMIN_ROOT + SEP + TOKEN;
+	/** A portion of a path designating an administration operation on one or more tokens. */
 	public static final String ADMIN_TOKENS = TOKENS;
+	/** A portion of a path designating administration operations on a particular user's tokens,
+	 * including the user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_TOKENS = ADMIN_USER_PARAM + SEP + ADMIN_TOKENS;
+	/** A portion of a path designating the revocation of all of a user's tokens, including the
+	 * user's account name as a path parameter.
+	 */
 	public static final String ADMIN_USER_TOKENS_REVOKE_ALL = ADMIN_USER_TOKENS + SEP + REVOKE_ALL;
+	/** A portion of a path designating the revocation of a token. */
 	public static final String ADMIN_USER_TOKENS_REVOKE = REVOKE;
+	/** A portoin of a path designating the revcation of a particular token from a particular user,
+	 * including the user's account name and the token ID as path parameters.
+	 */
 	public static final String ADMIN_USER_TOKENS_REVOKE_ID = ADMIN_USER_TOKENS + SEP + 
 			ADMIN_USER_TOKENS_REVOKE + SEP + TOKEN_ID_PARAM;
 	
+	/** A portion of a path designating the administration of a custom role. */
 	public static final String ADMIN_CUSTOM_ROLES = CUSTOM_ROLES;
+	/** A portion of a path designating the administration of a particular user's custom role,
+	 * including the user's account name as a path parameter. */
 	public static final String ADMIN_USER_CUSTOM_ROLES = ADMIN_USER_PARAM + SEP +
 			ADMIN_CUSTOM_ROLES;
 	
+	/** A portion of a path designating setting a custom role. */
 	public static final String ADMIN_CUSTOM_ROLES_SET = ADMIN_CUSTOM_ROLES + SEP +  "set";
+	/** The set custom role endpoint location. */
 	public static final String ADMIN_ROOT_CUSTOM_ROLES_SET = ADMIN_ROOT + SEP +
 			ADMIN_CUSTOM_ROLES_SET;
 	
+	/** A portion of a path designating deleting a custom role. */
 	public static final String ADMIN_CUSTOM_ROLES_DELETE = ADMIN_CUSTOM_ROLES + SEP +  "delete";
+	/** The delete custom role endpoint location. */
 	public static final String ADMIN_ROOT_CUSTOM_ROLES_DELETE = ADMIN_ROOT + SEP + 
 			ADMIN_CUSTOM_ROLES_DELETE;
 	
+	/** A portion of a path designating the administration of the service configuration. */
 	public static final String ADMIN_CONFIG = "config";
+	/** A portion of a path designating the administration of the basic configuration. */
 	public static final String ADMIN_CONFIG_BASIC = ADMIN_CONFIG + SEP + "basic";
+	/** A portion of a path designating the administration of the configuration of an identity
+	 * provider.
+	 */
 	public static final String ADMIN_CONFIG_PROVIDER = ADMIN_CONFIG + SEP + "provider";
+	/** A portion of a path designating the reset of the service configuration. */
 	public static final String ADMIN_CONFIG_RESET = ADMIN_CONFIG + SEP + RESET;
+	/** A portion of a path designating the administration of the tokens configuration. */
 	public static final String ADMIN_CONFIG_TOKEN = ADMIN_CONFIG + SEP + TOKEN;
+	/** The basic service configuration endpoint location. */
 	public static final String ADMIN_ROOT_CONFIG_BASIC = ADMIN_ROOT + SEP + ADMIN_CONFIG_BASIC;
+	/** The identity provider configuration endpoint location. */
 	public static final String ADMIN_ROOT_CONFIG_PROVIDER = ADMIN_ROOT + SEP +
 			ADMIN_CONFIG_PROVIDER;
+	/** The configuration reset endpoint location. */
 	public static final String ADMIN_ROOT_CONFIG_RESET = ADMIN_ROOT + SEP + ADMIN_CONFIG_RESET;
+	/** The token configuration endpoint location. */
 	public static final String ADMIN_ROOT_CONFIG_TOKEN = ADMIN_ROOT + SEP + ADMIN_CONFIG_TOKEN;
 	
 	/* localaccount endpoint */
 	
+	/** The local account endpoint root location. */
 	public static final String LOCAL_ROOT = SEP + LOCAL;
 	
+	/** A portion of a path designating a local account login. */
 	public static final String LOCAL_LOGIN = LOGIN;
+	/** The local account login endpoint location. */
 	public static final String LOCAL_ROOT_LOGIN = LOCAL_ROOT + SEP + LOGIN;
+	/** A portion of a path designating the results of a local login. */
 	public static final String LOCAL_LOGIN_RESULT = LOCAL_LOGIN + SEP + RESULT;
+	/** The local account login result endpoint location. */
 	public static final String LOCAL_ROOT_LOGIN_RESULT = LOCAL_ROOT + SEP + LOCAL_LOGIN + SEP +
 			RESULT;
 	
-	public static final String LOCAL_RESET = "reset";
+	/** A portion of a path designating the resetting of a local account's password. */
+	public static final String LOCAL_RESET = RESET;
+	/** The local account password reset endpoint location. */
 	public static final String LOCAL_ROOT_RESET = LOCAL_ROOT + SEP + LOCAL_RESET;
+	/** A portion of a path designating the results of a password reset. */
 	public static final String LOCAL_RESET_RESULT = LOCAL_RESET + SEP + RESULT;
+	/** The local account password reset result endpoint location. */
 	public static final String LOCAL_ROOT_RESET_RESULT = LOCAL_ROOT + SEP + LOCAL_RESET_RESULT;
 	
 	/* login endpoint */
 	
+	/** The login endpoint root location. */
 	public static final String LOGIN_ROOT = SEP + LOGIN;
 	
+	/** A portion of a path designating the start of an OAuth2 login process. */
 	public static final String LOGIN_START = START;
+	/** The OAuth2 login start endpoint location. */
 	public static final String LOGIN_ROOT_START = LOGIN_ROOT + SEP + START;
+	/** The OAuth2 login complete endpoint location. */
 	public static final String LOGIN_ROOT_COMPLETE = LOGIN_ROOT + SEP + COMPLETE;
+	/** A portion of a path designating the completion of an OAuth2 provider redirect, including
+	 * the provider name as a path parameter.
+	 */
 	public static final String LOGIN_COMPLETE_PROVIDER = COMPLETE_PROVIDER;
+	/** A portion of a path designating suggesting a user name for a new user. */
 	public static final String LOGIN_SUGGEST_NAME = SUGGESTNAME + SEP + NAME_ID;
+	/** The name suggestion endpoint location. */
 	public static final String LOGIN_ROOT_SUGGESTNAME = LOGIN_ROOT + SEP + SUGGESTNAME;
+	/** A portion of a path designating a choice must be made by a user with regard to an OAuth2
+	 * login.
+	 */
 	public static final String LOGIN_CHOICE = CHOICE;
+	/** The login user choice endpoint location. */
 	public static final String LOGIN_ROOT_CHOICE = LOGIN_ROOT + SEP + LOGIN_CHOICE;
+	/** A portion of a path designating cancellation of the login process. */
 	public static final String LOGIN_CANCEL = CANCEL;
+	/** The login cancel endpoint location */
 	public static final String LOGIN_ROOT_CANCEL = LOGIN_ROOT + SEP + LOGIN_CANCEL;
+	/** A portion of a path designating a user picking an account with which to login. */
 	public static final String LOGIN_PICK = PICK;
+	/** The login pink account endpoint location. */
 	public static final String LOGIN_ROOT_PICK = LOGIN_ROOT + SEP + LOGIN_PICK;
+	/** A portion of a path designating a user creating a new account. */
 	public static final String LOGIN_CREATE = CREATE;
+	/** The login create account endpoint location. */
 	public static final String LOGIN_ROOT_CREATE = LOGIN_ROOT + SEP + LOGIN_CREATE;
 	
 	/* link endpoint */
 	
-	public static final String LINK_ROOT = "/link";
+	/** the link endpoint root location. */
+	public static final String LINK_ROOT = SEP + "link";
 	
+	/** A portion of a path designating the start of an OAuth2 link process. */
 	public static final String LINK_START = START;
+	/** The OAuth2 link start endpoint location. */
 	public static final String LINK_ROOT_START = LINK_ROOT + SEP + START;
+	/** The OAuth2 link complete endpoint location. */
 	public static final String LINK_ROOT_COMPLETE = LINK_ROOT + SEP + COMPLETE;
+	/** A portion of a path designating the completion of an OAuth2 provider redirect, including
+	 * the provider name as a path parameter.
+	 */
 	public static final String LINK_COMPLETE_PROVIDER = COMPLETE_PROVIDER;
+	/** A portion of a path designating a choice must be made by a user with regard to an OAuth2
+	 * account link.
+	 */
 	public static final String LINK_CHOICE = CHOICE;
+	/** The link user choice endpoint location. */
 	public static final String LINK_ROOT_CHOICE = LINK_ROOT + SEP + LINK_CHOICE;
+	/** A portion of a path designating cancellation of the link process. */
 	public static final String LINK_CANCEL = CANCEL;
+	/** The link cancel endpoint location */
 	public static final String LINK_ROOT_CANCEL = LINK_ROOT + SEP + LINK_CANCEL;
+	/** A portion of a path designating a user picking a remote identity to link to their
+	 * account.
+	 */
 	public static final String LINK_PICK = PICK;
+	/** The link pink account endpoint location. */
 	public static final String LINK_ROOT_PICK = LINK_ROOT + SEP + LINK_PICK;
 	
 	/* logout endpoint */
-	public static final String LOGOUT_ROOT = "/logout";
 	
+	/** The logout endpoint root location. */
+	public static final String LOGOUT_ROOT = SEP + "logout";
+	
+	/** A portion of a path designating the result of a logout. */
 	public static final String LOGOUT_RESULT = RESULT;
+	/** The logout result endpoint location. */
 	public static final String LOGOUT_ROOT_RESULT = LOGOUT_ROOT + SEP + RESULT;
 	
 	/* me endpoint */
 	
-	public static final String ME_ROOT = "/me";
+	/** The me endpoint root location. */
+	public static final String ME_ROOT = SEP + "me";
+
+	/** A portion of a path designating the unlinking of a remote identity from a user account,
+	 * including the identity's ID as a path parameter.
+	 */
+	public static final String ME_UNLINK_ID = UNLINK + SEP + ID;
 	
-	public static final String ME_UNLINK = "unlink";
-	public static final String ME_UNLINK_ID = ME_UNLINK + SEP + ID;
+	/** The unlink endpoint location. */
+	public static final String ME_ROOT_UNLINK = ME_ROOT + SEP + UNLINK;
 	
-	public static final String ME_ROOT_UNLINK = ME_ROOT + SEP + ME_UNLINK;
-	
+	/** A portion of a path designating the user's roles. */
 	public static final String ME_ROLES = ROLES;
+	/** The user roles endpoint location. */
 	public static final String ME_ROOT_ROLES = ME_ROOT + SEP + ME_ROLES;
 	
 	/* tokens endpoint */
 	
+	/** The token endpoint root location. */
 	public static final String TOKENS_ROOT = SEP + TOKENS;
 	
+	/** A portion of a path designating the creation of a token. */
 	public static final String TOKENS_CREATE = CREATE;
+	/** The token creation endpoint location. */
 	public static final String TOKENS_ROOT_CREATE = TOKENS_ROOT + SEP + TOKENS_CREATE;
+	/** A portion of a path designating the revocation of a token. */
 	public static final String TOKENS_REVOKE = REVOKE;
+	/** The token revocation endpoint location. */
 	public static final String TOKENS_ROOT_REVOKE = TOKENS_ROOT + SEP + TOKENS_REVOKE;
+	/** A portion of a path designating the revocation of a token, including the token id as a
+	 * path parameter.
+	 */
 	public static final String TOKENS_REVOKE_ID = TOKENS_REVOKE + SEP + TOKEN_ID_PARAM;
+	/** A portion of a path designating the revocation of all of a user's tokens. */
 	public static final String TOKENS_REVOKE_ALL = REVOKE_ALL;
+	/** The revoke all tokens endpoint location. */
 	public static final String TOKENS_ROOT_REVOKE_ALL = TOKENS_ROOT + SEP + TOKENS_REVOKE_ALL;
 	
 	/* customroles endpoint */
 	
+	/** The custom roles endpoint location. */
 	public static final String CUSTOM_ROLES_ROOT = SEP + CUSTOM_ROLES;
 }

--- a/src/us/kbase/auth2/service/ui/UIToken.java
+++ b/src/us/kbase/auth2/service/ui/UIToken.java
@@ -6,7 +6,6 @@ import us.kbase.auth2.service.common.ExternalToken;
 
 public class UIToken extends ExternalToken {
 	
-	//TODO TEST
 	//TODO JAVADOC or swagger
 	
 	private final String os;

--- a/src/us/kbase/auth2/service/ui/UIToken.java
+++ b/src/us/kbase/auth2/service/ui/UIToken.java
@@ -7,7 +7,7 @@ import us.kbase.auth2.service.common.ExternalToken;
 public class UIToken extends ExternalToken {
 	
 	//TODO TEST
-	//TODO JAVADOC
+	//TODO JAVADOC or swagger
 	
 	private final String os;
 	private final String osver;

--- a/src/us/kbase/auth2/service/ui/UIUtils.java
+++ b/src/us/kbase/auth2/service/ui/UIUtils.java
@@ -39,6 +39,10 @@ import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.service.AuthExternalConfig;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
 
+/** Utility functions for the UI endpoints.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class UIUtils {
 
 	// attempts to deal with the mess of returning a relative path to the
@@ -120,7 +124,7 @@ public class UIUtils {
 				UIConstants.SECURE_COOKIES);
 	}
 
-	/** Get the maximum age for a cookie given a temporaray token.
+	/** Get the maximum age for a cookie given a temporary token.
 	 * @param token the token.
 	 * @return the maximum cookie age in seconds.
 	 */

--- a/src/us/kbase/test/auth2/lib/token/TokenTest.java
+++ b/src/us/kbase/test/auth2/lib/token/TokenTest.java
@@ -8,6 +8,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -393,6 +395,37 @@ public class TokenTest {
 		failCreateTokenSet(ht1, new HashSet<>(Arrays.asList(ht2, null, ht3)),
 				new NullPointerException("One of the tokens in the incoming set is null"));
 		
+	}
+	
+	@Test
+	public void tokenSetIsStored() throws Exception {
+		final UUID id1 = UUID.fromString("edc1dcbb-d370-4660-a639-01a72f0d578a");
+		final UUID id2 = UUID.fromString("8351a73a-d4c7-4c00-9a7d-012ace5d9519");
+		final UUID id3 = UUID.fromString("653cc5ce-37e6-4e61-ac25-48831657f257");
+		final UUID id4 = UUID.fromString("cb5e637c-cfbb-44eb-b179-843f3279f775");
+		final UUID id5 = UUID.fromString("354c4f2d-a472-43aa-a4bd-84392b2d3407");
+		
+		final StoredToken ht1 = StoredToken.getBuilder(TokenType.LOGIN, id1, new UserName("u"))
+				.withLifeTime(Instant.ofEpochMilli(1000), 1000).build();
+		final StoredToken ht2 = StoredToken.getBuilder(TokenType.DEV, id2, new UserName("u"))
+				.withLifeTime(Instant.ofEpochMilli(3000), 1000)
+				.withTokenName(new TokenName("n2")).build();
+		final StoredToken ht3 = StoredToken.getBuilder(TokenType.AGENT, id3, new UserName("u"))
+				.withLifeTime(Instant.ofEpochMilli(5000), 1000)
+				.withTokenName(new TokenName("n3")).build();
+		final StoredToken ht4 = StoredToken.getBuilder(TokenType.SERV, id4, new UserName("u"))
+				.withLifeTime(Instant.ofEpochMilli(7000), 1000)
+				.withTokenName(new TokenName("n4")).build();
+		final StoredToken ht5 = StoredToken.getBuilder(TokenType.SERV, id5, new UserName("u"))
+				.withLifeTime(Instant.ofEpochMilli(8000), 1000)
+				.withTokenName(new TokenName("n5")).build();
+
+		// test that unmodifiable sets don't break anything
+		final Set<StoredToken> tokens = Collections.unmodifiableSet(
+						new HashSet<>(Arrays.asList(ht2, ht3, ht4, ht5)));
+		final TokenSet ts = new TokenSet(ht1, tokens);
+		final List<StoredToken> sorted = new LinkedList<>(ts.getTokens());
+		assertThat("tokens not sorted", sorted, is(Arrays.asList(ht5, ht3, ht2, ht4)));
 	}
 	
 	private void failCreateTokenSet(

--- a/src/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -216,7 +216,7 @@ public class ServiceTestUtils {
 			throws Exception {
 		
 		assertThat("incorrect token context", uitoken.get("custom"), is(customContext));
-		assertThat("incorrect token type", uitoken.get("type"), is(type.getID()));
+		assertThat("incorrect token type", uitoken.get("type"), is(type.getDescription()));
 		final long created = (long) uitoken.get("created");
 		TestCommon.assertCloseToNow(created);
 		assertThat("incorrect expires", uitoken.get("expires"),

--- a/src/us/kbase/test/auth2/service/common/ExternalTokenTest.java
+++ b/src/us/kbase/test/auth2/service/common/ExternalTokenTest.java
@@ -2,6 +2,7 @@ package us.kbase.test.auth2.service.common;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -16,6 +17,7 @@ import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.lib.token.TokenName;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.service.common.ExternalToken;
+import us.kbase.test.auth2.TestCommon;
 
 public class ExternalTokenTest {
 	
@@ -58,6 +60,16 @@ public class ExternalTokenTest {
 		assertThat("incorrect name", et.getName(), is((String) null));
 		assertThat("incorrect custom context", et.getCustom(),
 				is(ImmutableMap.of("whee", "whoo")));
+	}
+	
+	@Test
+	public void constructFail() throws Exception {
+		try {
+			new ExternalToken(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("storedToken"));
+		}
 	}
 
 }

--- a/src/us/kbase/test/auth2/service/ui/TokensTest.java
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest.java
@@ -1,0 +1,327 @@
+package us.kbase.test.auth2.service.ui;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestHTML;
+import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.kbase.KBaseAuthConfig;
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.PasswordHashAndSalt;
+import us.kbase.auth2.lib.Role;
+import us.kbase.auth2.lib.TokenCreationContext;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.InvalidTokenException;
+import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.StoredToken;
+import us.kbase.auth2.lib.token.TokenName;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.auth2.lib.user.LocalUser;
+import us.kbase.test.auth2.MapBuilder;
+import us.kbase.test.auth2.MongoStorageTestManager;
+import us.kbase.test.auth2.StandaloneAuthServer;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.StandaloneAuthServer.ServerThread;
+import us.kbase.test.auth2.service.ServiceTestUtils;
+
+public class TokensTest {
+	
+	private static final String DB_NAME = "test_tokens_ui";
+	private static final String COOKIE_NAME = "login-cookie";
+	
+	private static final Client CLI = ClientBuilder.newClient();
+	
+	private static MongoStorageTestManager manager = null;
+	private static StandaloneAuthServer server = null;
+	private static int port = -1;
+	private static String host = null;
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		TestCommon.stfuLoggers();
+		manager = new MongoStorageTestManager(DB_NAME);
+		final Path cfgfile = ServiceTestUtils.generateTempConfigFile(
+				manager, DB_NAME, COOKIE_NAME);
+		TestCommon.getenv().put("KB_DEPLOYMENT_CONFIG", cfgfile.toString());
+		server = new StandaloneAuthServer(KBaseAuthConfig.class.getName());
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getPort() == null) {
+			Thread.sleep(1000);
+		}
+		port = server.getPort();
+		host = "http://localhost:" + port;
+	}
+	
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (server != null) {
+			server.stop();
+		}
+		if (manager != null) {
+			manager.destroy();
+		}
+	}
+	
+	@Before
+	public void beforeTest() throws Exception {
+		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+	}
+	
+	@Test
+	public void getTokensMinimalInput() throws Exception {
+		final String id = "edc1dcbb-d370-4660-a639-01a72f0d578a";
+
+		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
+				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000))
+				.build(),
+				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));
+		
+		final IncomingToken token = new IncomingToken("whoop");
+		manager.storage.storeToken(StoredToken.getBuilder(
+				TokenType.LOGIN, UUID.fromString(id),
+						new UserName("whoo"))
+				.withLifeTime(Instant.ofEpochMilli(10000), 1000000000000000L)
+				.build(),
+				token.getHashedToken().getTokenHash());
+		
+		final URI target = UriBuilder.fromUri(host).path("/tokens").build();
+		
+		final WebTarget wt = CLI.target(target);
+		
+		final Builder req = wt.request()
+				.cookie(COOKIE_NAME, token.getToken());
+
+		final Response res = req.get();
+		final String html = res.readEntity(String.class);
+		
+		TestCommon.assertNoDiffs(html, TestCommon.getTestExpectedData(getClass(),
+				TestCommon.getCurrentMethodName()));
+		
+		final Builder reqjson = wt.request()
+				.header("accept", MediaType.APPLICATION_JSON)
+				.header("authorization", token.getToken());
+
+		final Response resjson = reqjson.get();
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> json = resjson.readEntity(Map.class);
+		
+		final Map<String, Object> expected = MapBuilder.<String, Object>newHashMap()
+				.with("user", "whoo")
+				.with("dev", false)
+				.with("service", false)
+				.with("current", MapBuilder.newHashMap()
+						.with("type", "Login")
+						.with("id", id)
+						.with("expires", 1000000000010000L)
+						.with("created", 10000)
+						.with("name", null)
+						.with("user", "whoo")
+						.with("custom", Collections.emptyMap())
+						.with("os", null)
+						.with("osver", null)
+						.with("agent", null)
+						.with("agentver", null)
+						.with("device", null)
+						.with("ip", null)
+						.build())
+				.with("tokens", Collections.emptyList())
+				.with("revokeurl", "tokens/revoke/")
+				.with("createurl", "tokens/create")
+				.with("revokeallurl", "tokens/revokeall")
+				.build();
+		
+		assertThat("incorrect token get reponse", json, is(expected));
+	}
+	
+	@Test
+	public void getTokensMaximalInput() throws Exception {
+		final String id = "edc1dcbb-d370-4660-a639-01a72f0d578a";
+		final String id2 = "8351a73a-d4c7-4c00-9a7d-012ace5d9519";
+		final String id3 = "653cc5ce-37e6-4e61-ac25-48831657f257";
+
+		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
+				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000))
+				.withRole(Role.DEV_TOKEN)
+				.withRole(Role.SERV_TOKEN)
+				.build(),
+				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));
+		
+		final IncomingToken token = new IncomingToken("whoop");
+		manager.storage.storeToken(StoredToken.getBuilder(
+				TokenType.LOGIN, UUID.fromString(id),
+						new UserName("whoo"))
+				.withLifeTime(Instant.ofEpochMilli(10000), 1000000000000000L)
+				.withTokenName(new TokenName("wugga"))
+				.withContext(TokenCreationContext.getBuilder()
+						.withCustomContext("foo", "bar")
+						.withIpAddress(InetAddress.getByName("127.0.0.3"))
+						.withNullableAgent("ag", "agv")
+						.withNullableDevice("dev")
+						.withNullableOS("o", "osv")
+						.build())
+				.build(),
+				token.getHashedToken().getTokenHash());
+		
+		manager.storage.storeToken(StoredToken.getBuilder(
+				TokenType.AGENT, UUID.fromString(id2),
+						new UserName("whoo"))
+				.withLifeTime(Instant.ofEpochMilli(20000), 2000000000000000L)
+				.withContext(TokenCreationContext.getBuilder()
+						.withCustomContext("baz", "bat")
+						.withNullableAgent("ag2", "agv2")
+						.withNullableDevice("dev2")
+						.build())
+				.build(),
+				"somehash");
+		
+		manager.storage.storeToken(StoredToken.getBuilder(
+				TokenType.DEV, UUID.fromString(id3),
+						new UserName("whoo"))
+				.withLifeTime(Instant.ofEpochMilli(30000), 3000000000000000L)
+				.withTokenName(new TokenName("whee"))
+				.withContext(TokenCreationContext.getBuilder()
+						.withIpAddress(InetAddress.getByName("127.0.0.42"))
+						.withNullableDevice("dev3")
+						.build())
+				.build(),
+				"somehash2");
+		
+		final URI target = UriBuilder.fromUri(host).path("/tokens/").build();
+		
+		final WebTarget wt = CLI.target(target);
+		
+		final Builder req = wt.request()
+				.cookie(COOKIE_NAME, token.getToken());
+
+		final Response res = req.get();
+		final String html = res.readEntity(String.class);
+		
+		TestCommon.assertNoDiffs(html, TestCommon.getTestExpectedData(getClass(),
+				TestCommon.getCurrentMethodName()));
+		
+		final Builder reqjson = wt.request()
+				.header("accept", MediaType.APPLICATION_JSON)
+				.header("authorization", token.getToken());
+
+		final Response resjson = reqjson.get();
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> json = resjson.readEntity(Map.class);
+		
+		final Map<String, Object> expected = MapBuilder.<String, Object>newHashMap()
+				.with("user", "whoo")
+				.with("dev", true)
+				.with("service", true)
+				.with("current", MapBuilder.newHashMap()
+						.with("type", "Login")
+						.with("id", id)
+						.with("expires", 1000000000010000L)
+						.with("created", 10000)
+						.with("name", "wugga")
+						.with("user", "whoo")
+						.with("custom", ImmutableMap.of("foo", "bar"))
+						.with("os", "o")
+						.with("osver", "osv")
+						.with("agent", "ag")
+						.with("agentver", "agv")
+						.with("device", "dev")
+						.with("ip", "127.0.0.3")
+						.build())
+				.with("tokens", Arrays.asList(
+						MapBuilder.newHashMap()
+								.with("type", "Developer")
+								.with("id", id3)
+								.with("expires", 3000000000030000L)
+								.with("created", 30000)
+								.with("name", "whee")
+								.with("user", "whoo")
+								.with("custom", Collections.emptyMap())
+								.with("os", null)
+								.with("osver", null)
+								.with("agent", null)
+								.with("agentver", null)
+								.with("device", "dev3")
+								.with("ip", "127.0.0.42")
+								.build(),
+						MapBuilder.newHashMap()
+								.with("type", "Agent")
+								.with("id", id2)
+								.with("expires", 2000000000020000L)
+								.with("created", 20000)
+								.with("name", null)
+								.with("user", "whoo")
+								.with("custom", ImmutableMap.of("baz", "bat"))
+								.with("os", null)
+								.with("osver", null)
+								.with("agent", "ag2")
+								.with("agentver", "agv2")
+								.with("device", "dev2")
+								.with("ip", null)
+								.build()))
+				.with("revokeurl", "revoke/")
+				.with("createurl", "create")
+				.with("revokeallurl", "revokeall")
+				.build();
+		
+		assertThat("incorrect token get reponse", json, is(expected));
+	}
+	
+	@Test
+	public void getTokensFailNoToken() throws Exception {
+		final URI target = UriBuilder.fromUri(host).path("/tokens").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request();
+
+		failRequestHTML(req.get(), 400, "Bad Request",
+				new NoTokenProvidedException("No user token provided"));
+
+		req.header("accept", MediaType.APPLICATION_JSON);
+		
+		failRequestJSON(req.get(), 400, "Bad Request",
+				new NoTokenProvidedException("No user token provided"));
+	}
+	
+	@Test
+	public void getTokensFailBadToken() throws Exception {
+		final URI target = UriBuilder.fromUri(host).path("/tokens").build();
+		
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				.cookie(COOKIE_NAME, "foobar");
+
+		failRequestHTML(req.get(), 401, "Unauthorized", new InvalidTokenException());
+
+		final Builder req2 = wt.request()
+				.header("authorization", "boobar")
+				.header("accept", MediaType.APPLICATION_JSON);
+		
+		failRequestJSON(req2.get(), 401, "Unauthorized", new InvalidTokenException());
+	}
+
+}

--- a/src/us/kbase/test/auth2/service/ui/TokensTest_createTokenMaximalInput.testdata
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest_createTokenMaximalInput.testdata
@@ -1,0 +1,18 @@
+<html>
+<body>
+<p>Note for UI developers - this page should have no 3rd party javascript \/ analytics etc.<\/p>
+<p>Note that in a proper UI, the token name should be HTML-escaped.<\/p>
+
+Created token for %s:<br\/>
+Times are in milliseconds since the epoch.<br\/>
+Once you navigate away from this page, you'll never be able to see this token
+again.<br\/>
+
+Name: %s<br\/>
+Id: ([\w-]+)<br\/>
+Token: (\w+)<br\/>
+Created: (\d+)<br\/>
+Expires: (\d+)<br\/>
+<\/body>
+<\/html>
+\s*

--- a/src/us/kbase/test/auth2/service/ui/TokensTest_createTokenMinimalInput.testdata
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest_createTokenMinimalInput.testdata
@@ -1,0 +1,18 @@
+<html>
+<body>
+<p>Note for UI developers - this page should have no 3rd party javascript \/ analytics etc.<\/p>
+<p>Note that in a proper UI, the token name should be HTML-escaped.<\/p>
+
+Created token for %s:<br\/>
+Times are in milliseconds since the epoch.<br\/>
+Once you navigate away from this page, you'll never be able to see this token
+again.<br\/>
+
+Name: %s<br\/>
+Id: ([\w-]+)<br\/>
+Token: (\w+)<br\/>
+Created: (\d+)<br\/>
+Expires: (\d+)<br\/>
+<\/body>
+<\/html>
+\s*

--- a/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMaximalInput.testdata
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMaximalInput.testdata
@@ -6,7 +6,7 @@
 Expiration and creation dates are in milliseconds from the epoch.
 </p>
 <h3>Create a token:</h3>
-<form action="create" method="post">
+<form action="" method="post">
 	Token name: <input type="text" name="name"/><br/>
 	Custom token creation context: <input type="text" name="customcontext"/><br/>
 	<input type="checkbox" name="type" value="service"/>Server token<br/>

--- a/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMaximalInput.testdata
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMaximalInput.testdata
@@ -1,0 +1,59 @@
+<html>
+<body>
+<p>Note that in a proper UI, the token names should be HTML-escaped.</p>
+
+<h2>User: whoo</h2>
+Expiration and creation dates are in milliseconds from the epoch.
+</p>
+<h3>Create a token:</h3>
+<form action="create" method="post">
+	Token name: <input type="text" name="name"/><br/>
+	Custom token creation context: <input type="text" name="customcontext"/><br/>
+	<input type="checkbox" name="type" value="service"/>Server token<br/>
+	<input type="submit" value="Submit"/>
+</form>
+<form action="revokeall" method="post">
+	<input type="submit" value="Revoke all tokens and logout"/>
+</form>
+<h3>Current token:</h3>
+Name: wugga<br/>
+ID: edc1dcbb-d370-4660-a639-01a72f0d578a<br/>
+Type: Login<br/>
+Created: 10000<br/>
+Expires: 1000000000010000<br/>
+OS: o osv<br/>
+Agent: ag agv<br/>
+Device: dev<br/>
+IP: 127.0.0.3<br/>
+Custom: {foo&#61;bar}<br/>
+<br/>
+<h3>Tokens:</h3>
+Name: whee<br/>
+ID: 653cc5ce-37e6-4e61-ac25-48831657f257<br/>
+Type: Developer<br/>
+Created: 30000<br/>
+Expires: 3000000000030000<br/>
+OS:  <br/>
+Agent:  <br/>
+Device: dev3<br/>
+IP: 127.0.0.42<br/>
+Custom: {}<br/>
+<form action="revoke/653cc5ce-37e6-4e61-ac25-48831657f257" method="post">
+	<input type="submit" value="Revoke"/>
+</form>
+<br/>
+ID: 8351a73a-d4c7-4c00-9a7d-012ace5d9519<br/>
+Type: Agent<br/>
+Created: 20000<br/>
+Expires: 2000000000020000<br/>
+OS:  <br/>
+Agent: ag2 agv2<br/>
+Device: dev2<br/>
+IP: <br/>
+Custom: {baz&#61;bat}<br/>
+<form action="revoke/8351a73a-d4c7-4c00-9a7d-012ace5d9519" method="post">
+	<input type="submit" value="Revoke"/>
+</form>
+<br/>
+</body>
+</html>

--- a/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMinimalInput.testdata
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest_getTokensMinimalInput.testdata
@@ -1,0 +1,24 @@
+<html>
+<body>
+<p>Note that in a proper UI, the token names should be HTML-escaped.</p>
+
+<h2>User: whoo</h2>
+Expiration and creation dates are in milliseconds from the epoch.
+</p>
+<form action="tokens/revokeall" method="post">
+	<input type="submit" value="Revoke all tokens and logout"/>
+</form>
+<h3>Current token:</h3>
+ID: edc1dcbb-d370-4660-a639-01a72f0d578a<br/>
+Type: Login<br/>
+Created: 10000<br/>
+Expires: 1000000000010000<br/>
+OS:  <br/>
+Agent:  <br/>
+Device: <br/>
+IP: <br/>
+Custom: {}<br/>
+<br/>
+<h3>Tokens:</h3>
+</body>
+</html>

--- a/src/us/kbase/test/auth2/service/ui/UITokensTest.java
+++ b/src/us/kbase/test/auth2/service/ui/UITokensTest.java
@@ -1,0 +1,97 @@
+package us.kbase.test.auth2.service.ui;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.TokenCreationContext;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.token.NewToken;
+import us.kbase.auth2.lib.token.StoredToken;
+import us.kbase.auth2.lib.token.TokenType;
+import us.kbase.auth2.service.ui.NewUIToken;
+import us.kbase.auth2.service.ui.UIToken;
+import us.kbase.test.auth2.TestCommon;
+
+public class UITokensTest {
+
+	@Test
+	public void constructUITokenMinimal() throws Exception {
+		// only testing the methods in UIToken, not the supertype
+		final UUID id = UUID.randomUUID();
+		final UIToken t = new UIToken(StoredToken.getBuilder(
+				TokenType.AGENT, id, new UserName("foo"))
+				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(30000))
+				.build());
+		
+		assertThat("incorrect device", t.getDevice(), is((String) null));
+		assertThat("incorrect agent", t.getAgent(), is((String) null));
+		assertThat("incorrect agent version", t.getAgentver(), is((String) null));
+		assertThat("incorrect os", t.getOs(), is((String) null));
+		assertThat("incorrect os version", t.getOsver(), is((String) null));
+		assertThat("incorrect ip", t.getIp(), is((String) null));
+	}
+	
+	@Test
+	public void constructUITokenMaximal() throws Exception {
+		// only testing the methods in UIToken, not the supertype
+		final UUID id = UUID.randomUUID();
+		final UIToken t = new UIToken(StoredToken.getBuilder(
+				TokenType.AGENT, id, new UserName("foo"))
+				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(30000))
+				.withContext(TokenCreationContext.getBuilder()
+						.withIpAddress(InetAddress.getByName("127.0.0.3"))
+						.withNullableAgent("ag", "6")
+						.withNullableDevice("dev")
+						.withNullableOS("os1", "42")
+						.build())
+				.build());
+		
+		assertThat("incorrect device", t.getDevice(), is("dev"));
+		assertThat("incorrect agent", t.getAgent(), is("ag"));
+		assertThat("incorrect agent version", t.getAgentver(), is("6"));
+		assertThat("incorrect os", t.getOs(), is("os1"));
+		assertThat("incorrect os version", t.getOsver(), is("42"));
+		assertThat("incorrect ip", t.getIp(), is("127.0.0.3"));
+	}
+	
+	@Test
+	public void constructUITokenFail() throws Exception {
+		try {
+			new UIToken(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("storedToken"));
+		}
+	}
+	
+	@Test
+	public void constructNewUIToken() throws Exception {
+		// only testing the methods in NewUIToken, not the supertype
+		final UUID id = UUID.randomUUID();
+		final NewUIToken t = new NewUIToken(new NewToken(StoredToken.getBuilder(
+				TokenType.AGENT, id, new UserName("foo"))
+				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(30000))
+				.build(), "wheewhee"));
+		
+		assertThat("incorrect token", t.getToken(), is("wheewhee"));
+		
+	}
+	
+	@Test
+	public void constructNewUITokenFail() throws Exception {
+		try {
+			new NewUIToken(null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NullPointerException("token"));
+		}
+	}
+	
+}


### PR DESCRIPTION
Changes the token creation endpoint to /tokens from /tokens/create.

Changes POST /tokens/revokeall response to 204 from 200 to match the other 3 revoke endpoints.

Also adds Javadoc to the remaining UI classes that aren't targeted for Swagger treatment.