### PR TITLE
TASK-819 Return all identities at /link/choice endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ jdk:
 
 env:
   - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test               WIRED_TIGER=false
-  - MONGODB_VER=mongodb-linux-x86_64-2.6.12 ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.0.14 ANT_TEST=test_mongo_storage WIRED_TIGER=false
   - MONGODB_VER=mongodb-linux-x86_64-3.0.14 ANT_TEST=test_mongo_storage WIRED_TIGER=true
   - MONGODB_VER=mongodb-linux-x86_64-3.2.12 ANT_TEST=test_mongo_storage WIRED_TIGER=false

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,9 @@ Authentication Service MKII release notes
 -----
 
 * Initial release
+
+0.1.1
+-----
+
+* the /link/choice endpoint now returns the linked identities and the account to which they are
+  linked. If all identities are linked an error is not thrown.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+Authentication Service MKII release notes
+=========================================
+
+0.1.0
+-----
+
+* Initial release

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ accounts and tests if any, allow setting auth service url
 
 Auth service work
 -----------------
-* Complete UI
+* Complete rich UI (code not in this repo)
   * Currently only covers login, link, me, and tokens.
 * TODOs in the codebase
 * Read through all remaining prototype code and convert to production worthy

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -2031,9 +2031,7 @@ public class Authentication {
 		if (authcode == null || authcode.trim().isEmpty()) {
 			throw new MissingParameterException("authorization code");
 		}
-		final Set<RemoteIdentity> ris = idp.getIdentities(authcode, true);
-		filterLinkCandidates(ris);
-		return ris;
+		return idp.getIdentities(authcode, true);
 	}
 	
 	/** Continue the local portion of an OAuth2 link flow after redirection from a 3rd party
@@ -2084,6 +2082,8 @@ public class Authentication {
 					u.getUserName().getName());
 		}
 		final Set<RemoteIdentity> ids = getLinkCandidates(idp, authcode);
+		final Set<RemoteIdentity> filtered = new HashSet<>(ids);
+		filterLinkCandidates(filtered);
 		/* Don't throw an error if ids are empty since an auth UI is not controlling the call in
 		 * some cases - this call is almost certainly the result of a redirect from a 3rd party
 		 * provider. Any controllable error should be thrown when the process flow is back
@@ -2091,8 +2091,8 @@ public class Authentication {
 		 */
 		final LinkToken lt;
 		final ProviderConfig pc = cfg.getAppConfig().getProviderConfig(idp.getProviderName());
