### PR TITLE
TASK-771 Log xFF and realIP headers, logging filter tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -327,6 +327,7 @@
         <test name="us.kbase.test.auth2.lib.user.NewUserTest"/>
         <test name="us.kbase.test.auth2.providers.GlobusIdentityProviderTest"/>
         <test name="us.kbase.test.auth2.providers.GoogleIdentityProviderTest"/>
+        <test name="us.kbase.test.auth2.service.LoggingFilterTest"/>
         <test name="us.kbase.test.auth2.service.api.APITokenTest"/>
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
         <test name="us.kbase.test.auth2.service.api.UserEndpointTest"/>

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -1,6 +1,10 @@
 package us.kbase.auth2.service;
 
+import static us.kbase.auth2.service.common.ServiceCommon.nullOrEmpty;
+
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -26,8 +30,6 @@ import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
  */
 public class LoggingFilter implements ContainerRequestFilter,
 		ContainerResponseFilter {
-	
-	//TODO TEST unit tests
 	
 	private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final String X_REAL_IP = "X-Real-IP";
@@ -57,9 +59,35 @@ public class LoggingFilter implements ContainerRequestFilter,
 		logger.setCallInfo(reqcon.getMethod(),
 				(String.format("%.16f", Math.random())).substring(2),
 				getIpAddress(reqcon, ignoreIPheaders));
+		
+		logHeaders(reqcon, ignoreIPheaders);
 	}
 	
