### PR TITLE
Add builder to AuthExternalConfig

### DIFF
--- a/src/us/kbase/auth2/service/ui/Admin.java
+++ b/src/us/kbase/auth2/service/ui/Admin.java
@@ -640,8 +640,9 @@ public class Admin {
 		final ConfigItem<Boolean, Action> ignore = ConfigItem.set(!nullOrEmpty(ignoreip));
 		final ConfigItem<Boolean, Action> stack = ConfigItem.set(!nullOrEmpty(showstack));
 		
-		final AuthExternalConfig<Action> ext = new AuthExternalConfig<>(
-				new URLSet<>(postlogin, completelogin, postlink, completelink), ignore, stack);
+		final AuthExternalConfig<Action> ext = AuthExternalConfig.getBuilder(
+				new URLSet<>(postlogin, completelogin, postlink, completelink), ignore, stack)
+				.build();
 		try {
 			auth.updateConfig(getTokenFromCookie(headers, cfg.getTokenCookieName()),
 					AuthConfigUpdate.getBuilder().withLoginAllowed(!nullOrEmpty(allowLogin))
@@ -784,14 +785,15 @@ public class Admin {
 			throw new MissingParameterException("JSON body missing");
 		}
 		config.exceptOnAdditionalProperties();
-		final AuthExternalConfig<Action> ext = new AuthExternalConfig<>(
+		final AuthExternalConfig<Action> ext = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						config.getAllowedLoginURLPrefix(),
 						config.getCompleteLoginURL(),
 						config.getPostLinkURL(),
 						config.getCompleteLinkURL()),
 				config.getIgnoreIP(),
-				config.getShowStack());
+				config.getShowStack())
+				.build();
 		try {
 			auth.updateConfig(getToken(token),
 					AuthConfigUpdate.getBuilder().withNullableLoginAllowed(config.getAllowLogin())

--- a/src/us/kbase/test/auth2/service/AuthExternalConfigTest.java
+++ b/src/us/kbase/test/auth2/service/AuthExternalConfigTest.java
@@ -34,6 +34,34 @@ public class AuthExternalConfigTest {
 	}
 	
 	@Test
+	public void URLSetNoAction() {
+		final URLSet<Action> urlSet = URLSet.noAction();
+		
+		assertThat("incorrect log prefix", urlSet.getAllowedLoginRedirectPrefix(),
+				is(ConfigItem.noAction()));
+		assertThat("incorrect login redirect", urlSet.getCompleteLoginRedirect(),
+				is(ConfigItem.noAction()));
+		assertThat("incorrect post link redirect", urlSet.getPostLinkRedirect(),
+				is(ConfigItem.noAction()));
+		assertThat("incorrect link redirect", urlSet.getCompleteLinkRedirect(),
+				is(ConfigItem.noAction()));
+	}
+	
+	@Test
+	public void URLSetRemove() {
+		final URLSet<Action> urlSet = URLSet.remove();
+		
+		assertThat("incorrect log prefix", urlSet.getAllowedLoginRedirectPrefix(),
+				is(ConfigItem.remove()));
+		assertThat("incorrect login redirect", urlSet.getCompleteLoginRedirect(),
+				is(ConfigItem.remove()));
+		assertThat("incorrect post link redirect", urlSet.getPostLinkRedirect(),
+				is(ConfigItem.remove()));
+		assertThat("incorrect link redirect", urlSet.getCompleteLinkRedirect(),
+				is(ConfigItem.remove()));
+	}
+	
+	@Test
 	public void constructURLSetAction() throws Exception {
 		final URLSet<Action> urlSet = new URLSet<>(
 				ConfigItem.noAction(),
@@ -121,14 +149,15 @@ public class AuthExternalConfigTest {
 	
 	@Test
 	public void constructNoAction() throws Exception {
-		final AuthExternalConfig<Action> cfg = new AuthExternalConfig<>(
+		final AuthExternalConfig<Action> cfg = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.noAction(),
 						ConfigItem.noAction(),
 						ConfigItem.noAction(),
 						ConfigItem.noAction()),
 				ConfigItem.noAction(),
-				ConfigItem.noAction());
+				ConfigItem.noAction())
+				.build();
 		
 		assertThat("incorrect trace", cfg.isIncludeStackTraceInResponse(),
 				is(ConfigItem.noAction()));
@@ -146,14 +175,15 @@ public class AuthExternalConfigTest {
 	
 	@Test
 	public void constructRemove() throws Exception {
-		final AuthExternalConfig<Action> cfg = new AuthExternalConfig<>(
+		final AuthExternalConfig<Action> cfg = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.remove(),
 						ConfigItem.remove(),
 						ConfigItem.remove(),
 						ConfigItem.remove()),
 				ConfigItem.remove(),
-				ConfigItem.remove());
+				ConfigItem.remove())
+				.build();
 		
 		assertThat("incorrect trace", cfg.isIncludeStackTraceInResponse(),
 				is(ConfigItem.remove()));
@@ -180,14 +210,15 @@ public class AuthExternalConfigTest {
 	
 	@Test
 	public void constructSet() throws Exception {
-		final AuthExternalConfig<Action> cfg = new AuthExternalConfig<>(
+		final AuthExternalConfig<Action> cfg = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.set(new URL("http://u1.com")),
 						ConfigItem.set(new URL("http://u2.com")),
 						ConfigItem.set(new URL("http://u3.com")),
 						ConfigItem.set(new URL("http://u4.com"))),
 				ConfigItem.set(true),
-				ConfigItem.set(false));
+				ConfigItem.set(false))
+				.build();
 		
 		assertThat("incorrect trace", cfg.isIncludeStackTraceInResponse(),
 				is(ConfigItem.set(false)));
@@ -214,13 +245,14 @@ public class AuthExternalConfigTest {
 	
 	@Test
 	public void constructState() throws Exception {
-		final AuthExternalConfig<State> cfg = new AuthExternalConfig<>(
+		final AuthExternalConfig<State> cfg = AuthExternalConfig.getBuilder(
 				new URLSet<>(ConfigItem.emptyState(),
 						ConfigItem.state(new URL("http://u2.com")),
 						ConfigItem.state(new URL("http://u3.com")),
 						ConfigItem.emptyState()),
 				ConfigItem.emptyState(),
-				ConfigItem.state(true));
+				ConfigItem.state(true))
+				.build();
 		
 		assertThat("incorrect trace", cfg.isIncludeStackTraceInResponse(),
 				is(ConfigItem.state(true)));
@@ -236,14 +268,15 @@ public class AuthExternalConfigTest {
 		assertThat("incorrect toMap", cfg.toMap(), is(Collections.emptyMap()));
 		
 		// swap the boolean states
-		final AuthExternalConfig<State> cfg2 = new AuthExternalConfig<>(
+		final AuthExternalConfig<State> cfg2 = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.emptyState(),
 						ConfigItem.state(new URL("http://u2.com")),
 						ConfigItem.state(new URL("http://u3.com")),
 						ConfigItem.emptyState()),
 				ConfigItem.state(true),
-				ConfigItem.emptyState());
+				ConfigItem.emptyState())
+				.build();
 		
 		assertThat("incorrect trace", cfg2.isIncludeStackTraceInResponse(),
 				is(ConfigItem.emptyState()));
@@ -254,14 +287,15 @@ public class AuthExternalConfigTest {
 	
 	@Test
 	public void constructMixed() throws Exception {
-		final AuthExternalConfig<Action> cfg = new AuthExternalConfig<>(
+		final AuthExternalConfig<Action> cfg = AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.remove(),
 						ConfigItem.set(new URL("http://u2.com")),
 						ConfigItem.noAction(),
 						ConfigItem.set(new URL("http://u4.com"))),
 				ConfigItem.remove(),
-				ConfigItem.set(false));
+				ConfigItem.set(false))
+				.build();
 		
 		assertThat("incorrect trace", cfg.isIncludeStackTraceInResponse(),
 				is(ConfigItem.set(false)));
@@ -320,21 +354,21 @@ public class AuthExternalConfigTest {
 		final URLSet<Action> setURL = new URLSet<>(setU, setU, setU, setU);
 		final URLSet<State> staURL = new URLSet<>(staU, staU, staU, staU);
 		
-		failConstruct(null, setB, setB,
+		failBuild(null, setB, setB,
 				new NullPointerException("urlSet"));
-		failConstruct(setURL, null, setB,
+		failBuild(setURL, null, setB,
 				new NullPointerException("ignoreIPHeaders"));
-		failConstruct(staURL, staB, null,
+		failBuild(staURL, staB, null,
 				new NullPointerException("includeStackTraceInResponse"));
 	}
 	
-	private <T extends ConfigAction> void failConstruct(
+	private <T extends ConfigAction> void failBuild(
 			final URLSet<T> urlSet,
 			final ConfigItem<Boolean, T> ignoreIPHeaders,
 			final ConfigItem<Boolean, T> includeStackTraceInResponse,
 			final Exception expected) {
 		try {
-			new AuthExternalConfig<>(urlSet, ignoreIPHeaders, includeStackTraceInResponse);
+			AuthExternalConfig.getBuilder(urlSet, ignoreIPHeaders, includeStackTraceInResponse);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, expected);
@@ -347,14 +381,15 @@ public class AuthExternalConfigTest {
 		final AuthExternalConfig<State> cfg = new AuthExternalConfigMapper()
 				.fromMap(Collections.emptyMap());
 		
-		assertThat("incorrect config", cfg, is(new AuthExternalConfig<>(
+		assertThat("incorrect config", cfg, is(AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState()),
 				ConfigItem.emptyState(),
-				ConfigItem.emptyState())));
+				ConfigItem.emptyState())
+				.build()));
 	}
 	
 	@Test
@@ -369,14 +404,15 @@ public class AuthExternalConfigTest {
 						.with("includeStackTraceInResponse", ConfigItem.emptyState())
 						.build());
 		
-		assertThat("incorrect config", cfg, is(new AuthExternalConfig<>(
+		assertThat("incorrect config", cfg, is(AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState(),
 						ConfigItem.emptyState()),
 				ConfigItem.emptyState(),
-				ConfigItem.emptyState())));
+				ConfigItem.emptyState())
+				.build()));
 	}
 	
 	@Test
@@ -391,14 +427,15 @@ public class AuthExternalConfigTest {
 						.with("includeStackTraceInResponse", ConfigItem.state("false"))
 						.build());
 		
-		assertThat("incorrect config", cfg, is(new AuthExternalConfig<>(
+		assertThat("incorrect config", cfg, is(AuthExternalConfig.getBuilder(
 				new URLSet<>(
 						ConfigItem.state(new URL("http://u1.com")),
 						ConfigItem.state(new URL("http://u2.com")),
 						ConfigItem.state(new URL("http://u3.com")),
 						ConfigItem.state(new URL("http://u4.com"))),
 				ConfigItem.state(true),
-				ConfigItem.state(false))));
+				ConfigItem.state(false))
+				.build()));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -352,14 +352,15 @@ public class ServiceCommonTest {
 	public void isIgnoreIPsInHeaders() throws Exception {
 		final Authentication auth = mock(Authentication.class);
 		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
-				.thenReturn(new AuthExternalConfig<>(
+				.thenReturn(AuthExternalConfig.getBuilder(
 						new URLSet<>(
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState()),
 						ConfigItem.state(false),
-						ConfigItem.state(false)));
+						ConfigItem.state(false))
+						.build());
 		assertThat("incorrect ignore IPs setting", ServiceCommon.isIgnoreIPsInHeaders(auth),
 				is(false));
 	}

--- a/src/us/kbase/test/auth2/service/ui/AdminTest.java
+++ b/src/us/kbase/test/auth2/service/ui/AdminTest.java
@@ -74,14 +74,15 @@ public class AdminTest {
 		when(auth.getConfig(eq(new IncomingToken("token")), any(AuthExternalConfigMapper.class)))
 				.thenReturn(new AuthConfigSetWithUpdateTime<AuthExternalConfig<State>>(
 						new AuthConfig(false, null, null),
-						new AuthExternalConfig<>(
+						AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.emptyState(),
 										ConfigItem.emptyState(),
 										ConfigItem.emptyState(),
 										ConfigItem.emptyState()),
 								ConfigItem.emptyState(),
-								ConfigItem.emptyState()),
+								ConfigItem.emptyState())
+						.build(),
 						45000));
 		
 		assertThat("incorrect config", admin.getConfig(headers, uriInfo), is(MapBuilder.newHashMap()
@@ -122,7 +123,7 @@ public class AdminTest {
 		when(uriInfo.getPath()).thenReturn("/admin/config/token/");
 		
 		when(auth.getConfig(eq(new IncomingToken("token")), any(AuthExternalConfigMapper.class)))
-				.thenReturn(new AuthConfigSetWithUpdateTime<AuthExternalConfig<State>>(
+				.thenReturn(new AuthConfigSetWithUpdateTime<>(
 						new AuthConfig(
 								true,
 								ImmutableMap.of(
@@ -135,14 +136,15 @@ public class AdminTest {
 										TokenLifetimeType.LOGIN, 1000 * 24 * 3600 * 84L,
 										TokenLifetimeType.SERV, 1000 * 24 * 3600 * 2L
 								)),
-						new AuthExternalConfig<>(
+						AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.state(new URL("http://u1.com")),
 										ConfigItem.state(new URL("http://u2.com")),
 										ConfigItem.state(new URL("http://u3.com")),
 										ConfigItem.state(new URL("http://u4.com"))),
 								ConfigItem.state(true),
-								ConfigItem.state(true)),
+								ConfigItem.state(true))
+						.build(),
 						52000));
 		
 		assertThat("incorrect config", admin.getConfig(headers, uriInfo), is(MapBuilder.newHashMap()
@@ -261,7 +263,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(false)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.remove(),
 										ConfigItem.remove(),
@@ -269,7 +271,7 @@ public class AdminTest {
 										ConfigItem.remove()),
 								ConfigItem.set(false),
 								ConfigItem.set(false)
-								))
+								).build())
 						.build());
 	}
 	
@@ -291,7 +293,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(false)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.remove(),
 										ConfigItem.remove(),
@@ -299,7 +301,7 @@ public class AdminTest {
 										ConfigItem.remove()),
 								ConfigItem.set(false),
 								ConfigItem.set(false)
-								))
+								).build())
 						.build());
 	}
 	