-		if (ids.size() == 1 && !pc.isForceLinkChoice()) {
-			lt = getLinkToken(idp, u.getUserName(), ids.iterator().next());
+		if (filtered.size() == 1 && !pc.isForceLinkChoice()) {
+			lt = getLinkToken(idp, u.getUserName(), filtered.iterator().next(), ids);
 		} else { // will store an ID set if said set is empty.
 			final TemporaryToken tt = storeIdentitiesTemporarily(ids, LINK_TOKEN_LIFETIME_MS);
 			logInfo("Stored temporary token {} with {} link identities", tt.getId(), ids.size());
@@ -2106,7 +2106,8 @@ public class Authentication {
 	private LinkToken getLinkToken(
 			final IdentityProvider idp,
 			final UserName userName,
-			final RemoteIdentity remoteIdentity)
+			final RemoteIdentity remoteIdentity,
+			final Set<RemoteIdentity> allIds)
 			throws AuthStorageException, LinkFailedException {
 		try {
 			final boolean linked = storage.link(userName, remoteIdentity);
@@ -2117,11 +2118,12 @@ public class Authentication {
 					"User unexpectedly disappeared from the database", e);
 		} catch (IdentityLinkedException e) {
 			// well, crap. race condition and now there are no link candidates left.
-			final TemporaryToken tt = storeIdentitiesTemporarily(Collections.emptySet(),
-					LINK_TOKEN_LIFETIME_MS);
+			final TemporaryToken tt = storeIdentitiesTemporarily(allIds, LINK_TOKEN_LIFETIME_MS);
 			logInfo("A race condition means that the identity {} is already linked to a user " +
-					"other than {}. Stored empty identity set with temporary token {}",
-					remoteIdentity.getRemoteID().getID(), userName.getName(), tt.getId());
+					"other than {}. Stored identity set with {} linked identities with " +
+					"temporary token {}",
+					remoteIdentity.getRemoteID().getID(), userName.getName(), allIds.size(),
+					tt.getId());
 			return new LinkToken(tt);
 		}
 	}

--- a/src/us/kbase/auth2/lib/LinkIdentities.java
+++ b/src/us/kbase/auth2/lib/LinkIdentities.java
@@ -4,66 +4,76 @@ import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.user.AuthUser;
 
-/** A set of remote identities possessed by a user that may be linked to the user's account.
- * As such, remote identities that are already linked to the user's account should not be included.
+// very similar to login state, but not similar enough to share code easily and maintain a lack
+// of coupling.
+
+/** A set of remote identities possessed by a user that may be linked to the user's account, and,
+ * for informational purposes, remote identities that are already linked to accounts.
  * @author gaprice@lbl.gov
  *
  */
 public class LinkIdentities {
 	
-	private final AuthUser user;
+	private final UserName userName;
 	private final Set<RemoteIdentity> idents;
+	private final Map<UserName, Set<RemoteIdentity>> linked;
 	private final String provider;
 	private final Instant expires;
 
-	/** Create a set of identities that are linkable to a user account.
-	 * @param user the user to which the identities may be linked.
-	 * @param ids the remote identities.
-	 * @param expires the time the identities expire.
-	 */
-	public LinkIdentities(
-			final AuthUser user,
+	private LinkIdentities(
+			final UserName userName,
+			final String provider,
 			final Set<RemoteIdentity> ids,
+			final Map<UserName, Set<RemoteIdentity>> linked,
 			final Instant expires) {
-		nonNull(user, "user");
-		nonNull(expires, "expires");
-		if (ids == null || ids.isEmpty()) {
-			throw new IllegalArgumentException("No remote IDs provided");
-		}
-		Utils.noNulls(ids, "null item in ids");
-		this.user = user;
-		final TreeSet<RemoteIdentity> treeids = new TreeSet<>(
-				LoginState.Builder.REMOTE_IDENTITY_COMPARATOR);
-		treeids.addAll(ids);
-		this.idents = Collections.unmodifiableSet(treeids);
-		this.provider = ids.iterator().next().getRemoteID().getProviderName();
+		this.userName = userName;
+		this.provider = provider;
+		this.idents = Collections.unmodifiableSet(ids);
+		this.linked = Collections.unmodifiableMap(linked);
 		this.expires = expires;
-		for (final RemoteIdentity ri: ids) {
-			if (!provider.equals(ri.getRemoteID().getProviderName())) {
-				throw new IllegalArgumentException(
-						"Only identities from one provider can be included in the set");
-			}
-		}
 	}
 	
-	/** Get the user associated with the remote identities.
+	/** Get the user to which unlinked remote IDs may be added.
 	 * @return the user.
 	 */
-	public AuthUser getUser() {
-		return user;
+	public UserName getUser() {
+		return userName;
 	}
 
-	/** Get the remote identities.
+	/** Get the unlinked remote identities.
 	 * @return the remote identities. May be empty if no linkable identities are available.
 	 */
 	public Set<RemoteIdentity> getIdentities() {
 		return idents;
+	}
+	
+	/** Get the set of users that are associated with linked identities in this set. May include
+	 * the user returned by {@link #getUser()}.
+	 * @return the users that are linked to a remote identity in this set of identities.
+	 */
+	public Set<UserName> getLinkedUsers() {
+		return linked.keySet();
+	}
+	
+	/** Get the remote identities that are already linked to a user account.
+	 * @param userName the user for which identities will be retrieved.
+	 * @return the linked remote identities.
+	 */
+	public Set<RemoteIdentity> getLinkedIdentities(final UserName userName) {
+		nonNull(userName, "userName");
+		if (!linked.containsKey(userName)) {
+			throw new IllegalArgumentException("No such user: " + userName.getName());
+		}
+		return Collections.unmodifiableSet(linked.get(userName));
 	}
 	
 	/** Get the provider of the identities.
@@ -86,8 +96,9 @@ public class LinkIdentities {
 		int result = 1;
 		result = prime * result + ((expires == null) ? 0 : expires.hashCode());
 		result = prime * result + ((idents == null) ? 0 : idents.hashCode());
+		result = prime * result + ((linked == null) ? 0 : linked.hashCode());
 		result = prime * result + ((provider == null) ? 0 : provider.hashCode());
-		result = prime * result + ((user == null) ? 0 : user.hashCode());
+		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
 		return result;
 	}
 
@@ -117,6 +128,13 @@ public class LinkIdentities {
 		} else if (!idents.equals(other.idents)) {
 			return false;
 		}
+		if (linked == null) {
+			if (other.linked != null) {
+				return false;
+			}
+		} else if (!linked.equals(other.linked)) {
+			return false;
+		}
 		if (provider == null) {
 			if (other.provider != null) {
 				return false;
@@ -124,13 +142,106 @@ public class LinkIdentities {
 		} else if (!provider.equals(other.provider)) {
 			return false;
 		}
-		if (user == null) {
-			if (other.user != null) {
+		if (userName == null) {
+			if (other.userName != null) {
 				return false;
 			}
-		} else if (!user.equals(other.user)) {
+		} else if (!userName.equals(other.userName)) {
 			return false;
 		}
 		return true;
+	}
+	
+	/** Create a LinkIdentities builder.
+	 * @param userName the name of the user that was logged in when retrieving the identities.
+	 * @param provider the name of the identity provider that provided the identities for this
+	 * login attempt.
+	 * @param expires the date the identities expire.
+	 * @return the builder.
+	 */
+	public static Builder getBuilder(
+			final UserName userName,
+			final String provider,
+			final Instant expires) {
+		return new Builder(userName, provider, expires);
+	}
+	
+	/** A builder for a LinkIdentites instance.
+	 * @author gaprice@lbl.gov
+	 *
+	 */
+	public static class Builder {
+		
+		static final Comparator<RemoteIdentity> REMOTE_IDENTITY_COMPARATOR =
+				LoginState.Builder.REMOTE_IDENTITY_COMPARATOR;
+
+		private final UserName userName;
+		private final Set<RemoteIdentity> idents = new TreeSet<>(REMOTE_IDENTITY_COMPARATOR);
+		private final Map<UserName, Set<RemoteIdentity>> linked = new TreeMap<>();
+		private final String provider;
+		private final Instant expires;
+		
+		private Builder(
+				final UserName userName,
+				final String provider,
+				final Instant expires) {
+			if (provider == null || provider.trim().isEmpty()) {
+				throw new IllegalArgumentException("provider cannot be null or empty");
+			}
+			nonNull(userName, "userName");
+			nonNull(expires, "expires");
+			this.provider = provider;
+			this.expires = expires;
+			this.userName = userName;
+		}
+		
+		/** Add a remote identity that is not associated with a user account.
+		 * @param remoteID the remote identity to add.
+		 * @return this builder.
+		 */
+		public Builder withIdentity(final RemoteIdentity remoteID) {
+			// should probably check that the identity doesn't already exist in either of the
+			// maps... but eh for now
+			nonNull(remoteID, "remoteID");
+			checkProvider(remoteID);
+			idents.add(remoteID);
+			return this;
+		}
+
+		private void checkProvider(final RemoteIdentity remoteID) {
+			if (!provider.equals(remoteID.getRemoteID().getProviderName())) {
+				throw new IllegalStateException(
+						"Cannot have multiple providers in the same login state");
+			}
+		}
+
+		/** Add a user account to which the user has access based on a 3rd party identity.
+		 * @param user the user account.
+		 * @param remoteID the 3rd party identity that grants the user access to the user account.
+		 * @return this builder.
+		 */
+		public Builder withUser(final AuthUser user, final RemoteIdentity remoteID) {
+			// should probably check that the identity doesn't already exist in either of the
+			// maps... but eh for now
+			nonNull(user, "user");
+			nonNull(remoteID, "remoteID");
+			checkProvider(remoteID);
+			if (user.getIdentity(remoteID) == null) {
+				throw new IllegalArgumentException("user does not contain remote ID");
+			}
+			final UserName name = user.getUserName();
+			if (!linked.containsKey(name)) {
+				linked.put(name, new TreeSet<>(REMOTE_IDENTITY_COMPARATOR));
+			}
+			linked.get(name).add(remoteID);
+			return this;
+		}
+
+		/** Build a new LinkIdentities instance.
+		 * @return the new instance.
+		 */
+		public LinkIdentities build() {
+			return new LinkIdentities(userName, provider, idents, linked, expires);
+		}
 	}
 }

--- a/src/us/kbase/auth2/lib/exceptions/ErrorType.java
+++ b/src/us/kbase/auth2/lib/exceptions/ErrorType.java
@@ -56,7 +56,7 @@ public enum ErrorType {
 	NO_SUCH_ROLE			(50040, "No such role"),
 	/** The attempt to link one account to another failed. */
 	LINK_FAILED				(60000, "Account linkage failed"),
-	/** The attemp to unlink one account from another failed. */
+	/** The attempt to unlink one account from another failed. */
 	UNLINK_FAILED			(60010, "Account unlink failed"),
 	/** The requested operation is not supported. */
 	UNSUPPORTED_OP			(70000, "Unsupported operation");

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -47,6 +47,10 @@ public class Fields {
 	
 	/** Whether unlinking a remote identity from an account is allowed. */
 	public static final String UNLINK = "unlink";
+	/** Identities that are already linked to an account. */
+	public static final String LINKED = "linked";
+	/** Whether identities are available for linking to an account. */
+	public static final String HAS_LINKS = "haslinks";
 	
 	/* login and linking */
 	

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -24,7 +24,7 @@ public class Root {
 	
 	//TODO JAVADOC or swagger
 	
-	private static final String VERSION = "0.1.0";
+	private static final String VERSION = "0.1.1";
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
@@ -237,16 +237,26 @@ public class AuthenticationLinkTest {
 		
 		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
-				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
+				new RemoteIdentityDetails("user2", "full2", "f2@g.com")),
+				new RemoteIdentity(
+						new RemoteIdentityID("Prov", "id3"),
+						new RemoteIdentityDetails("user3", "full3", "f3@g.com"))))
 				.thenReturn(null);
 
-		final RemoteIdentity storageRemoteID = new RemoteIdentity(
+		final RemoteIdentity storageRemoteID2 = new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"));
 		
-		when(storage.getUser(storageRemoteID)).thenReturn(Optional.absent()).thenReturn(null);
+		final RemoteIdentity storageRemoteID3 = new RemoteIdentity(
+				new RemoteIdentityID("Prov", "id3"),
+				new RemoteIdentityDetails("user3", "full3", "f3@g.com"));
 		
-		when(storage.link(new UserName("baz"), storageRemoteID))
+		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.absent()).thenReturn(null);
+		when(storage.getUser(storageRemoteID3)).thenReturn(Optional.of(AuthUser.getBuilder(
+				new UserName("whee"), new DisplayName("arg"), Instant.now())
+				.withIdentity(storageRemoteID3).build())).thenReturn(null);
+		
+		when(storage.link(new UserName("baz"), storageRemoteID2))
 				.thenThrow(new IdentityLinkedException("foo"));
 		
 		final UUID tokenID = UUID.randomUUID();
@@ -262,12 +272,12 @@ public class AuthenticationLinkTest {
 		verify(storage).storeIdentitiesTemporarily(new TemporaryToken(
 				tokenID, "sometoken", Instant.ofEpochMilli(10000), 10 * 60 * 1000)
 						.getHashedToken(),
-				Collections.emptySet());
+				set(storageRemoteID2, storageRemoteID3));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO, String.format(
 				"A race condition means that the identity fda04183ab36b12041695c2f78f07713 " +
-				"is already linked to a user other than baz. Stored empty identity set with " +
-				"temporary token %s", tokenID), Authentication.class));
+				"is already linked to a user other than baz. Stored identity set with 2 linked " +
+				"identities with temporary token %s", tokenID), Authentication.class));
 	}
 	
 	@Test
