### PR TITLE
Make the login temp token a session token

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,9 +12,16 @@ Authentication Service MKII release notes
 * the /link/choice endpoint now returns the linked identities and the account to which they are
   linked. If all identities are linked an error is not thrown.
 
-0.1.2
+0.2.0
 -----
 
-* The user identity is now tracked throughout the linking process to eliminate the possibility
+* BACKWARDS INCOMPATIBILITY: after upgrading to 0.2.0, all login and link in process tokens will
+  be invalid. Users will need to restart the login or linking processes.
+* The temptokens MongoDB collection is no longer used and may be deleted.
+* The user identity is now tracked throughout the linking process to reduce the possibility
   of another user hijacking said process. This could occur if user A starts, but does not complete,
   the linking process, and user B logs in while the link-in-process cookie has not expired.
+* Temporary tokens are scoped to one of three operation stages: link start, link complete,
+  and login. Attempting to use a temporary token in an inappropriate scope will throw an error.
+* Login temporary tokens are now session tokens so that they're removed on browser exit. The tokens
+  still expire after 30m server side.

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -335,7 +335,7 @@ public class Login {
 		return new NewCookie(new Cookie(IN_PROCESS_LOGIN_COOKIE,
 				token == null ? "no token" : token.getToken(), UIPaths.LOGIN_ROOT, null),
 				"logintoken",
-				token == null ? 0 : getMaxCookieAge(token), UIConstants.SECURE_COOKIES);
+				token == null ? 0 : -1, UIConstants.SECURE_COOKIES);
 	}
 
 	@GET

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -24,7 +24,7 @@ public class Root {
 	
 	//TODO JAVADOC or swagger
 	
-	private static final String VERSION = "0.1.2";
+	private static final String VERSION = "0.2.0";
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/src/us/kbase/test/auth2/service/ui/LoginTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LoginTest.java
@@ -54,6 +54,7 @@ import us.kbase.auth2.lib.PasswordHashAndSalt;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.TemporarySessionData;
+import us.kbase.auth2.lib.TemporarySessionData.Operation;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.AuthException;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
@@ -688,9 +689,8 @@ public class LoginTest {
 		final NewCookie tempCookie = res.getCookies().get("in-process-login-token");
 		final NewCookie expectedtemp = new NewCookie("in-process-login-token",
 				tempCookie.getValue(),
-				"/login", null, "logintoken", tempCookie.getMaxAge(), false);
+				"/login", null, "logintoken", -1, false);
 		assertThat("incorrect temp cookie less value and max age", tempCookie, is(expectedtemp));
-		TestCommon.assertCloseTo(tempCookie.getMaxAge(), 30 * 60, 10);
 		
 		final TemporarySessionData tis = manager.storage.getTemporarySessionData(
 				new IncomingToken(tempCookie.getValue()).getHashedToken());
@@ -767,13 +767,13 @@ public class LoginTest {
 		final NewCookie tempCookie = res.getCookies().get("in-process-login-token");
 		final NewCookie expectedtemp = new NewCookie("in-process-login-token",
 				tempCookie.getValue(),
-				"/login", null, "logintoken", tempCookie.getMaxAge(), false);
-		assertThat("incorrect temp cookie less value and max age", tempCookie, is(expectedtemp));
-		TestCommon.assertCloseTo(tempCookie.getMaxAge(), 30 * 60, 10);
+				"/login", null, "logintoken", -1, false);
+		assertThat("incorrect temp cookie less value", tempCookie, is(expectedtemp));
 		
 		final TemporarySessionData tis = manager.storage.getTemporarySessionData(
 				new IncomingToken(tempCookie.getValue()).getHashedToken());
 		
+		assertThat("incorrect op", tis.getOperation(), is(Operation.ERROR));
 		assertThat("incorrect error", tis.getError(), is(Optional.of("errorwhee")));
 	}
 	

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
@@ -108,7 +108,7 @@ public class SimpleEndpointsTest {
 	 * an error message or a git commit hash depending on the test environment, so both are
 	 * allowed
 	 */
-	private static final String SERVER_VER = "0.1.2";
+	private static final String SERVER_VER = "0.2.0";
 	private static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 


### PR DESCRIPTION
killed when the browser is exited