### PR TITLE
Add test mode to deployment config

### DIFF
--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -1,4 +1,5 @@
 [authserv2]
+test-mode-enabled={{ default .Env.test_mode_enabled false}}
 mongo-host={{ default .Env.mongo_host "ci-mongo" }}
 mongo-db={{ default .Env.mongo_db "auth2" }}
 mongo-user={{ default .Env.mongo_user "" }}


### PR DESCRIPTION
Uses the `test_mode_enabled` environment variable, with default=false