@@ -337,7 +347,7 @@ public class AuthenticationLinkTest {
 	}
 	
 	@Test
-	public void linkWithTokenNoIDsDueToFilter() throws Exception {
+	public void linkWithTokenNoAvailableIDsDueToFilter() throws Exception {
 		final IdentityProvider idp = mock(IdentityProvider.class);
 
 		when(idp.getProviderName()).thenReturn("prov");
@@ -395,12 +405,12 @@ public class AuthenticationLinkTest {
 		verify(storage).storeIdentitiesTemporarily(new TemporaryToken(
 				tokenID, "sometoken", Instant.ofEpochMilli(10000), 10 * 60 * 1000)
 						.getHashedToken(),
-				Collections.emptySet());
+				set(storageRemoteID));
 		
 		verify(storage, never()).link(any(), any());
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO, String.format(
-				"Stored temporary token %s with 0 link identities", tokenID),
+				"Stored temporary token %s with 1 link identities", tokenID),
 				Authentication.class));
 	}
 	
@@ -477,12 +487,12 @@ public class AuthenticationLinkTest {
 		verify(storage).storeIdentitiesTemporarily(new TemporaryToken(
 				tokenID, "sometoken", Instant.ofEpochMilli(10000), 10 * 60 * 1000)
 						.getHashedToken(),
-				set(storageRemoteID3, storageRemoteID4));
+				set(storageRemoteID2, storageRemoteID3, storageRemoteID4));
 		
 		verify(storage, never()).link(any(), any());
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO, String.format(
-				"Stored temporary token %s with 2 link identities", tokenID),
+				"Stored temporary token %s with 3 link identities", tokenID),
 				Authentication.class));
 	}
 	
