### PR TITLE
SCT-158 Add test mode boolean to config

### DIFF
--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -54,6 +54,8 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private static final String KEY_SUFFIX_ID_PROVS_LINK_REDIRECT =
 			"-link-redirect-url";
 	private static final String KEY_SUFFIX_ID_PROVS_CUSTOM = "-custom-";
+	private static final String TRUE = "true";
+	private static final String KEY_TEST_MODE_ENABLED = "test-mode-enabled";
 	
 	private final SLF4JAutoLogger logger;
 	private final String mongoHost;
@@ -62,6 +64,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private final Optional<char[]> mongoPwd;
 	private final String cookieName;
 	private final Set<IdentityProviderConfig> providers;
+	private final boolean isTestModeEnabled;
 
 	public KBaseAuthConfig() throws AuthConfigurationException {
 		this(getConfigPathFromEnv(), false);
@@ -81,6 +84,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 					JsonServerSyslog.LOG_LEVEL_INFO, true));
 		}
 		try {
+			isTestModeEnabled = TRUE.equals(getString(KEY_TEST_MODE_ENABLED, cfg));
 			mongoHost = getString(KEY_MONGO_HOST, cfg, true);
 			mongoDB = getString(KEY_MONGO_DB, cfg, true);
 			mongoUser = Optional.fromNullable(getString(KEY_MONGO_USER, cfg));
@@ -295,5 +299,10 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	@Override
 	public String getTokenCookieName() {
 		return cookieName;
+	}
+	
+	@Override
+	public boolean isTestModeEnabled() {
+		return isTestModeEnabled;
 	}
 }

--- a/src/us/kbase/auth2/service/AuthBuilder.java
+++ b/src/us/kbase/auth2/service/AuthBuilder.java
@@ -97,8 +97,7 @@ public class AuthBuilder {
 					idc.getIdentityProviderFactoryClassName(), IdentityProviderFactory.class);
 			providers.add(fac.configure(idc));
 		}
-		//TODO TESTMODE get testmode toggle from config
-		return new Authentication(s, providers, defaultExternalConfig, false);
+		return new Authentication(s, providers, defaultExternalConfig, c.isTestModeEnabled());
 	}
 	
 	public MongoClient getMongoClient() {

--- a/src/us/kbase/auth2/service/AuthStartupConfig.java
+++ b/src/us/kbase/auth2/service/AuthStartupConfig.java
@@ -18,4 +18,5 @@ public interface AuthStartupConfig {
 	Optional<String> getMongoUser();
 	Optional<char[]> getMongoPwd();
 	String getTokenCookieName();
+	boolean isTestModeEnabled();
 }

--- a/src/us/kbase/test/auth2/service/LoggingFilterTest.java
+++ b/src/us/kbase/test/auth2/service/LoggingFilterTest.java
@@ -100,6 +100,11 @@ public class LoggingFilterTest {
 		public String getTokenCookieName() {
 			return COOKIE_NAME;
 		}
+		
+		@Override
+		public boolean isTestModeEnabled() {
+			return false;
+		}
 	}
 	
 	@BeforeClass


### PR DESCRIPTION
Adds the ability to turn test mode on and off via the configuration.
Tested manually. Next is integration tests for the test user endpoints.