### PR TITLE
Add test users to mongo storage.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -372,6 +372,7 @@
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTestTokensTest"/>
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUpdateUserFieldsTest"/>
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageUserCreateGetTest"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTestUserCreateGetTest"/>
       </junit>
     </jacoco:coverage>
     <fail message="Test failure detected, check test results." if="test.failed" />

--- a/src/us/kbase/auth2/cli/AuthCLI.java
+++ b/src/us/kbase/auth2/cli/AuthCLI.java
@@ -179,7 +179,7 @@ public class AuthCLI {
 		if (a.setroot) {
 			ret = setRootPassword(a, auth);
 		
-		//TODO POSTPROD remove this code and all dependent code
+		//TODO NOW remove this code and all dependent code
 		
 		/* The code below in the next block is not covered by tests and will be removed after
 		 * the auth2 service is released in KBase production and the Globus endpoint shutdown.

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -110,6 +110,24 @@ public interface AuthStorage {
 			throws UserExistsException, AuthStorageException, IdentityLinkedException,
 				NoSuchRoleException;
 	
+
+	/** Create a test user. Test users have no password and no linked accounts and therefore
+	 * login is impossible. Test users expire from the system after a given amount of time,
+	 * generally less than an hour.
+	 * 
+	 * Note that {@link AuthUser#isLocal()} returns true for test users since local users are
+	 * defined as having no remote identities, but test users still have no passwords.
+	 * @param name the user's name.
+	 * @param display the user's display name.
+	 * @param created the date the user was created.
+	 * @param expires the data the user expires from the system.
+	 * @throws UserExistsException if the user already exists.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs. 
+	 */
+	void testModeCreateUser(UserName name, DisplayName display, Instant created, Instant expires)
+			throws UserExistsException, AuthStorageException;
+	
 	/** Disable a user account.
 	 * @param user the name of the account to be disabled.
 	 * @param admin the admin disabling the account.
@@ -138,7 +156,25 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs.
 	 */
-	AuthUser getUser(UserName userName)
+	AuthUser getUser(UserName userName) throws AuthStorageException, NoSuchUserException;
+	
+	/** Get a test user.
+	 * @param userName the user to get.
+	 * @return the user.
+	 * @throws NoSuchUserException if the user does not exist.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 */
+	AuthUser testModeGetUser(UserName userName) throws AuthStorageException, NoSuchUserException;
+	
+	/** Get the date a test user expires from the system.
+	 * @param userName the user whose records will be accessed..
+	 * @return the user's expiration date.
+	 * @throws NoSuchUserException if the user does not exist.
+	 * @throws AuthStorageException if a problem connecting with the storage
+	 * system occurs.
+	 */
+	Instant testModeGetUserExpiry(UserName userName)
 			throws AuthStorageException, NoSuchUserException;
 	
 	/** Gets a user linked to a remote identity. Returns an empty Optional if the user doesn't
@@ -448,4 +484,5 @@ public interface AuthStorage {
 	<T extends ExternalConfig> AuthConfigSet<T> getConfig(
 			ExternalConfigMapper<T> mapper)
 			throws AuthStorageException, ExternalConfigMappingException;
+
 }

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -63,6 +63,10 @@ public class Fields {
 	 * Null if the password has never been reset.
 	 */
 	public static final String USER_RESET_PWD_LAST = "lastrst";
+	/** The date the user expires from the system. This is only used for test users and is
+	 * unsafe to enable on real users.
+	 */
+	public static final String USER_EXPIRES = "expires";
 	
 	/* *****************
 	 * Policy ID fields

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -398,7 +398,7 @@ public class MongoStorage implements AuthStorage {
 			throws AuthStorageException, NoSuchLocalUserException {
 		final Document user;
 		try {
-			user = getUserDoc(userName, true);
+			user = getUserDoc(COL_USERS, userName, true);
 		} catch (NoSuchUserException e) {
 			throw new NoSuchLocalUserException(userName.getName());
 		}
@@ -555,7 +555,7 @@ public class MongoStorage implements AuthStorage {
 			final boolean forceReset)
 			throws NoSuchUserException, AuthStorageException {
 		nonNull(creds, "creds");
-		getUserDoc(name, true); //check the user actually is local
+		getUserDoc(COL_USERS, name, true); //check the user actually is local
 		final String pwdhsh = Base64.getEncoder().encodeToString(creds.getPasswordHash());
 		final String encsalt = Base64.getEncoder().encodeToString(creds.getSalt());
 		final Document set = new Document(Fields.USER_RESET_PWD, forceReset)
@@ -568,7 +568,7 @@ public class MongoStorage implements AuthStorage {
 	@Override
 	public void forcePasswordReset(final UserName name)
 			throws NoSuchUserException, AuthStorageException {
-		getUserDoc(name, true); //check user is local. Could do this in one step but meh
+		getUserDoc(COL_USERS, name, true); //check user is local. Could do this in one step but meh
 		updateUser(name, new Document(Fields.USER_RESET_PWD, true));
 	}
 	
@@ -632,6 +632,50 @@ public class MongoStorage implements AuthStorage {
 			throw new AuthStorageException("Connection to database failed: " + e.getMessage(), e);
 		}
 	}
+	
+	// not super psyched about 3 different user creation methods but merging them was too nasty
+	@Override
+	public void testModeCreateUser(
+			final UserName name,
+			final DisplayName display,
+			final Instant created,
+			final Instant expires)
+			throws UserExistsException, AuthStorageException {
+		nonNull(name, "name");
+		nonNull(display, "display");
+		nonNull(created, "created");
+		nonNull(expires, "expires");
+		if (name.isRoot()) {
+			throw new IllegalArgumentException("Test users cannot be root");
+		}
+		final Document u = new Document(
+				Fields.USER_NAME, name.getName())
+				.append(Fields.USER_LOCAL, false)
+				.append(Fields.USER_EMAIL, null)
+				.append(Fields.USER_DISPLAY_NAME, display.getName())
+				.append(Fields.USER_DISPLAY_NAME_CANONICAL, display.getCanonicalDisplayName())
+				.append(Fields.USER_ROLES, new HashSet<>())
+				.append(Fields.USER_CUSTOM_ROLES, new HashSet<>())
+				.append(Fields.USER_IDENTITIES, new LinkedList<>())
+				.append(Fields.USER_POLICY_IDS, new LinkedList<>())
+				.append(Fields.USER_CREATED, Date.from(created))
+				.append(Fields.USER_LAST_LOGIN, null)
+				.append(Fields.USER_DISABLED_ADMIN, null)
+				.append(Fields.USER_DISABLED_DATE, null)
+				.append(Fields.USER_DISABLED_REASON, null)
+				.append(Fields.USER_EXPIRES, Date.from(expires));
+		try {
+			db.getCollection(COL_TEST_USERS).insertOne(u);
+		} catch (MongoWriteException mwe) {
+			if (DuplicateKeyExceptionChecker.isDuplicate(mwe)) {
+				throw new UserExistsException(name.getName());
+			} else {
+				throw new AuthStorageException("Database write failed", mwe);
+			}
+		} catch (MongoException e) {
+			throw new AuthStorageException("Connection to database failed: " + e.getMessage(), e);
+		}
+	}
 
 	private List<Document> toDocument(final Map<PolicyID, Instant> policyIDs) {
 		final List<Document> ret = new LinkedList<>();
@@ -641,12 +685,15 @@ public class MongoStorage implements AuthStorage {
 		return ret;
 	}
 
-	private Document getUserDoc(final UserName userName, final boolean local)
+	private Document getUserDoc(
+			final String collection,
+			final UserName userName,
+			final boolean local)
 			throws AuthStorageException, NoSuchUserException {
 		nonNull(userName, "userName");
 		final Document projection = new Document(Fields.USER_PWD_HSH, 0)
 				.append(Fields.USER_SALT, 0);
-		final Document user = findOne(COL_USERS,
+		final Document user = findOne(collection,
 				new Document(Fields.USER_NAME, userName.getName()), projection);
 		if (user == null) {
 			throw new NoSuchUserException(userName.getName());
@@ -861,7 +908,27 @@ public class MongoStorage implements AuthStorage {
 	@Override
 	public AuthUser getUser(final UserName userName)
 			throws AuthStorageException, NoSuchUserException {
-		return toUser(getUserDoc(userName, false));
+		return toUser(getUserDoc(COL_USERS, userName, false));
+	}
+	
+	@Override
+	public AuthUser testModeGetUser(final UserName userName)
+			throws AuthStorageException, NoSuchUserException {
+		final Document userDoc = getUserDoc(COL_TEST_USERS, userName, false);
+		/* although expired test users are automatically deleted from the DB by mongo, the thread
+		 * only runs ~1/min, so check here
+		 */
+		if (Instant.now().isAfter(userDoc.getDate(Fields.USER_EXPIRES).toInstant())) {
+			throw new NoSuchUserException(userName.getName());
+		}
+		return toUser(userDoc);
+	}
+	
+	@Override
+	public Instant testModeGetUserExpiry(final UserName userName)
+			throws AuthStorageException, NoSuchUserException {
+		return getUserDoc(COL_TEST_USERS, userName, false)
+				.getDate(Fields.USER_EXPIRES).toInstant();
 	}
 
 	private AuthUser toUser(final Document user) throws AuthStorageException {

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -123,6 +123,7 @@ public class MongoStorage implements AuthStorage {
 	
 	private static final int SCHEMA_VERSION = 1;
 	
+	// collection names;
 	private static final String COL_CONFIG = "config";
 	private static final String COL_CONFIG_APPLICATION = "config_app";
 	private static final String COL_CONFIG_PROVIDERS = "config_prov";
@@ -132,7 +133,9 @@ public class MongoStorage implements AuthStorage {
 	private static final String COL_TEMP_DATA = "tempdata";
 	private static final String COL_CUST_ROLES = "cust_roles";
 	
+	// test collection names;
 	private static final String COL_TEST_TOKEN = "test_tokens";
+	private static final String COL_TEST_USERS = "test_users";
 	
 	private static final Map<TokenLifetimeType, String>
 			TOKEN_LIFETIME_FIELD_MAP;
@@ -225,6 +228,21 @@ public class MongoStorage implements AuthStorage {
 		INDEXES.put(COL_CONFIG_EXTERNAL, extcfg);
 		
 		// *** test collection indexes ***
+		
+		//user indexes
+		final Map<List<String>, IndexOptions> testUsers = new HashMap<>();
+		//find users and ensure user names are unique
+		testUsers.put(Arrays.asList(Fields.USER_NAME), IDX_UNIQ);
+		//find users by display name
+		testUsers.put(Arrays.asList(Fields.USER_DISPLAY_NAME_CANONICAL), null);
+		//find users by roles
+		testUsers.put(Arrays.asList(Fields.USER_ROLES), IDX_SPARSE);
+		//find users by custom roles
+		testUsers.put(Arrays.asList(Fields.USER_CUSTOM_ROLES), IDX_SPARSE);
+		testUsers.put(Arrays.asList(Fields.USER_EXPIRES), 
+				new IndexOptions().expireAfter(0L, TimeUnit.SECONDS));
+		INDEXES.put(COL_TEST_USERS, testUsers);
+		
 		//token indexes
 		final Map<List<String>, IndexOptions> testToken = new HashMap<>();
 		testToken.put(Arrays.asList(Fields.TOKEN_USER_NAME), null);

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageStartUpTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageStartUpTest.java
@@ -140,7 +140,8 @@ public class MongoStorageStartUpTest extends MongoStorageTester {
 				"tempdata",
 				"tokens",
 				"test_tokens",
-				"users");
+				"users",
+				"test_users");
 		if (includeSystemIndexes) {
 			expected.add("system.indexes");
 		}
@@ -363,6 +364,42 @@ public class MongoStorageStartUpTest extends MongoStorageTester {
 						.append("key", new Document("user", 1))
 						.append("name", "user_1")
 						.append("ns", "test_mongostorage.users")
+				)));
+	}
+	
+	@Test
+	public void indexesTestUsers() {
+		final Set<Document> indexes = new HashSet<>();
+		db.getCollection("test_users").listIndexes().forEach((Consumer<Document>) indexes::add);
+		assertThat("incorrect indexes", indexes, is(set(
+				new Document("v", indexVer)
+						.append("key", new Document("custrls", 1))
+						.append("name", "custrls_1")
+						.append("ns", "test_mongostorage.test_users")
+						.append("sparse", true),
+				new Document("v", indexVer)
+						.append("key", new Document("dispcan", 1))
+						.append("name", "dispcan_1")
+						.append("ns", "test_mongostorage.test_users"),
+				new Document("v", indexVer)
+						.append("key", new Document("_id", 1))
+						.append("name", "_id_")
+						.append("ns", "test_mongostorage.test_users"),
+				new Document("v", indexVer)
+						.append("key", new Document("roles", 1))
+						.append("name", "roles_1")
+						.append("ns", "test_mongostorage.test_users")
+						.append("sparse", true),
+				new Document("v", indexVer)
+						.append("unique", true)
+						.append("key", new Document("user", 1))
+						.append("name", "user_1")
+						.append("ns", "test_mongostorage.test_users"),
+				new Document("v", indexVer)
+						.append("key", new Document("expires", 1))
+						.append("name", "expires_1")
+						.append("ns", "test_mongostorage.test_users")
+						.append("expireAfterSeconds", 0L)
 				)));
 	}
 }

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestUserCreateGetTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestUserCreateGetTest.java
@@ -1,0 +1,175 @@
+package us.kbase.test.auth2.lib.storage.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static us.kbase.test.auth2.TestCommon.set;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.UserDisabledState;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.exceptions.NoSuchUserException;
+import us.kbase.auth2.lib.exceptions.UserExistsException;
+import us.kbase.auth2.lib.identity.RemoteIdentity;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.user.AuthUser;
+import us.kbase.auth2.lib.user.NewUser;
+import us.kbase.test.auth2.TestCommon;
+
+public class MongoStorageTestUserCreateGetTest extends MongoStorageTester {
+	
+	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
+			new RemoteIdentityID("prov", "bar1"),
+			new RemoteIdentityDetails("user1", "full1", "email1"));
+
+	@Test
+	public void createAndGet() throws Exception {
+		final Instant expiry = Instant.now().plus(1, ChronoUnit.DAYS);
+		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"),
+				Instant.ofEpochMilli(10000), expiry);
+		
+		final Instant e = storage.testModeGetUserExpiry(new UserName("foo"));
+		assertThat("incorrect expiry", e, is(expiry));
+		
+		final AuthUser u = storage.testModeGetUser(new UserName("foo"));
+		
+		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
+				is(Optional.absent()));
+		assertThat("incorrect creation", u.getCreated(), is(Instant.ofEpochMilli(10000)));
+		assertThat("incorrect custom roles", u.getCustomRoles(), is(Collections.emptySet()));
+		assertThat("incorrect disabled state", u.getDisabledState(), is(new UserDisabledState()));
+		assertThat("incorrect display name", u.getDisplayName(), is(new DisplayName("bar")));
+		assertThat("incorrect email", u.getEmail(), is(EmailAddress.UNKNOWN));
+		assertThat("incorrect enable toggle date", u.getEnableToggleDate(), is(Optional.absent()));
+		assertThat("incorrect grantable roles", u.getGrantableRoles(),
+				is(Collections.emptySet()));
+		assertThat("incorrect identities", u.getIdentities(), is(set()));
+		assertThat("incorrect policy ids", u.getPolicyIDs(), is(Collections.emptyMap()));
+		assertThat("incorrect last login", u.getLastLogin(), is(Optional.absent()));
+		assertThat("incorrect disabled reason", u.getReasonForDisabled(), is(Optional.absent()));
+		assertThat("incorrect roles", u.getRoles(), is(Collections.emptySet()));
+		assertThat("incorrect user name", u.getUserName(), is(new UserName("foo")));
+		assertThat("incorrect is disabled", u.isDisabled(), is(false));
+		assertThat("incorrect is local", u.isLocal(), is(true));
+		assertThat("incorrect is root", u.isRoot(), is(false));
+	}
+	
+	@Test
+	public void getNullUser() {
+		failGetUser(null, new NullPointerException("userName"));
+		failGetUserExpiry(null, new NullPointerException("userName"));
+	}
+	
+	@Test
+	public void getNoSuchUser() throws Exception {
+		final Instant expiry = Instant.now().plus(1, ChronoUnit.DAYS);
+		storage.testModeCreateUser(new UserName("user1"), new DisplayName("bar1"),
+				Instant.ofEpochMilli(10000), expiry);
+
+		failGetUser(new UserName("user2"), new NoSuchUserException("user2"));
+		failGetUserExpiry(new UserName("user2"), new NoSuchUserException("user2"));
+	}
+	
+	@Test
+	public void getStdUserFromTestCollection() throws Exception {
+		storage.createUser(NewUser.getBuilder(
+				new UserName("user"), new DisplayName("bar"), Instant.now(), REMOTE1)
+				.build());
+		
+		failGetUser(new UserName("user"), new NoSuchUserException("user"));
+	}
+	
+	@Test
+	public void getTestUserFromStdCollection() throws Exception {
+		final Instant expiry = Instant.now().plus(1, ChronoUnit.DAYS);
+		storage.testModeCreateUser(new UserName("user1"), new DisplayName("bar1"),
+				Instant.ofEpochMilli(10000), expiry);
+		
+		try {
+			storage.getUser(new UserName("user1"));
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new NoSuchUserException("user1"));
+		}
+	}
+	
+	@Test
+	public void getExpiredUser() throws Exception {
+		// this test could fail to cover the intended code if mongo happens to remove the user
+		// before the get occurs.
+		// since the removal thread only runs 1/min should be rare.
+		storage.testModeCreateUser(new UserName("user1"), new DisplayName("bar1"),
+				Instant.ofEpochMilli(10000), Instant.now());
+		Thread.sleep(1);
+		failGetUser(new UserName("user1"), new NoSuchUserException("user1"));
+	}
+	
+	private void failGetUser(final UserName user, final Exception e) {
+		try {
+			storage.testModeGetUser(user);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	private void failGetUserExpiry(final UserName user, final Exception e) {
+		try {
+			storage.testModeGetUserExpiry(user);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, e);
+		}
+	}
+	
+	@Test
+	public void createUserBadArgsFail() throws Exception {
+		final UserName u = new UserName("foo");
+		final DisplayName n = new DisplayName("bar");
+		final Instant c = Instant.ofEpochMilli(1000);
+		final Instant e = Instant.now().plus(1, ChronoUnit.DAYS);
+		
+		failCreateuser(null, n, c, e, new NullPointerException("name"));
+		failCreateuser(UserName.ROOT, n, c, e,
+				new IllegalArgumentException("Test users cannot be root"));
+		failCreateuser(u, null, c, e, new NullPointerException("display"));
+		failCreateuser(u, n, null, e, new NullPointerException("created"));
+		failCreateuser(u, n, c, null, new NullPointerException("expires"));
+	}
+	
+	@Test
+	public void createUserDuplicateFail() throws Exception {
+		final Instant expiry = Instant.now().plus(1, ChronoUnit.DAYS);
+		storage.testModeCreateUser(new UserName("user1"), new DisplayName("bar1"),
+				Instant.ofEpochMilli(10000), expiry);
+		
+		failCreateuser(new UserName("user1"), new DisplayName("whee"),
+				Instant.ofEpochMilli(100000), expiry.plus(3, ChronoUnit.MINUTES),
+				new UserExistsException("user1"));
+	}
+	
+	private void failCreateuser(
+			final UserName name,
+			final DisplayName display,
+			final Instant created,
+			final Instant expires,
+			final Exception expected) {
+		try {
+			storage.testModeCreateUser(name, display, created, expires);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
@@ -44,7 +44,9 @@ public class MongoStorageTester {
 	
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		manager.destroy();
+		if (manager != null) {
+			manager.destroy();
+		}
 	}
 	
 	@Before


### PR DESCRIPTION
Allows for expiration of test users from the system. This may cause
strange errors if the user expires before the user's tokens expire, but
since it's for test users only we don't care.