@@ -916,14 +926,6 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityID("prov", "id4"),
 				new RemoteIdentityDetails("user4", "full4", "f4@g.com"));
 		
-		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now()).build()))
-				.thenReturn(null);
-		when(storage.getUser(storageRemoteID3)).thenReturn(Optional.absent())
-				.thenReturn(null);
-		when(storage.getUser(storageRemoteID4)).thenReturn(Optional.absent())
-				.thenReturn(null);
-		
 		final UUID tokenID = UUID.randomUUID();
 		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
 		when(rand.getToken()).thenReturn("sometoken").thenReturn(null);
@@ -937,10 +939,10 @@ public class AuthenticationLinkTest {
 		verify(storage).storeIdentitiesTemporarily(new TemporaryToken(
 				tokenID, "sometoken", Instant.ofEpochMilli(10000), 10 * 60 * 1000)
 						.getHashedToken(),
-				set(storageRemoteID3, storageRemoteID4));
+				set(storageRemoteID2, storageRemoteID3, storageRemoteID4));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO, String.format(
-				"Stored temporary token %s with 2 link identities", tokenID),
+				"Stored temporary token %s with 3 link identities", tokenID),
 				Authentication.class));
 	}
 	

--- a/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
@@ -7,14 +7,9 @@ import static us.kbase.test.auth2.TestCommon.set;
 
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
 
 import org.junit.Test;
