### PR TITLE
Add test user integration test

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -341,6 +341,7 @@
         <test name="us.kbase.test.auth2.service.api.APITokenTest"/>
         <test name="us.kbase.test.auth2.service.api.TokenEndpointTest"/>
         <test name="us.kbase.test.auth2.service.api.TestModeTest"/>
+        <test name="us.kbase.test.auth2.service.api.TestModeIntegrationTest"/>
         <test name="us.kbase.test.auth2.service.api.UserEndpointTest"/>
         <test name="us.kbase.test.auth2.service.common.ExternalTokenTest"/>
         <test name="us.kbase.test.auth2.service.common.IncomingJSONTest"/>

--- a/src/us/kbase/auth2/service/api/TestMode.java
+++ b/src/us/kbase/auth2/service/api/TestMode.java
@@ -30,7 +30,6 @@ import us.kbase.auth2.service.common.IncomingJSON;
 @Path(APIPaths.TESTMODE_V2)
 public class TestMode {
 	
-	// TODO TESTMODE TEST integration
 	// TODO TESTMODE legacy class
 	// TODO JAVADOC or swagger
 	

--- a/src/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -372,13 +372,27 @@ public class ServiceTestUtils {
 	public static Path generateTempConfigFile(
 			final MongoStorageTestManager manager,
 			final String dbName,
-			final String cookieName) throws IOException {
+			final String cookieName)
+			throws IOException {
+		return generateTempConfigFile(manager, dbName, cookieName, false);
+	}
+	
+	public static Path generateTempConfigFile(
+			final MongoStorageTestManager manager,
+			final String dbName,
+			final String cookieName,
+			final boolean testMode)
+			throws IOException {
 		final Ini ini = new Ini();
 		final Section sec = ini.add("authserv2");
 		sec.add("mongo-host", "localhost:" + manager.mongo.getServerPort());
 		sec.add("mongo-db", dbName);
 		sec.add("token-cookie-name", cookieName);
 		// don't bother with logger name
+		
+		if (testMode) {
+			sec.add("test-mode-enabled", "true");
+		}
 		
 		sec.add("identity-providers", "prov1, prov2");
 		

--- a/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
+++ b/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
@@ -1,0 +1,139 @@
+package us.kbase.test.auth2.service.api;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.kbase.KBaseAuthConfig;
+import us.kbase.test.auth2.MongoStorageTestManager;
+import us.kbase.test.auth2.StandaloneAuthServer;
+import us.kbase.test.auth2.TestCommon;
+import us.kbase.test.auth2.StandaloneAuthServer.ServerThread;
+import us.kbase.test.auth2.service.ServiceTestUtils;
+
+public class TestModeIntegrationTest {
+	
+	//TODO TESTMODE TEST integration test showing the test mode fails when server is not set up in test mode
+
+	/* Eventually all the other api integration tests should be reduced to the minimum possible
+	 * and moved to an API integration test class like this one. The API classes should be modified
+	 * to allow for easy instantiation via constructor dependency injection and
+	 * most of the current integration tests should be converted to unit tests.
+	 */
+	
+	/* Integration tests for test api API endpoints. Minimal tests to make sure all the layers
+	 * communicate correctly.
+	 */
+	
+	private static final String DB_NAME = "test_api_integration";
+	private static final String COOKIE_NAME = "login-cookie";
+	
+	private static final Client CLI = ClientBuilder.newClient();
+	
+	private static MongoStorageTestManager manager = null;
+	private static StandaloneAuthServer server = null;
+	private static int port = -1;
+	private static String host = null;
+	
+	@BeforeClass
+	public static void beforeClass() throws Exception {
+		TestCommon.stfuLoggers();
+		manager = new MongoStorageTestManager(DB_NAME);
+		final Path cfgfile = ServiceTestUtils.generateTempConfigFile(
+				manager, DB_NAME, COOKIE_NAME, true);
+		TestCommon.getenv().put("KB_DEPLOYMENT_CONFIG", cfgfile.toString());
+		server = new StandaloneAuthServer(KBaseAuthConfig.class.getName());
+		new ServerThread(server).start();
+		System.out.println("Main thread waiting for server to start up");
+		while (server.getPort() == null) {
+			Thread.sleep(1000);
+		}
+		port = server.getPort();
+		host = "http://localhost:" + port;
+	}
+	
+	@AfterClass
+	public static void afterClass() throws Exception {
+		if (server != null) {
+			server.stop();
+		}
+		if (manager != null) {
+			manager.destroy();
+		}
+	}
+	
+	@Before
+	public void beforeTest() throws Exception {
+		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+	}
+	
+	@Test
+	public void createAndGetTestUser() {
+		final URI target = UriBuilder.fromUri(host).path("/testmode/api/V2/testmodeonly/user/")
+				.build();
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request();
+		
+		final Response res = req.post(Entity.json(
+				ImmutableMap.of("user", "whee", "display", "whoo")));
+
+		assertThat("incorrect response code", res.getStatus(), is(200));
+		
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> response = res.readEntity(Map.class);
+		
+		final long created = (long) response.get("created");
+		response.remove("created");
+		TestCommon.assertCloseToNow(created);
+		
+		final Map<String, Object> expected = new HashMap<>();
+		expected.put("lastlogin", null);
+		expected.put("display", "whoo");
+		expected.put("roles", Collections.emptyList());
+		expected.put("customroles", Collections.emptyList());
+		expected.put("policyids", Collections.emptyList());
+		expected.put("user", "whee");
+		expected.put("local", true);
+		expected.put("email", null);
+		expected.put("idents", Collections.emptyList());
+		
+		assertThat("incorrect return", response, is(expected));
+		
+		final URI target2 = UriBuilder.fromUri(host)
+				.path("/testmode/api/V2/testmodeonly/user/whee").build();
+		final WebTarget wt2 = CLI.target(target2);
+		final Builder req2 = wt2.request();
+		
+		final Response res2 = req2.get();
+		
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> response2 = res2.readEntity(Map.class);
+		
+		assertThat("incorrect response code", res2.getStatus(), is(200));
+		
+		expected.put("created", created);
+		
+		assertThat("incorrect get user", response2, is(expected));
+	}
+	
+}


### PR DESCRIPTION
Also contains a potential fix for a test error that so far only occurs
in TravisCI. It appears that locally the tests always call a particular
method out of the two methods for the KBase legacy POST endpoints, while
in TravisCI a random method is called. If the wrong method is called, an
unexpected error is thrown. Hence, the methods are combined and very
simplistic content negotiation is done at runtime rather than statically
via JAX-RS annotations.