@@ -321,7 +323,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(true)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.set(new URL("http://u1.com")),
 										ConfigItem.set(new URL("http://u2.com")),
@@ -329,7 +331,7 @@ public class AdminTest {
 										ConfigItem.set(new URL("http://u4.com"))),
 								ConfigItem.set(true),
 								ConfigItem.set(true)
-								))
+								).build())
 						.build());
 	}
 	
@@ -407,14 +409,15 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(false)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.remove(),
 										ConfigItem.remove(),
 										ConfigItem.remove(),
 										ConfigItem.remove()),
 								ConfigItem.set(false),
-								ConfigItem.set(false)))
+								ConfigItem.set(false)
+								).build())
 						.build());
 		
 		failUpdateBasic(admin, headers, "", "", "", "", new InvalidTokenException());
@@ -452,7 +455,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withNullableLoginAllowed(null)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.noAction(),
 										ConfigItem.noAction(),
@@ -460,7 +463,7 @@ public class AdminTest {
 										ConfigItem.noAction()),
 								ConfigItem.noAction(),
 								ConfigItem.noAction()
-								))
+								).build())
 						.build());
 	}
 	
@@ -479,7 +482,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withNullableLoginAllowed(null)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.noAction(),
 										ConfigItem.noAction(),
@@ -487,7 +490,7 @@ public class AdminTest {
 										ConfigItem.noAction()),
 								ConfigItem.noAction(),
 								ConfigItem.noAction()