-	//TODO TEST xff and realip headers
+	private void logHeaders(
+			final ContainerRequestContext request,
+			final boolean ignoreIPsInHeaders) {
+		if (!ignoreIPsInHeaders) {
+			final List<String> log = new LinkedList<>();
+			final String xFF = request.getHeaderString(X_FORWARDED_FOR);
+			final String realIP = request.getHeaderString(X_REAL_IP);
+			if (!nullOrEmpty(xFF)) {
+				log.add(X_FORWARDED_FOR + ": " + xFF);
+			}
+			if (!nullOrEmpty(realIP)) {
+				log.add(X_REAL_IP + ": " + realIP);
+			}
+			if (!nullOrEmpty(realIP) || !nullOrEmpty(xFF)) {
+				log.add("Remote IP: " + servletRequest.getRemoteAddr());
+				logInfo(String.join(", ", log));
+			}
+		}
+	}
+	
+	private void logInfo(final String format, final Object... args) {
+		LoggerFactory.getLogger(getClass()).info(format, args);
+		
+	}
+
 	private String getIpAddress(
 			final ContainerRequestContext request,
 			final boolean ignoreIPsInHeaders) {
@@ -67,14 +95,13 @@ public class LoggingFilter implements ContainerRequestFilter,
 		final String realIP = request.getHeaderString(X_REAL_IP);
 
 		if (!ignoreIPsInHeaders) {
-			if (xFF != null && !xFF.trim().isEmpty()) {
+			if (!nullOrEmpty(xFF)) {
 				return xFF.split(",")[0].trim();
 			}
-			if (realIP != null && !realIP.trim().isEmpty()) {
+			if (!nullOrEmpty(realIP)) {
 				return realIP.trim();
 			}
 		}
-		//TODO LOG always log xff, real ip, and request ip
 		return servletRequest.getRemoteAddr();
 	}
 
@@ -83,7 +110,7 @@ public class LoggingFilter implements ContainerRequestFilter,
 			final ContainerRequestContext reqcon,
 			final ContainerResponseContext rescon)
 			throws IOException {
-		LoggerFactory.getLogger(getClass()).info("{} {} {} {}",
+		logInfo("{} {} {} {}",
 				reqcon.getMethod(),
 				reqcon.getUriInfo().getAbsolutePath(),
 				rescon.getStatus(),

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -18,11 +18,16 @@ import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
 import us.kbase.auth2.service.AuthExternalConfig.AuthExternalConfigMapper;
 
+/** The logger for the auth service. Sets up the logging info (e.g. the method, a random call ID,
+ * and the IP address) for each request and logs the method, path, status code, and user agent on
+ * a response.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class LoggingFilter implements ContainerRequestFilter,
 		ContainerResponseFilter {
 	
 	//TODO TEST unit tests
-	//TODO JAVADOC
 	
 	private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final String X_REAL_IP = "X-Real-IP";
@@ -49,13 +54,13 @@ public class LoggingFilter implements ContainerRequestFilter,
 					"An error occurred in the logger when attempting " +
 					"to get the server configuration", e); 
 		}
-		logger.setCallInfo(reqcon.getMethod(), (String.format("%.16f", Math.random()))
-				.substring(2),
+		logger.setCallInfo(reqcon.getMethod(),
+				(String.format("%.16f", Math.random())).substring(2),
 				getIpAddress(reqcon, ignoreIPheaders));
 	}
 	
 	//TODO TEST xff and realip headers
-	public String getIpAddress(
+	private String getIpAddress(
 			final ContainerRequestContext request,
 			final boolean ignoreIPsInHeaders) {
 		final String xFF = request.getHeaderString(X_FORWARDED_FOR);

--- a/src/us/kbase/auth2/service/SLF4JAutoLogger.java
+++ b/src/us/kbase/auth2/service/SLF4JAutoLogger.java
@@ -19,6 +19,8 @@ public interface SLF4JAutoLogger {
 			final String id,
 			final String ipAddress);
 	
+	//TODO NOW CODE get rid of this method and instead make own call ID handler to decouple logger and exception handler.
+	
 	/** Get the call ID for the call being handled in this thread.
 	 * @return the call ID.
 	 */

--- a/src/us/kbase/auth2/service/SLF4JAutoLogger.java
+++ b/src/us/kbase/auth2/service/SLF4JAutoLogger.java
@@ -19,8 +19,6 @@ public interface SLF4JAutoLogger {
 			final String id,
 			final String ipAddress);
 	
-	//TODO NOW CODE get rid of this method and instead make own call ID handler to decouple logger and exception handler.
-	
 	/** Get the call ID for the call being handled in this thread.
 	 * @return the call ID.
 	 */

--- a/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
+++ b/src/us/kbase/auth2/service/exceptions/ExceptionHandler.java
@@ -37,7 +37,7 @@ import us.kbase.auth2.service.template.TemplateProcessor;
 
 public class ExceptionHandler implements ExceptionMapper<Throwable> {
 
-	//TODO TEST unit tests
+	//TODO TEST unit tests, probably makes sense to do logging & exceptions in the same test file
 	//TODO JAVADOC
 	
 	@Context
@@ -68,6 +68,7 @@ public class ExceptionHandler implements ExceptionMapper<Throwable> {
 					"An error occurred in the error handler when attempting " +
 					"to get the server configuration", e); 
 		}
+		//TODO CODE get rid of the logger.getCallID() method and instead make own call ID handler to decouple logger and exception handler.
 		final ErrorMessage em = new ErrorMessage(ex, logger.getCallID(), includeStack);
 		String ret;
 		if (mt.equals(MediaType.APPLICATION_JSON_TYPE)) {

--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -29,7 +29,6 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -754,7 +753,7 @@ public class Admin {
 		}
 	}
 	
-	@PUT
+	@POST
 	@Path(UIPaths.ADMIN_CONFIG)
 	@Consumes(MediaType.APPLICATION_JSON)
 	public void updateConfig(

--- a/src/us/kbase/test/auth2/service/LoggingFilterTest.java
+++ b/src/us/kbase/test/auth2/service/LoggingFilterTest.java
@@ -1,0 +1,202 @@
+package us.kbase.test.auth2.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static us.kbase.test.auth2.TestCommon.set;
+
+import java.net.URI;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import us.kbase.auth2.lib.identity.IdentityProviderConfig;
+import us.kbase.auth2.service.AuthStartupConfig;
+import us.kbase.auth2.service.LoggingFilter;
+import us.kbase.auth2.service.SLF4JAutoLogger;
+import us.kbase.common.test.RegexMatcher;
+import us.kbase.test.auth2.MongoStorageTestManager;
+import us.kbase.test.auth2.StandaloneAuthServer;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.StandaloneAuthServer.ServerThread;
+
+public class LoggingFilterTest {
+	
+	private static final String DB_NAME = "test_link_ui";
+	private static final String COOKIE_NAME = "login-cookie";
+	
+	private static final Client CLI = ClientBuilder.newClient();
+	
+	private static MongoStorageTestManager manager = null;
+	private static StandaloneAuthServer server = null;
+	private static int port = -1;
+	private static String host = null;
+	
+	private static List<ILoggingEvent> logEvents = new LinkedList<>();
+	
+	private static SLF4JAutoLogger autologgermock = mock(SLF4JAutoLogger.class);
+	
+	public static class LoggingFilterTestConfig implements AuthStartupConfig {
+		
+		public static String mongohost;
+
+		@Override
+		public SLF4JAutoLogger getLogger() {
+			return autologgermock;
+		}
+
+		@Override
+		public Set<IdentityProviderConfig> getIdentityProviderConfigs() {
+			return set();
+		}
+
+		@Override
+		public String getMongoHost() {
+			return mongohost;
+		}
+
+		@Override
+		public String getMongoDatabase() {
+			return DB_NAME;
+		}
+
+		@Override
+		public Optional<String> getMongoUser() {
+			return Optional.absent();
+		}
+
+		@Override
+		public Optional<char[]> getMongoPwd() {
+			return Optional.absent();
+		}
+
+		@Override
+		public String getTokenCookieName() {
+			return COOKIE_NAME;
+		}
+	}
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		TestCommon.stfuLoggers();
+		manager = new MongoStorageTestManager(DB_NAME);
+		LoggingFilterTestConfig.mongohost = "localhost:" + manager.mongo.getServerPort();
+		server = new StandaloneAuthServer(LoggingFilterTestConfig.class.getName());
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getPort() == null) {
+			Thread.sleep(1000);
+		}
+		port = server.getPort();
+		host = "http://localhost:" + port;
+		setUpSLF4JTestLoggerAppender();
+	}
+	
+	private static void setUpSLF4JTestLoggerAppender() {
+		// MongoStorageTestManager turns off the logger, so reenable here
+		((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+				.getLogger("us.kbase.auth2.service.LoggingFilter"))
+				.setLevel(ch.qos.logback.classic.Level.ALL);
+		final Logger authRootLogger = (Logger) LoggerFactory.getLogger("us.kbase.auth2");
+		authRootLogger.setLevel(Level.ALL);
+		final AppenderBase<ILoggingEvent> appender =
+				new AppenderBase<ILoggingEvent>() {
+			@Override
+			protected void append(final ILoggingEvent event) {
+				logEvents.add(event);
+			}
+		};
+		appender.start();
+		authRootLogger.addAppender(appender);
+	}
+	
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (server != null) {
+			server.stop();
+		}
+		if (manager != null) {
+			manager.destroy();
+		}
+	}
+	
+	@Before
+	public void beforeTest() throws Exception {
+		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+		logEvents.clear();
+		reset(autologgermock); // bad practice but too expensive to restart server per test
+		// should look into unit testing the logger again at some point, but difficult to find
+		// good examples of how to test with @Context injections, and what I did see was absurdly
+		// complex
+		// not that this isn't absurdly complex, but I could get it working anyway
+	}
+	
+	private class SetCallInfoAnswer implements Answer<Void> {
+		
+		private String recordedmethod;
+		private String recordedid;
+		private String recordedip;
+
+		@Override
+		public Void answer(final InvocationOnMock inv) throws Throwable {
+			recordedmethod = inv.getArgument(0);
+			recordedid = inv.getArgument(1);
+			recordedip = inv.getArgument(2);
+			return null;
+		}
+		
+		public void check(final String method, final String ip) {
+			assertThat("incorrect method", recordedmethod, is(method));
+			assertThat("invalid call id", recordedid, RegexMatcher.matches("\\d{16}"));
+			assertThat("incorrect ip address", recordedip, is(ip));
+		}
+	}
+	
+	@Test
+	public void ignoreIPHeaders() throws Exception {
+		
+		final SetCallInfoAnswer ans = new SetCallInfoAnswer();
+		doAnswer(ans).when(autologgermock).setCallInfo(
+				any(String.class), any(String.class), any(String.class));
+
+		final URI target = UriBuilder.fromUri(host).path("/").build();
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request();
+		final Response res = req.get();
+
+		assertThat("incorrect status code", res.getStatus(), is(200));
+		ans.check("GET", "127.0.0.1");
+		
+		assertThat("incorrect number of log events", logEvents.size(), is(1));
+		final ILoggingEvent event = logEvents.get(0);
+		assertThat("incorrect log level", event.getLevel(), is(Level.INFO));
+		assertThat("incorrect caller", event.getLoggerName(), is(LoggingFilter.class.getName()));
+		assertThat("incorrect message", event.getFormattedMessage(), is(String.format(
+				"GET %s/ 200 Jersey/2.23.2 (HttpUrlConnection 1.8.0_91)", host)));
+	}
+
+}

--- a/src/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -400,6 +400,10 @@ public class ServiceTestUtils {
 	public static void enableLogin(final String host, final IncomingToken admintoken) {
 		setAdmin(host, admintoken, ImmutableMap.of("allowlogin", true));
 	}
+	
+	public static void ignoreIpHeaders(final String host, final IncomingToken admintoken) {
+		setAdmin(host, admintoken, ImmutableMap.of("ignoreip", true));
+	}
 
 	private static void setAdmin(
 			final String host,
@@ -407,7 +411,7 @@ public class ServiceTestUtils {
 			final Map<String, Object> json) {
 		final Response r = CLI.target(host + "/admin/config").request()
 				.header("authorization", admintoken.getToken())
-				.put(Entity.json(json));
+				.post(Entity.json(json));
 		assertThat("failed to set config", r.getStatus(), is(204));
 	}
 


### PR DESCRIPTION
Now logs the xFF and realIP headers when used to determine the IP address.

Adds tests for the LoggingFilter class, which sets up the log info for the logging implementation provided by the startup config. 