### PR TITLE
Refactor IdentityProviderConfig to use a builder.

### DIFF
--- a/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
+++ b/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.AfterClass;
@@ -18,7 +17,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
 
 import us.kbase.auth2.kbase.KBaseAuthConfig;
 import us.kbase.auth2.lib.identity.IdentityProviderConfig;
@@ -138,24 +136,26 @@ public class KBaseAuthConfigTest {
 				Arrays.equals(cfg.getMongoPwd().get(), "mpwd".toCharArray()), is(true));
 		assertThat("incorrect test mode", cfg.isTestModeEnabled(), is(true));
 		assertThat("incorrect id providers", cfg.getIdentityProviderConfigs(), is(set(
-				new IdentityProviderConfig(
+				IdentityProviderConfig.getBuilder(
 						"facclass",
 						new URL("https://login.prov1.com"),
 						new URL("https://api.prov1.com"),
 						"clientid",
 						"secret",
 						new URL("https://loginredirect.com"),
-						new URL("https://linkredirect.com"),
-						ImmutableMap.of("foo", "bar", "bat", "baz")),
-				new IdentityProviderConfig(
+						new URL("https://linkredirect.com"))
+						.withCustomConfiguration("foo", "bar")
+						.withCustomConfiguration("bat", "baz")
+						.build(),
+				IdentityProviderConfig.getBuilder(
 						"facclass2",
 						new URL("https://login.prov2.com"),
 						new URL("https://api.prov2.com"),
 						"clientid2",
 						"secret2",
 						new URL("https://loginredirect2.com"),
-						new URL("https://linkredirect2.com"),
-						Collections.emptyMap())
+						new URL("https://linkredirect2.com"))
+						.build()
 				)));
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
@@ -252,24 +252,26 @@ public class KBaseAuthConfigTest {
 				Arrays.equals(cfg.getMongoPwd().get(), "mpwd".toCharArray()), is(true));
 		assertThat("incorrect test mode", cfg.isTestModeEnabled(), is(true));
 		assertThat("incorrect id providers", cfg.getIdentityProviderConfigs(), is(set(
-				new IdentityProviderConfig(
+				IdentityProviderConfig.getBuilder(
 						"facclass",
 						new URL("https://login.prov1.com"),
 						new URL("https://api.prov1.com"),
 						"clientid",
 						"secret",
 						new URL("https://loginredirect.com"),
-						new URL("https://linkredirect.com"),
-						ImmutableMap.of("foo", "bar", "bat", "baz")),
-				new IdentityProviderConfig(
+						new URL("https://linkredirect.com"))
+						.withCustomConfiguration("foo", "bar")
+						.withCustomConfiguration("bat", "baz")
+						.build(),
+				IdentityProviderConfig.getBuilder(
 						"facclass2",
 						new URL("https://login.prov2.com"),
 						new URL("https://api.prov2.com"),
 						"clientid2",
 						"secret2",
 						new URL("https://loginredirect2.com"),
-						new URL("https://linkredirect2.com"),
-						Collections.emptyMap())
+						new URL("https://linkredirect2.com"))
+						.build()
 				)));
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
@@ -595,15 +597,15 @@ public class KBaseAuthConfigTest {
 		final KBaseAuthConfig cfg = new KBaseAuthConfig(cfgfile, false);
 		
 		try {
-			cfg.getIdentityProviderConfigs().add(new IdentityProviderConfig(
+			cfg.getIdentityProviderConfigs().add(IdentityProviderConfig.getBuilder(
 						"facclass2",
 						new URL("https://login.prov2.com"),
 						new URL("https://api.prov2.com"),
 						"clientid2",
 						"secret2",
 						new URL("https://loginredirect2.com"),
-						new URL("https://linkredirect2.com"),
-						Collections.emptyMap()));
+						new URL("https://linkredirect2.com"))
+						.build());
 			fail("expected exception");
 		} catch (UnsupportedOperationException e) {
 			// test passes

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -113,10 +113,10 @@ public class AuthenticationConstructorTest {
 	
 	@Test
 	public void nulls() throws Exception {
-		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
+		final IdentityProviderConfig cfg1 = IdentityProviderConfig.getBuilder(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
-				Collections.emptyMap());
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"))
+				.build();
 		
 		final AuthStorage storage = mock(AuthStorage.class);
 		failConstruct(null, Collections.emptySet(), new TestExternalConfig<>(SET_FOO),
@@ -162,14 +162,14 @@ public class AuthenticationConstructorTest {
 	public void withIDs() throws Exception {
 		/* Doesn't test the prov config - tested in methods that use the config */
 		final AuthStorage storage = mock(AuthStorage.class);
-		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
+		final IdentityProviderConfig cfg1 = IdentityProviderConfig.getBuilder(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
-				Collections.emptyMap());
-		final IdentityProviderConfig cfg2 = new IdentityProviderConfig(
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"))
+				.build();
+		final IdentityProviderConfig cfg2 = IdentityProviderConfig.getBuilder(
 				"prov2", new URL("https://login2.com"), new URL("https://link2.com"),
-				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"),
-				Collections.emptyMap());
+				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"))
+				.build();
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv("Prov1", cfg1));
@@ -201,14 +201,14 @@ public class AuthenticationConstructorTest {
 	@Test
 	public void withIDsFailDuplicate() throws Exception {
 		final AuthStorage storage = mock(AuthStorage.class);
-		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
+		final IdentityProviderConfig cfg1 = IdentityProviderConfig.getBuilder(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
-				Collections.emptyMap());
-		final IdentityProviderConfig cfg2 = new IdentityProviderConfig(
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"))
+				.build();
+		final IdentityProviderConfig cfg2 = IdentityProviderConfig.getBuilder(
 				"prov2", new URL("https://login2.com"), new URL("https://link2.com"),
-				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"),
-				Collections.emptyMap());
+				"cli2", "sec2", new URL("https://loginre2.com"), new URL("https://linkre2.com"))
+				.build();
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv("Prov1", cfg1));
@@ -228,10 +228,10 @@ public class AuthenticationConstructorTest {
 	@Test
 	public void withIDsFailNullEmpty() throws Exception {
 		final AuthStorage storage = mock(AuthStorage.class);
-		final IdentityProviderConfig cfg1 = new IdentityProviderConfig(
+		final IdentityProviderConfig cfg1 = IdentityProviderConfig.getBuilder(
 				"prov1", new URL("https://login1.com"), new URL("https://link1.com"),
-				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"),
-				Collections.emptyMap());
+				"cli1", "sec1", new URL("https://loginre1.com"), new URL("https://linkre1.com"))
+				.build();
 		
 		final Set<IdentityProvider> ids = new HashSet<>();
 		ids.add(new NullIdProv(null, cfg1));

--- a/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
@@ -45,6 +45,8 @@ import us.kbase.test.auth2.TestCommon;
 
 public class GlobusIdentityProviderTest {
 	
+	//TODO TEST ignore secondary identities
+	
 	private static final String CONTENT_TYPE = "content-type";
 	private static final String ACCEPT = "accept";
 	private static final String APP_JSON = "application/json";
@@ -94,15 +96,15 @@ public class GlobusIdentityProviderTest {
 	private static final IdentityProviderConfig CFG;
 	static {
 		try {
-			CFG = new IdentityProviderConfig(
+			CFG = IdentityProviderConfig.getBuilder(
 					GlobusIdentityProviderFactory.class.getName(),
 					new URL("https://login.com"),
 					new URL("https://setapiurl.com"),
 					"foo",
 					"bar",
 					new URL("https://loginredir.com"),
-					new URL("https://linkredir.com"),
-					Collections.emptyMap());
+					new URL("https://linkredir.com"))
+					.build();
 		} catch (IdentityProviderConfigurationException | MalformedURLException e) {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
@@ -148,15 +150,15 @@ public class GlobusIdentityProviderTest {
 	@Test
 	public void createFail() throws Exception {
 		failCreate(null, new NullPointerException("idc"));
-		failCreate(new IdentityProviderConfig(
+		failCreate(IdentityProviderConfig.getBuilder(
 				"foo",
 				CFG.getLoginURL(),
 				CFG.getApiURL(),
 				CFG.getClientID(),
 				CFG.getClientSecret(),
 				CFG.getLoginRedirectURL(),
-				CFG.getLinkRedirectURL(),
-				Collections.emptyMap()),
+				CFG.getLinkRedirectURL())
+				.build(),
 				new IllegalArgumentException(
 						"Configuration class name doesn't match factory class name: foo"));
 	}
@@ -501,15 +503,15 @@ public class GlobusIdentityProviderTest {
 	
 	private IdentityProviderConfig getTestIDConfig(final Map<String, String> customConfig)
 			throws MalformedURLException, IdentityProviderConfigurationException {
-		return new IdentityProviderConfig(
+		return IdentityProviderConfig.getBuilder(
 				GlobusIdentityProviderFactory.class.getName(),
 				new URL("https://login.com"),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				"foo",
 				"bar",
 				new URL("https://loginredir.com"),
-				new URL("https://linkredir.com"),
-				customConfig);
+				new URL("https://linkredir.com"))
+				.build();
 	}
 
 	private String getBasicAuth(final IdentityProviderConfig idconfig) {
@@ -673,15 +675,15 @@ public class GlobusIdentityProviderTest {
 	public void getIdentityWithoutSecondariesAndLinkURL() throws Exception {
 		final String clientID = "clientID2";
 		final String authCode = "authcode2";
-		final IdentityProviderConfig idconfig = new IdentityProviderConfig(
+		final IdentityProviderConfig idconfig = IdentityProviderConfig.getBuilder(
 				GlobusIdentityProviderFactory.class.getName(),
 				new URL("https://login2.com"),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				clientID,
 				"bar2",
 				new URL("https://loginredir2.com"),
-				new URL("https://linkredir2.com"),
-				Collections.emptyMap());
+				new URL("https://linkredir2.com"))
+				.build();
 		final IdentityProvider idp = new GlobusIdentityProvider(idconfig);
 		final String bauth = getBasicAuth(idconfig);
 		

--- a/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
@@ -9,7 +9,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -92,15 +91,15 @@ public class GoogleIdentityProviderTest {
 	private static final IdentityProviderConfig CFG;
 	static {
 		try {
-			CFG = new IdentityProviderConfig(
+			CFG = IdentityProviderConfig.getBuilder(
 					GoogleIdentityProviderFactory.class.getName(),
 					new URL("https://glogin.com"),
 					new URL("https://gsetapiurl.com"),
 					"gfoo",
 					"gbar",
 					new URL("https://gloginredir.com"),
-					new URL("https://glinkredir.com"),
-					Collections.emptyMap());
+					new URL("https://glinkredir.com"))
+					.build();
 		} catch (IdentityProviderConfigurationException | MalformedURLException e) {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
@@ -145,15 +144,15 @@ public class GoogleIdentityProviderTest {
 	@Test
 	public void createFail() throws Exception {
 		failCreate(null, new NullPointerException("idc"));
-		failCreate(new IdentityProviderConfig(
+		failCreate(IdentityProviderConfig.getBuilder(
 				"foo",
 				CFG.getLoginURL(),
 				CFG.getApiURL(),
 				CFG.getClientID(),
 				CFG.getClientSecret(),
 				CFG.getLoginRedirectURL(),
-				CFG.getLinkRedirectURL(),
-				Collections.emptyMap()),
+				CFG.getLinkRedirectURL())
+				.build(),
 				new IllegalArgumentException(
 						"Configuration class name doesn't match factory class name: foo"));
 	}
@@ -192,15 +191,15 @@ public class GoogleIdentityProviderTest {
 	private IdentityProviderConfig getTestIDConfig()
 			throws IdentityProviderConfigurationException, MalformedURLException,
 			URISyntaxException {
-		return new IdentityProviderConfig(
+		return IdentityProviderConfig.getBuilder(
 				GoogleIdentityProviderFactory.class.getName(),
 				new URL("https://glogin.com"),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				"gfoo",
 				"gbar",
 				new URL("https://gloginredir.com"),
-				new URL("https://glinkredir.com"),
-				Collections.emptyMap());
+				new URL("https://glinkredir.com"))
+				.build();
 	}
 	
 	@Test
@@ -388,15 +387,15 @@ public class GoogleIdentityProviderTest {
 	@Test
 	public void getIdentityWithLinkURL() throws Exception {
 		final String authCode = "authcode2";
-		final IdentityProviderConfig idconfig = new IdentityProviderConfig(
+		final IdentityProviderConfig idconfig = IdentityProviderConfig.getBuilder(
 				GoogleIdentityProviderFactory.class.getName(),
 				new URL("https://glogin2.com"),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				"someclient",
 				"bar2",
 				new URL("https://gloginredir2.com"),
-				new URL("https://glinkredir2.com"),
-				Collections.emptyMap());
+				new URL("https://glinkredir2.com"))
+				.build();
 		final IdentityProvider idp = new GoogleIdentityProvider(idconfig);
 		
 		setUpCallAuthToken(authCode, "footoken2", "https://glinkredir2.com",

--- a/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
@@ -91,15 +91,15 @@ public class OrcIDIdentityProviderTest {
 	private static final IdentityProviderConfig CFG;
 	static {
 		try {
-			CFG = new IdentityProviderConfig(
+			CFG = IdentityProviderConfig.getBuilder(
 					OrcIDIdentityProviderFactory.class.getName(),
 					new URL("https://ologin.com"),
 					new URL("https://osetapiurl.com"),
 					"ofoo",
 					"obar",
 					new URL("https://ologinredir.com"),
-					new URL("https://olinkredir.com"),
-					Collections.emptyMap());
+					new URL("https://olinkredir.com"))
+					.build();
 		} catch (IdentityProviderConfigurationException | MalformedURLException e) {
 			throw new RuntimeException("Fix yer tests newb", e);
 		}
@@ -144,15 +144,15 @@ public class OrcIDIdentityProviderTest {
 	@Test
 	public void createFail() throws Exception {
 		failCreate(null, new NullPointerException("idc"));
-		failCreate(new IdentityProviderConfig(
+		failCreate(IdentityProviderConfig.getBuilder(
 				"foo",
 				CFG.getLoginURL(),
 				CFG.getApiURL(),
 				CFG.getClientID(),
 				CFG.getClientSecret(),
 				CFG.getLoginRedirectURL(),
-				CFG.getLinkRedirectURL(),
-				Collections.emptyMap()),
+				CFG.getLinkRedirectURL())
+				.build(),
 				new IllegalArgumentException(
 						"Configuration class name doesn't match factory class name: foo"));
 	}
@@ -191,15 +191,15 @@ public class OrcIDIdentityProviderTest {
 	private IdentityProviderConfig getTestIDConfig()
 			throws IdentityProviderConfigurationException, MalformedURLException,
 			URISyntaxException {
-		return new IdentityProviderConfig(
+		return IdentityProviderConfig.getBuilder(
 				OrcIDIdentityProviderFactory.class.getName(),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				"ofoo",
 				"obar",
 				new URL("https://ologinredir.com"),
-				new URL("https://olinkredir.com"),
-				Collections.emptyMap());
+				new URL("https://olinkredir.com"))
+				.build();
 	}
 	
 	@Test
@@ -369,15 +369,15 @@ public class OrcIDIdentityProviderTest {
 	private void getIdentityWithLinkURL(final String email, final Map<String, Object> response)
 			throws Exception {
 		final String authCode = "authcode2";
-		final IdentityProviderConfig idconfig = new IdentityProviderConfig(
+		final IdentityProviderConfig idconfig = IdentityProviderConfig.getBuilder(
 				OrcIDIdentityProviderFactory.class.getName(),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				new URL("http://localhost:" + mockClientAndServer.getPort()),
 				"someclient",
 				"bar2",
 				new URL("https://ologinredir2.com"),
-				new URL("https://olinkredir2.com"),
-				Collections.emptyMap());
+				new URL("https://olinkredir2.com"))
+				.build();
 		final IdentityProvider idp = new OrcIDIdentityProvider(idconfig);
 		final String orcID = "0000-0001-1234-5678";
 		


### PR DESCRIPTION
In preparation for adding more optional arguments. Don't want to have to
add more constructors.