-								))
+								).build())
 						.build());
 	}
 	
@@ -512,7 +515,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withNullableLoginAllowed(null)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.remove(),
 										ConfigItem.remove(),
@@ -520,7 +523,7 @@ public class AdminTest {
 										ConfigItem.remove()),
 								ConfigItem.remove(),
 								ConfigItem.remove()
-								))
+								).build())
 						.build());
 	}
 	
@@ -538,7 +541,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(true)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.set(new URL("http://u1.com")),
 										ConfigItem.set(new URL("http://u2.com")),
@@ -546,7 +549,7 @@ public class AdminTest {
 										ConfigItem.set(new URL("http://u4.com"))),
 								ConfigItem.set(true),
 								ConfigItem.set(true)
-								))
+								).build())
 						.build());
 	}
 	
@@ -564,7 +567,7 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withLoginAllowed(false)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.set(new URL("http://u1.com")),
 										ConfigItem.set(new URL("http://u2.com")),
@@ -572,7 +575,7 @@ public class AdminTest {
 										ConfigItem.set(new URL("http://u4.com"))),
 								ConfigItem.set(false),
 								ConfigItem.set(false)
-								))
+								).build())
 						.build());
 	}
 	
@@ -680,14 +683,15 @@ public class AdminTest {
 				new IncomingToken("token"),
 				AuthConfigUpdate.getBuilder()
 						.withNullableLoginAllowed(null)
-						.withExternalConfig(new AuthExternalConfig<>(
+						.withExternalConfig(AuthExternalConfig.getBuilder(
 								new URLSet<>(
 										ConfigItem.noAction(),
 										ConfigItem.noAction(),
 										ConfigItem.noAction(),
 										ConfigItem.noAction()),
 								ConfigItem.noAction(),
-								ConfigItem.noAction()))
+								ConfigItem.noAction()
+								).build())
 						.build());
 		
 		final Boolean n = null;

