### PR TITLE
SCT-158 Add test mode disabled integration test for /user

### DIFF
--- a/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
+++ b/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
@@ -33,8 +33,6 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 
 public class TestModeIntegrationTest {
 	
-	//TODO TESTMODE TEST integration test showing the test mode fails when server is not set up in test mode
-
 	/* Eventually all the other api integration tests should be reduced to the minimum possible
 	 * and moved to an API integration test class like this one. The API classes should be modified
 	 * to allow for easy instantiation via constructor dependency injection and

--- a/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -48,6 +48,7 @@ import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
 import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
+import us.kbase.auth2.lib.exceptions.TestModeException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.identity.RemoteIdentity;
 import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
@@ -109,6 +110,42 @@ public class UserEndpointTest {
 	@Before
 	public void beforeTest() throws Exception {
 		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+	}
+	
+	@Test
+	public void testModeFail() throws Exception {
+		// get user
+		final URI target2 = UriBuilder.fromUri(host).path("/testmode/api/V2/testmodeonly/user/foo")
+				.build();
+		final WebTarget wt2 = CLI.target(target2);
+		final Builder req2 = wt2.request()
+				// GDI, Jersey adds a default accept header and I can't figure out how to stop it
+				// http://stackoverflow.com/questions/40900870/how-do-i-get-jersey-test-client-to-not-fill-in-a-default-accept-header
+				.header("accept", MediaType.APPLICATION_JSON);
+		
+		final Response res2 = req2.get();
+		
+		assertThat("incorrect response code", res2.getStatus(), is(400));
+		
+		failRequestJSON(res2, 400, "Bad Request",
+				new TestModeException(ErrorType.UNSUPPORTED_OP, "Test mode is not enabled"));
+		
+		// create user
+		final URI target = UriBuilder.fromUri(host).path("/testmode/api/V2/testmodeonly/user/")
+				.build();
+		final WebTarget wt = CLI.target(target);
+		final Builder req = wt.request()
+				// GDI, Jersey adds a default accept header and I can't figure out how to stop it
+				// http://stackoverflow.com/questions/40900870/how-do-i-get-jersey-test-client-to-not-fill-in-a-default-accept-header
+				.header("accept", MediaType.APPLICATION_JSON);
+		
+		final Response res = req.post(Entity.json(
+				ImmutableMap.of("user", "whee", "display", "whoo")));
+		
+		assertThat("incorrect response code", res.getStatus(), is(400));
+		
+		failRequestJSON(res, 400, "Bad Request",
+				new TestModeException(ErrorType.UNSUPPORTED_OP, "Test mode is not enabled"));
 	}
 	
 	@Test


### PR DESCRIPTION
Tests that getting and creating users in test mode does not work when
test-mode-enabled!=true in in the config.