### PR TITLE
Minor cleanup, docs, TODO doc

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,31 +1,6 @@
 Auth2 TODO list
 ===============
 
-Update core services and SDK modules
-------------------------------------
-*Note:* not in auth team scope unless specified
-
-Need to use updated server stubs & auth clients, use tokens for magic user
-accounts and tests if any, allow setting auth service url
-
-* Shock & Awe - Rich
-* Perl auth & server stubs - Keith
-* Handle service & manager - Keith
-* Narrative (Login UI and Lua) - Bill R. (external to auth team)
-  * Token cleanup - remove backup token, make simple token format
-* kb_sdk
-  * Tests support token vs uid/pwd & setting auth url
-  * Recompile & test all SDK modules
-* NJSW
-* User Profile
-  * Update to get and set user name & email from and to auth service
-* Service wizard
-* Narrative Method Store
-* Data Import Export
-* Search
-* Solar auth
-* Bulk IO
-
 Auth service work
 -----------------
 * Complete rich UI (code not in this repo)
@@ -33,27 +8,21 @@ Auth service work
 * TODOs in the codebase
 * Read through all remaining prototype code and convert to production worthy
 * Code review
-  * Mike Sneddon
   * Steve Chan
 * Code analysis:
   * https://www.codacy.com/
   * https://find-sec-bugs.github.io/
 * Tests
+  * Redo UI/API tests to move most tests to unit test from integration tests
+    * Use constructor dependency injection to make UTs easy
+    * Minimal integration tests
 * Documentation
   * Code documentation
-  * User documentation and education (probably need doc team help here)
-    * Login & signup very different
   * Try swagger again - go from code -> docs vs. other way around
   * Server manual, incl user and admin coverage
 * General
   * Lock local account for X m after Y failed logins - use sshguard or something here
   * Make server root return endpoints
-* Deploy
-  * Dockerization
-
-External dependencies
----------------------
-* JGI stops using uid/pwd to login for jgidm account
 
 Future work
 -----------

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -2095,7 +2095,6 @@ public class Authentication {
 		}
 	}
 	
-	//TODO TESTMODE clear() method
 
 	/** Complete the OAuth2 login process.
 	 * 

--- a/src/us/kbase/auth2/lib/exceptions/ErrorType.java
+++ b/src/us/kbase/auth2/lib/exceptions/ErrorType.java
@@ -82,7 +82,7 @@ public enum ErrorType {
 	private final int errcode;
 	private final String error;
 	
-	ErrorType(final int errcode, final String error) {
+	private ErrorType(final int errcode, final String error) {
 		this.errcode = errcode;
 		this.error = error;
 	}

--- a/src/us/kbase/auth2/lib/token/TokenName.java
+++ b/src/us/kbase/auth2/lib/token/TokenName.java
@@ -4,8 +4,19 @@ import us.kbase.auth2.lib.Name;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 
+/** Represents a user-assigned name for a token. The name is an arbitrary string of no more than
+ * 100 characters.
+ * @author gaprice@lbl.gov
+ *
+ */
 public class TokenName extends Name {
 	
+	/** Create a token name.
+	 * @param name the name.
+	 * @throws MissingParameterException if the name is null or the empty string.
+	 * @throws IllegalParameterException if the name is longer than 100 characters or contains
+	 * control characters.
+	 */
 	public TokenName(final String name)
 			throws MissingParameterException, IllegalParameterException {
 		super(name, "token name", 100);

--- a/src/us/kbase/auth2/lib/token/TokenType.java
+++ b/src/us/kbase/auth2/lib/token/TokenType.java
@@ -52,14 +52,14 @@ public enum TokenType {
 	}
 	
 	/** Get a token type based on a supplied ID.
-	 * @param id the id.
+	 * @param id the id for the token type.
 	 * @return a token type.
 	 * @throws IllegalArgumentException if there is no token type matching the ID.
 	 */
-	public static TokenType getType(final String id) {
-		if (!TYPE_MAP.containsKey(id)) {
-			throw new IllegalArgumentException("Invalid role id: " + id);
+	public static TokenType getType(final String type) {
+		if (!TYPE_MAP.containsKey(type)) {
+			throw new IllegalArgumentException("Invalid token type: " + type);
 		}
-		return TYPE_MAP.get(id);
+		return TYPE_MAP.get(type);
 	}
 }

--- a/src/us/kbase/auth2/service/api/Token.java
+++ b/src/us/kbase/auth2/service/api/Token.java
@@ -41,11 +41,15 @@ public class Token {
 
 	//TODO JAVADOC or swagger
 	
-	@Inject
 	private Authentication auth;
 	
-	@Inject
 	private UserAgentParser userAgentParser;
+	
+	@Inject
+	public Token(final Authentication auth, final UserAgentParser userAgentParser) {
+		this.auth = auth;
+		this.userAgentParser = userAgentParser;
+	}
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)

--- a/src/us/kbase/test/auth2/lib/token/TokenTest.java
+++ b/src/us/kbase/test/auth2/lib/token/TokenTest.java
@@ -75,11 +75,16 @@ public class TokenTest {
 				is(TokenType.DEV));
 		assertThat("failed to get service token type", TokenType.getType("Serv"),
 				is(TokenType.SERV));
+		failGetType(null, "Invalid token type: null");
+		failGetType("foo", "Invalid token type: foo");
+	}
+	
+	private void failGetType(final String type, final String exception) {
 		try {
-			TokenType.getType(null);
-			fail("got bad type");
-		} catch (IllegalArgumentException e) {
-			assertThat("incorrect exception message", e.getMessage(), is("Invalid role id: null"));
+			TokenType.getType(type);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(exception));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -207,6 +207,19 @@ public class ServiceCommonTest {
 	
 	@Test
 	public void getTokenContextWithCustomContextAndBadIP() throws Exception {
+		/* Some really annoying ISPs will send you to a custom search page or something
+		 * when you look up a fake domain, so if InetAddress finds an address we have to alter
+		 * the test.
+		 */
+		InetAddress expectedAddr = null;
+		try {
+			expectedAddr = InetAddress.getByName("fakeip");
+			System.err.println("Buttwipe ISP detected. 'fakeip' domain was redirected to " +
+					expectedAddr + ". Please be sure to run this test again on a " +
+					"non-buttwipe ISP.");
+		} catch (Exception e) {
+			//do nothing
+		}
 		final HttpServletRequest req = mock(HttpServletRequest.class);
 		// mocked because creation takes multiple seconds
 		final UserAgentParser parser = mock(UserAgentParser.class);
@@ -225,6 +238,7 @@ public class ServiceCommonTest {
 				.withNullableOS("Windows NT", "6.1")
 				.withCustomContext("baz", "bat")
 				.withCustomContext("foo", "bar")
+				.withNullableIpAddress(expectedAddr)
 				.build();
 		
 		assertThat("incorrect context", res, is(expected));


### PR DESCRIPTION
also fixed tests to pass on current isp, which redirects non-existent
domains to its search page.

TODO ensure travis test logs do not contain the phrase 'buttwipe'. That
indicates the tests are not running correctly.