-
-import com.google.common.base.Optional;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import us.kbase.auth2.lib.DisplayName;
@@ -30,12 +25,16 @@ import us.kbase.test.auth2.TestCommon;
 public class LinkIdentitiesTest {
 	
 	private final static RemoteIdentity REMOTE1 = new RemoteIdentity(
-			new RemoteIdentityID("foo", "bar"),
+			new RemoteIdentityID("prov", "bar"),
 			new RemoteIdentityDetails("user", "full", "email"));
 	
 	private final static RemoteIdentity REMOTE2 = new RemoteIdentity(
-			new RemoteIdentityID("foo1", "bar1"),
+			new RemoteIdentityID("prov", "bar1"),
 			new RemoteIdentityDetails("user1", "full1", "email1"));
+	
+	private static final RemoteIdentity REMOTE3 = new RemoteIdentity(
+			new RemoteIdentityID("prov", "bar3"),
+			new RemoteIdentityDetails("user3", "full3", "email3"));
 			
 	private final static AuthUser AUTH_USER;
 	static {
@@ -55,101 +54,268 @@ public class LinkIdentitiesTest {
 	}
 	
 	@Test
-	public void constructWithIDsSuccess() throws Exception {
-		final Set<RemoteIdentity> ids = new HashSet<>();
-		ids.add(REMOTE2);
+	public void buildMinimal() throws Exception {
+		final LinkIdentities li = LinkIdentities.getBuilder(
+				new UserName("foo"), "prov", Instant.ofEpochMilli(10000)).build();
 		
-		final LinkIdentities li = new LinkIdentities(AUTH_USER, ids, Instant.ofEpochMilli(10000));
-		
-		//check the user is correct
-		assertThat("incorrect username", li.getUser().getUserName(), is(new UserName("foo")));
-		assertThat("incorrect email", li.getUser().getEmail(), is(new EmailAddress("f@g.com")));
-		assertThat("incorrect displayname", li.getUser().getDisplayName(),
-				is(new DisplayName("bar")));
-		assertThat("incorrect user id number", li.getUser().getIdentities().size(), is(1));
-		assertThat("incorrect user identity", li.getUser().getIdentities().iterator().next(), is(
-				new RemoteIdentity(
-						new RemoteIdentityID("foo", "bar"),
-						new RemoteIdentityDetails("user", "full", "email"))));
-		assertThat("incorrect creation date", li.getUser().getCreated(),
-				is(AUTH_USER.getCreated()));
-		assertThat("incorrect login date", li.getUser().getLastLogin(), is(Optional.absent()));
-		
-		// check provider is correct
-		assertThat("incorrect provider", li.getProvider(), is("foo1"));
-		
-		// check expires is correct
-		assertThat("incorrect expires", li.getExpires(),
-				is(Instant.ofEpochMilli(10000)));
-		
-		//check the identity is correct
-		assertThat("incorrect identity number", li.getIdentities().size(), is(1));
-		assertThat("incorrect identity", li.getIdentities().iterator().next(), is(
-				new RemoteIdentity(
-						new RemoteIdentityID("foo1", "bar1"),
-						new RemoteIdentityDetails("user1", "full1", "email1"))));
+		assertThat("incorrect username", li.getUser(), is(new UserName("foo")));
+		assertThat("incorrect provider", li.getProvider(), is("prov"));
+		assertThat("incorrect expires", li.getExpires(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect indets", li.getIdentities(), is(set()));
+		assertThat("incorrect linked users", li.getLinkedUsers(), is(set()));
 	}
 	
 	@Test
-	public void identitesAreUnmodifiable() throws Exception {
-		final Set<RemoteIdentity> ids = new HashSet<>();
-		ids.add(REMOTE2);
-		
-		final LinkIdentities li = new LinkIdentities(AUTH_USER, ids, Instant.now());
-		assertThat("incorrect ids size", li.getIdentities().size(), is(1));
-		try {
-			li.getIdentities().add(REMOTE1);
-			fail("mutable identities");
-		} catch (Exception e) {
-			TestCommon.assertExceptionCorrect(e, new UnsupportedOperationException());
-		}
-		assertThat("incorrect ids size", li.getIdentities().size(), is(1));
+	public void nullsAndEmpties() throws Exception {
+		final Instant i = Instant.ofEpochMilli(10000);
+		final UserName u = new UserName("foo");
+		failBuildStart(null, "p", i, new NullPointerException("userName"));
+		failBuildStart(u, null, i, new IllegalArgumentException(
+				"provider cannot be null or empty"));
+		failBuildStart(u, "    \t    ", i, new IllegalArgumentException(
+				"provider cannot be null or empty"));
+		failBuildStart(u, "p", null, new NullPointerException("expires"));
 	}
 	
-	@Test
-	public void constructFail() throws Exception {
-		failConstruct(null, new HashSet<>(Arrays.asList(REMOTE1)), Instant.now(),
-				new NullPointerException("user"));
-		failConstruct(AUTH_USER, (Set<RemoteIdentity>) null, Instant.now(),
-				new IllegalArgumentException("No remote IDs provided"));
-		failConstruct(AUTH_USER, new HashSet<>(), Instant.now(),
-				new IllegalArgumentException("No remote IDs provided"));
-		failConstruct(AUTH_USER, TestCommon.set(REMOTE1, null), Instant.now(),
-				new NullPointerException("null item in ids"));
-		failConstruct(AUTH_USER, TestCommon.set(REMOTE1, REMOTE2), Instant.now(),
-				new IllegalArgumentException(
-						"Only identities from one provider can be included in the set"));
-		failConstruct(AUTH_USER, new HashSet<>(Arrays.asList(REMOTE1)), null,
-				new NullPointerException("expires"));
-	}
-	
-	private void failConstruct(
-			final AuthUser au,
-			final Set<RemoteIdentity> ids,
+	private void failBuildStart(
+			final UserName userName,
+			final String provider,
 			final Instant expires,
 			final Exception e) {
 		try {
-			new LinkIdentities(au, ids, expires);
-			fail("created bad LinkIdentities");
+			LinkIdentities.getBuilder(userName, provider, expires);
+			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);
 		}
 	}
 	
 	@Test
-	public void sortedIDs() throws Exception {
-		final RemoteIdentity ri1 = new RemoteIdentity( // 7c82320ccb87106b9e7a7aaab6cf0ac4
-				new RemoteIdentityID("foo1", "bar1"),
-				new RemoteIdentityDetails("user1", "full1", "email1"));
-		final RemoteIdentity ri2 = new RemoteIdentity( // 58341bf1fbb4626c29faf54a5fa47370
-				new RemoteIdentityID("foo1", "bar2"),
-				new RemoteIdentityDetails("user1", "full1", "email1"));
-		final RemoteIdentity ri3 = new RemoteIdentity( // 075ee8906acaf44619eb4d36934f6064
-				new RemoteIdentityID("foo1", "bar3"),
-				new RemoteIdentityDetails("user1", "full1", "email1"));
+	public void buildWithIdentities() throws Exception {
+		final LinkIdentities li = LinkIdentities.getBuilder(
+				new UserName("whee"), "prov", Instant.ofEpochMilli(10000))
+				.withIdentity(REMOTE1).withIdentity(REMOTE2).build();
 		
-		final List<RemoteIdentity> linkIdentities = new LinkedList<>(
-				new LinkIdentities(AUTH_USER, set(ri1, ri2, ri3), Instant.now()).getIdentities());
-		assertThat("sort failed", linkIdentities, is(Arrays.asList(ri3, ri2, ri1)));
+		assertThat("incorrect username", li.getUser(), is(new UserName("whee")));
+		assertThat("incorrect provider", li.getProvider(), is("prov"));
+		assertThat("incorrect expires", li.getExpires(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect indets", li.getIdentities(), is(set(REMOTE1, REMOTE2)));
+		assertThat("incorrect linked users", li.getLinkedUsers(), is(set()));
+	}
+	
+	@Test
+	public void addIdentityFail() throws Exception {
+		final UserName u = new UserName("foo");
+		failAddIdentity(LinkIdentities.getBuilder(u, "prov", Instant.now()), null,
+				new NullPointerException("remoteID"));
+		
+		failAddIdentity(LinkIdentities.getBuilder(u, "prov1", Instant.now()), REMOTE1,
+				new IllegalStateException(
+						"Cannot have multiple providers in the same login state"));
+	}
+
+	private void failAddIdentity(
+			final LinkIdentities.Builder b,
+			final RemoteIdentity ri, 
+			final Exception e) {
+		try {
+			b.withIdentity(ri);
+			fail("excpected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void buildWithUsers() throws Exception {
+		final RemoteIdentity ri1 = new RemoteIdentity(
+				new RemoteIdentityID("prov", "id1"),
+				new RemoteIdentityDetails("u1", "f1", "f1@g.com"));
+		final RemoteIdentity ri2 = new RemoteIdentity(
+				new RemoteIdentityID("prov", "id2"),
+				new RemoteIdentityDetails("u2", "f2", "f2@g.com"));
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("bar"), new DisplayName("d"), Instant.now())
+				.withIdentity(ri1)
+				.withIdentity(ri2)
+				.build();
+		final LinkIdentities li = LinkIdentities.getBuilder(
+				new UserName("whee"), "prov", Instant.ofEpochMilli(10000))
+				.withUser(AUTH_USER, REMOTE1)
+				.withUser(u, ri1)
+				.withUser(u, ri2)
+				.build();
+		
+		assertThat("incorrect username", li.getUser(), is(new UserName("whee")));
+		assertThat("incorrect provider", li.getProvider(), is("prov"));
+		assertThat("incorrect expires", li.getExpires(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect indets", li.getIdentities(), is(set()));
+		assertThat("incorrect linked users", li.getLinkedUsers(),
+				is(set(new UserName("bar"), new UserName("foo"))));
+		assertThat("incorrect idents", li.getLinkedIdentities(new UserName("foo")),
+				is(set(REMOTE1)));
+		assertThat("incorrect idents", li.getLinkedIdentities(new UserName("bar")),
+				is(set(ri1, ri2)));
+	}
+	
+	@Test
+	public void addUserFail() throws Exception {
+		final UserName u = new UserName("foo");
+		failAddUser(LinkIdentities.getBuilder(u, "prov", Instant.now()), null, REMOTE1,
+				new NullPointerException("user"));
+		
+		failAddUser(LinkIdentities.getBuilder(u, "prov", Instant.now()), AUTH_USER, null,
+				new NullPointerException("remoteID"));
+		
+		failAddUser(LinkIdentities.getBuilder(u, "prov1", Instant.now()), AUTH_USER, REMOTE1,
+				new IllegalStateException(
+						"Cannot have multiple providers in the same login state"));
+		
+		failAddUser(LinkIdentities.getBuilder(u, "prov", Instant.now()), AUTH_USER, REMOTE2,
+				new IllegalArgumentException("user does not contain remote ID"));
+	}
+	
+	private void failAddUser(
+			final LinkIdentities.Builder b,
+			final AuthUser u,
+			final RemoteIdentity ri,
+			final Exception e) {
+		try {
+			b.withUser(u, ri);
+			fail("excpected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void buildWithIdentitiesAndUsers() throws Exception {
+		final RemoteIdentity ri1 = new RemoteIdentity(
+				new RemoteIdentityID("prov", "id1"),
+				new RemoteIdentityDetails("u1", "f1", "f1@g.com"));
+		final RemoteIdentity ri2 = new RemoteIdentity(
+				new RemoteIdentityID("prov", "id2"),
+				new RemoteIdentityDetails("u2", "f2", "f2@g.com"));
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("bar"), new DisplayName("d"), Instant.now())
+				.withIdentity(ri1)
+				.withIdentity(ri2)
+				.build();
+		final LinkIdentities li = LinkIdentities.getBuilder(
+				new UserName("whee"), "prov", Instant.ofEpochMilli(10000))
+				.withUser(AUTH_USER, REMOTE1)
+				.withUser(u, ri1)
+				.withUser(u, ri2)
+				.withIdentity(REMOTE2)
+				.build();
+		
+		assertThat("incorrect username", li.getUser(), is(new UserName("whee")));
+		assertThat("incorrect provider", li.getProvider(), is("prov"));
+		assertThat("incorrect expires", li.getExpires(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect indets", li.getIdentities(), is(set(REMOTE2)));
+		assertThat("incorrect linked users", li.getLinkedUsers(),
+				is(set(new UserName("bar"), new UserName("foo"))));
+		assertThat("incorrect idents", li.getLinkedIdentities(new UserName("foo")),
+				is(set(REMOTE1)));
+		assertThat("incorrect idents", li.getLinkedIdentities(new UserName("bar")),
+				is(set(ri1, ri2)));
+	}
+	
+	@Test
+	public void sortedUserNames() throws Exception {
+		final DisplayName dn = new DisplayName("d");
+		final Instant now = Instant.now();
+		final LinkIdentities ls = LinkIdentities.getBuilder(
+				new UserName("fake"), "prov", Instant.now())
+				.withUser(AuthUser.getBuilder(new UserName("foo"), dn, now)
+						.withIdentity(REMOTE1).build(), REMOTE1)
+				.withUser(AuthUser.getBuilder(new UserName("bar"), dn, now)
+						.withIdentity(REMOTE2).build(), REMOTE2)
+				.withUser(AuthUser.getBuilder(new UserName("baz"), dn, now)
+						.withIdentity(REMOTE3).build(), REMOTE3)
+				.build();
+		
+		assertThat("user names aren't sorted", new LinkedList<>(ls.getLinkedUsers()),
+				is(Arrays.asList(new UserName("bar"), new UserName("baz"), new UserName("foo"))));
+	}
+	
+	@Test
+	public void sortedUnlinkedIdentities() throws Exception {
+		final LinkIdentities ls = LinkIdentities.getBuilder(
+				new UserName("fake"), "prov", Instant.now())
+				.withIdentity(REMOTE3) // id is b5bc5fbd0e014aedb8541109a6536eca
+				.withIdentity(REMOTE1) // id is 225fa1634408e1c55c984bd8b199587e
+				.withIdentity(REMOTE2) // id is 589bebde3cf9c926f88420769025677b
+				.build();
+		assertThat("idents aren't sorted", new LinkedList<>(ls.getIdentities()),
+				is(Arrays.asList(REMOTE1, REMOTE2, REMOTE3)));
+	}
+	
+	@Test
+	public void sortedLinkedIdentities() throws Exception {
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("foo"), new DisplayName("dn"), Instant.now())
+				.withIdentity(REMOTE3)
+				.withIdentity(REMOTE1)
+				.withIdentity(REMOTE2)
+				.build();
+		
+		final LinkIdentities ls = LinkIdentities.getBuilder(
+				new UserName("fake"), "prov", Instant.now())
+				.withUser(u, REMOTE3) // id is b5bc5fbd0e014aedb8541109a6536eca
+				.withUser(u, REMOTE1) // id is 225fa1634408e1c55c984bd8b199587e
+				.withUser(u, REMOTE2) // id is 589bebde3cf9c926f88420769025677b
+				.build();
+		assertThat("user idents aren't sorted",
+				new LinkedList<>(ls.getLinkedIdentities(new UserName("foo"))),
+						is(Arrays.asList(REMOTE1, REMOTE2, REMOTE3)));
+	}
+	
+	@Test
+	public void unmodifiable() throws Exception {
+		final LinkIdentities ls = LinkIdentities.getBuilder(
+				new UserName("fake"), "prov", Instant.now())
+				.withUser(AUTH_USER, REMOTE1).withIdentity(REMOTE2).build();
+		
+		try {
+			ls.getIdentities().add(REMOTE2);
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			// test passes
+		}
+		
+		try {
+			ls.getLinkedUsers().add(new UserName("whee"));
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			// test passes
+		}
+		
+		try {
+			ls.getLinkedIdentities(new UserName("foo")).add(REMOTE2);
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			// test passes
+		}
+	}
+	
+	@Test
+	public void noSuchUser() throws Exception {
+		final LinkIdentities ls = LinkIdentities.getBuilder(
+				new UserName("fake"), "prov", Instant.now())
+				.withUser(AUTH_USER, REMOTE1).withIdentity(REMOTE3).build();
+		
+		try {
+			ls.getLinkedIdentities(null);
+			fail("expected exception");
+		} catch (NullPointerException e) {
+			assertThat("correct exception message", e.getMessage(), is("userName"));
+		}
+		try {
+			ls.getLinkedIdentities(new UserName("foo4"));
+			fail("expected exception");
+		} catch (IllegalArgumentException e) {
+			assertThat("correct exception message", e.getMessage(), is("No such user: foo4"));
+		}
 	}
 }

--- a/src/us/kbase/test/auth2/service/ui/LinkTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest.java
@@ -464,7 +464,8 @@ public class LinkTest {
 		final TemporaryIdentities tis = manager.storage.getTemporaryIdentities(
 				new IncomingToken(token).getHashedToken());
 		
-		assertThat("incorrect remote ids", tis.getIdentities().get(), is(set(REMOTE2, REMOTE3)));
+		assertThat("incorrect remote ids", tis.getIdentities().get(),
+				is(set(REMOTE1, REMOTE2, REMOTE3)));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/service/ui/LinkTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest.java
@@ -20,7 +20,9 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.ws.rs.client.Client;
@@ -621,21 +623,39 @@ public class LinkTest {
 	
 	@Test
 	public void linkChoiceHTML() throws Exception {
-		linkChoiceHTML("/link/choice", TestCommon.getTestExpectedData(getClass(),
+		linkChoiceHTML("/link/choice", set(REMOTE1, REMOTE2, REMOTE3),
+				TestCommon.getTestExpectedData(getClass(),
+				TestCommon.getCurrentMethodName()));
+	}
+	
+	@Test
+	public void linkChoiceHTMLNoLinks() throws Exception {
+		linkChoiceHTML("/link/choice", set(REMOTE1),
+				TestCommon.getTestExpectedData(getClass(),
+				TestCommon.getCurrentMethodName()));
+	}
+	
+	@Test
+	public void linkChoiceHTMLOnlyLinks() throws Exception {
+		linkChoiceHTML("/link/choice", set(REMOTE2, REMOTE3),
+				TestCommon.getTestExpectedData(getClass(),
 				TestCommon.getCurrentMethodName()));
 	}
 	
 	@Test
 	public void linkChoiceHTMLTrailingSlash() throws Exception {
-		linkChoiceHTML("/link/choice/", TestCommon.getTestExpectedData(getClass(),
+		linkChoiceHTML("/link/choice/", set(REMOTE1, REMOTE2, REMOTE3),
+				TestCommon.getTestExpectedData(getClass(),
 				TestCommon.getCurrentMethodName()));
 	}
 
-	private void linkChoiceHTML(final String path, final String expected) throws Exception {
+	private void linkChoiceHTML(
+			final String path,
+			final Set<RemoteIdentity> storedIDs,
+			final String expected) throws Exception {
 		final TemporaryToken tt = new TemporaryToken(UUID.randomUUID(), "this is a token",
 				Instant.ofEpochMilli(1493000000000L), 10000000000000L);
-		manager.storage.storeIdentitiesTemporarily(tt.getHashedToken(),
-				set(REMOTE1, REMOTE2, REMOTE3));
+		manager.storage.storeIdentitiesTemporarily(tt.getHashedToken(), storedIDs);
 		
 		final NewToken nt = setUpLinkUserAndToken(); // uses REMOTE1
 		
@@ -657,19 +677,73 @@ public class LinkTest {
 	
 	@Test
 	public void linkChoiceJSON() throws Exception {
-		linkChoiceJSON("/link/choice", "");
+		linkChoiceJSON("/link/choice", "",
+				set(REMOTE1, REMOTE2, REMOTE3),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user2",
+								"id", "5fbea2e6ce3d02f7cdbde0bc31be8059"),
+						ImmutableMap.of("provusername", "user3",
+								"id", "de0702aa7927b562e0d6be5b6527cfb2")
+						),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user1",
+								"id", "ef0518c79af70ed979907969c6d0a0f7",
+								"user", "u1")
+						));
+	}
+	
+	@Test
+	public void linkChoiceJSONNoLinks() throws Exception {
+		linkChoiceJSON("/link/choice", "",
+				set(REMOTE1),
+				Collections.emptyList(),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user1",
+								"id", "ef0518c79af70ed979907969c6d0a0f7",
+								"user", "u1")
+						));
+	}
+	
+	@Test
+	public void linkChoiceJSONOnlyLinks() throws Exception {
+		linkChoiceJSON("/link/choice", "",
+				set(REMOTE2, REMOTE3),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user2",
+								"id", "5fbea2e6ce3d02f7cdbde0bc31be8059"),
+						ImmutableMap.of("provusername", "user3",
+								"id", "de0702aa7927b562e0d6be5b6527cfb2")
+						),
+				Collections.emptyList());
 	}
 	
 	@Test
 	public void linkChoiceJSONTrailingSlash() throws Exception {
-		linkChoiceJSON("/link/choice/", "../");
+		linkChoiceJSON("/link/choice/", "../",
+				set(REMOTE1, REMOTE2, REMOTE3),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user2",
+								"id", "5fbea2e6ce3d02f7cdbde0bc31be8059"),
+						ImmutableMap.of("provusername", "user3",
+								"id", "de0702aa7927b562e0d6be5b6527cfb2")
+						),
+				Arrays.asList(
+						ImmutableMap.of("provusername", "user1",
+								"id", "ef0518c79af70ed979907969c6d0a0f7",
+								"user", "u1")
+						));
 	}
 	
-	private void linkChoiceJSON(final String path, final String urlprefix) throws Exception {
+	private void linkChoiceJSON(
+			final String path,
+			final String urlprefix,
+			final Set<RemoteIdentity> storedIDs,
+			final List<Map<String, String>> idents,
+			final List<Map<String, String>> linked)
+			throws Exception {
 		final TemporaryToken tt = new TemporaryToken(UUID.randomUUID(), "this is a token",
 				Instant.ofEpochMilli(1493000000000L), 10000000000000L);
-		manager.storage.storeIdentitiesTemporarily(tt.getHashedToken(),
-				set(REMOTE1, REMOTE2, REMOTE3));
+		manager.storage.storeIdentitiesTemporarily(tt.getHashedToken(), storedIDs);
 		
 		final NewToken nt = setUpLinkUserAndToken(); // uses REMOTE1
 		
@@ -688,20 +762,15 @@ public class LinkTest {
 		@SuppressWarnings("unchecked")
 		final Map<String, Object> json = res.readEntity(Map.class);
 		
-		System.out.println(json);
-		
 		final Map<String, Object> expectedJson = new HashMap<>();
 		expectedJson.put("pickurl", urlprefix + "pick");
 		expectedJson.put("cancelurl", urlprefix + "cancel");
 		expectedJson.put("expires", 11493000000000L);
 		expectedJson.put("provider", "prov");
 		expectedJson.put("user", "u1");
-		expectedJson.put("idents", Arrays.asList(
-				ImmutableMap.of("provusername", "user2",
-						"id", "5fbea2e6ce3d02f7cdbde0bc31be8059"),
-				ImmutableMap.of("provusername", "user3",
-						"id", "de0702aa7927b562e0d6be5b6527cfb2")
-				));
+		expectedJson.put("haslinks", !idents.isEmpty());
+		expectedJson.put("idents", idents);
+		expectedJson.put("linked", linked);
 		
 		ServiceTestUtils.assertObjectsEqual(json, expectedJson);
 	}

--- a/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTML.testdata
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTML.testdata
@@ -30,5 +30,9 @@ Provider username: user3<br/>
 </form>
 </p>
 
+<h2>Already linked identities:</h2>
+
+Username: u1<br/>
+Provider username: user1<br/>
 </html>
 </body>

--- a/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTMLNoLinks.testdata
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTMLNoLinks.testdata
@@ -1,0 +1,21 @@
+<html>
+<body>
+<p>Note that in a proper UI, the provider and username should be HTML-escaped.</p>
+
+Choices expire: 11493000000000<br/>
+
+<form action="cancel" method="post">
+	<input type="submit" value="Cancel account linking"/>
+</form>
+
+<h2>Link prov account</h2>
+
+<p>Link one of the following provider accounts to your <strong>u1</strong>
+account:</p>
+
+<h2>Already linked identities:</h2>
+
+Username: u1<br/>
+Provider username: user1<br/>
+</html>
+</body>

--- a/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTMLOnlyLinks.testdata
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest_linkChoiceHTMLOnlyLinks.testdata
@@ -4,7 +4,7 @@
 
 Choices expire: 11493000000000<br/>
 
-<form action="../cancel" method="post">
+<form action="cancel" method="post">
 	<input type="submit" value="Cancel account linking"/>
 </form>
 
@@ -14,25 +14,23 @@ Choices expire: 11493000000000<br/>
 account:</p>
 
 Provider username: user2<br/>
-<form action="../pick" method="post">
+<form action="pick" method="post">
 	<input type="hidden" name="id" value="5fbea2e6ce3d02f7cdbde0bc31be8059"/>
 	<input type="submit" value="Link"/>
 </form>
 Provider username: user3<br/>
-<form action="../pick" method="post">
+<form action="pick" method="post">
 	<input type="hidden" name="id" value="de0702aa7927b562e0d6be5b6527cfb2"/>
 	<input type="submit" value="Link"/>
 </form>
 
 <p> or
-<form action="../pick" method="post">
+<form action="pick" method="post">
 	<input type="submit" value="Link all"/>
 </form>
 </p>
 
 <h2>Already linked identities:</h2>
 
-Username: u1<br/>
-Provider username: user1<br/>
 </html>
 </body>

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
@@ -108,7 +108,7 @@ public class SimpleEndpointsTest {
 	 * an error message or a git commit hash depending on the test environment, so both are
 	 * allowed
 	 */
-	private static final String SERVER_VER = "0.1.0";
+	private static final String SERVER_VER = "0.1.1";
 	private static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 

--- a/templates/linkchoice.mustache
+++ b/templates/linkchoice.mustache
@@ -20,6 +20,7 @@ Provider username: {{provusername}}<br/>
 	<input type="submit" value="Link"/>
 </form>
 {{/idents}}
+{{#haslinks}}
 
 <p> or
 <form action="{{pickurl}}" method="post">
@@ -27,5 +28,12 @@ Provider username: {{provusername}}<br/>
 </form>
 </p>
 
+{{/haslinks}}
+<h2>Already linked identities:</h2>
+
+{{#linked}}
+Username: {{user}}<br/>
+Provider username: {{provusername}}<br/>
+{{/linked}}
 </html>
 </body>


### PR DESCRIPTION
Instead of throwing an error if there are no identities available to
link at the link choice endpoint, return the already linked identities.
This allows the UI to construct a much richer error message.