--- a/src/us/kbase/test/auth2/service/ui/UIUtilsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/UIUtilsTest.java
@@ -603,14 +603,15 @@ public class UIUtilsTest {
 	public void getExternalURI() throws Exception {
 		final Authentication auth = mock(Authentication.class);
 		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
-				.thenReturn(new AuthExternalConfig<>(
+				.thenReturn(AuthExternalConfig.getBuilder(
 						new URLSet<>(
 								ConfigItem.state(new URL("http://whee/whoo")),
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState()),
 						ConfigItem.state(false),
-						ConfigItem.state(false)));
+						ConfigItem.state(false))
+						.build());
 		
 		final URI ret = UIUtils.getExternalConfigURI(
 				auth, e -> e.getURLSet().getAllowedLoginRedirectPrefix(), "/foo");
@@ -622,14 +623,15 @@ public class UIUtilsTest {
 	public void getExternalURIDefault() throws Exception {
 		final Authentication auth = mock(Authentication.class);
 		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
-				.thenReturn(new AuthExternalConfig<>(
+				.thenReturn(AuthExternalConfig.getBuilder(
 						new URLSet<>(
 								ConfigItem.emptyState(),
 								ConfigItem.state(new URL("http://whee/whoo")),
 								ConfigItem.emptyState(),
 								ConfigItem.emptyState()),
 						ConfigItem.state(false),
-						ConfigItem.state(false)));
+						ConfigItem.state(false))
+						.build());
 		
 		final URI ret = UIUtils.getExternalConfigURI(
 				auth, e -> e.getURLSet().getAllowedLoginRedirectPrefix(), "https://foo");


### PR DESCRIPTION
So we can add optional items without changing code in places where the
optional items aren't important and without making a new constructor
every time