### PR TITLE
Pass environment to identity providers on link or login

### DIFF
--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -39,11 +39,14 @@ public interface IdentityProvider {
 	 * @param authcode the authcode returned from the identity provider on the redirect after
 	 * login.
 	 * @param link whether the authcode was associated with a login or link url.
+	 * @param environment the name of the environment that was used when configuring the redirect
+	 * url. Pass null for the default environment.
 	 * @return the set of identities returned from the provider.
 	 * @throws IdentityRetrievalException if getting the idenities failed.
+	 * @throws NoSuchEnvironmentException if there is no such environment configured. 
 	 */
-	Set<RemoteIdentity> getIdentities(String authcode, boolean link)
-			throws IdentityRetrievalException;
+	Set<RemoteIdentity> getIdentities(String authcode, boolean link, String environment)
+			throws IdentityRetrievalException, NoSuchEnvironmentException;
 	
 	/** Get the names of the additional environments beyond the default environment that are
 	 * configured. See {@link #getLoginURL(String, boolean, String)}.

--- a/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
@@ -156,15 +156,18 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 		}
 		
 		@Override
-		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		public Set<RemoteIdentity> getIdentities(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			/* Note authcode only works once. After that globus returns
 			 * {error=invalid_grant}
 			 */
 			if (authcode == null || authcode.trim().isEmpty()) {
 				throw new IllegalArgumentException("authcode cannot be null or empty");
 			}
-			final String accessToken = getAccessToken(authcode, link);
+			final String accessToken = getAccessToken(authcode, link, environment);
 			final Idents idents = getPrimaryIdentity(accessToken, ignoreSecondaries);
 			final Set<RemoteIdentity> secondaries = getSecondaryIdentities(
 					accessToken, idents.secondaryIDs);
@@ -287,14 +290,15 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 			return ret;
 		}
 	
-		private String getAccessToken(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		private String getAccessToken(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			
 			final MultivaluedMap<String, String> formParameters = new MultivaluedHashMap<>();
 			formParameters.add("code", authcode);
-			formParameters.add("redirect_uri", link ?
-					cfg.getLinkRedirectURL().toString() :
-					cfg.getLoginRedirectURL().toString());
+			formParameters.add("redirect_uri", getRedirectURL(link, environment).toString());
 			formParameters.add("grant_type", "authorization_code");
 			
 			final URI target = UriBuilder.fromUri(toURI(cfg.getApiURL())).path(TOKEN_PATH).build();

--- a/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
@@ -145,12 +145,15 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 		}
 	
 		@Override
-		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		public Set<RemoteIdentity> getIdentities(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			if (authcode == null || authcode.trim().isEmpty()) {
 				throw new IllegalArgumentException("authcode cannot be null or empty");
 			}
-			final String accessToken = getAccessToken(authcode, link);
+			final String accessToken = getAccessToken(authcode, link, environment);
 			final RemoteIdentity ri = getIdentity(accessToken);
 			return new HashSet<>(Arrays.asList(ri));
 		}
@@ -220,14 +223,15 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 			}
 		}
 	
-		private String getAccessToken(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		private String getAccessToken(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			final MultivaluedMap<String, String> formParameters =
 					new MultivaluedHashMap<>();
 			formParameters.add("code", authcode);
-			formParameters.add("redirect_uri", link ?
-					cfg.getLinkRedirectURL().toString() :
-					cfg.getLoginRedirectURL().toString());
+			formParameters.add("redirect_uri", getRedirectURL(link, environment).toString());
 			formParameters.add("grant_type", "authorization_code");
 			formParameters.add("client_id", cfg.getClientID());
 			formParameters.add("client_secret", cfg.getClientSecret());

--- a/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
@@ -139,12 +139,16 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 		}
 	
 		@Override
-		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		public Set<RemoteIdentity> getIdentities(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			if (authcode == null || authcode.trim().isEmpty()) {
 				throw new IllegalArgumentException("authcode cannot be null or empty");
 			}
-			final OrcIDAccessTokenResponse accessToken = getAccessToken(authcode, link);
+			final OrcIDAccessTokenResponse accessToken = getAccessToken(
+					authcode, link, environment);
 			final RemoteIdentity ri = getIdentity(accessToken);
 			return new HashSet<>(Arrays.asList(ri));
 		}
@@ -229,14 +233,15 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 			}
 		}
 		
-		private OrcIDAccessTokenResponse getAccessToken(final String authcode, final boolean link)
-				throws IdentityRetrievalException {
+		private OrcIDAccessTokenResponse getAccessToken(
+				final String authcode,
+				final boolean link,
+				final String environment)
+				throws IdentityRetrievalException, NoSuchEnvironmentException {
 			final MultivaluedMap<String, String> formParameters =
 					new MultivaluedHashMap<>();
 			formParameters.add("code", authcode);
-			formParameters.add("redirect_uri", link ?
-					cfg.getLinkRedirectURL().toString() :
-					cfg.getLoginRedirectURL().toString());
+			formParameters.add("redirect_uri", getRedirectURL(link, environment).toString());
 			formParameters.add("grant_type", "authorization_code");
 			formParameters.add("client_id", cfg.getClientID());
 			formParameters.add("client_secret", cfg.getClientSecret());

--- a/src/us/kbase/auth2/service/ui/Link.java
+++ b/src/us/kbase/auth2/service/ui/Link.java
@@ -171,7 +171,7 @@ public class Link {
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthenticationException, NoSuchProviderException,
 				AuthStorageException, LinkFailedException, UnauthorizedException,
-				NoTokenProvidedException {
+				NoTokenProvidedException, NoSuchEnvironmentException {
 		
 		//provider cannot be null or empty here since it's a path param
 		final MultivaluedMap<String, String> qps = uriInfo.getQueryParameters();
@@ -184,7 +184,7 @@ public class Link {
 		} else {
 			checkState(state, retstate);
 			final IncomingToken token = getLinkInProcessToken(userCookie);
-			final LinkToken lt = auth.link(token, provider, authcode);
+			final LinkToken lt = auth.link(token, provider, authcode, null); //TODO NOW pass env
 			if (lt.isLinked()) {
 				tt = Optional.absent();
 			} else {

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -254,7 +254,7 @@ public class Login {
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthStorageException,
 				IllegalParameterException, UnauthorizedException, NoSuchIdentityProviderException,
-				IdentityRetrievalException, AuthenticationException{
+				IdentityRetrievalException, AuthenticationException, NoSuchEnvironmentException{
 		
 		// provider cannot be null or empty since it's a path param
 		final URI redirectURI = getPostLoginRedirectURI(redirect, UIPaths.ME_ROOT); // fail early
@@ -269,7 +269,7 @@ public class Login {
 			checkState(state, retstate);
 			final TokenCreationContext tcc = getTokenContext(
 					userAgentParser, req, isIgnoreIPsInHeaders(auth), Collections.emptyMap());
-			lr = auth.login(provider, authcode, tcc);
+			lr = auth.login(provider, authcode, null, tcc); //TODO NOW pass environment
 		}
 		final Response r;
 		// always redirect so the authcode doesn't remain in the title bar

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -153,7 +153,10 @@ public class AuthenticationConstructorTest {
 		}
 
 		@Override
-		public Set<RemoteIdentity> getIdentities(final String authcode, final boolean link)
+		public Set<RemoteIdentity> getIdentities(
+				final String authcode,
+				final boolean link,
+				final String environment)
 				throws IdentityRetrievalException {
 			return Collections.emptySet();
 		}

--- a/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
@@ -53,6 +53,7 @@ import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.auth2.lib.exceptions.NoSuchEnvironmentException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
@@ -228,7 +229,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.now())
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -241,7 +242,7 @@ public class AuthenticationLinkTest {
 
 		when(storage.link(new UserName("baz"), storageRemoteID)).thenReturn(true);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", null);
 		
 		verify(storage).deleteTemporarySessionData(token.getHashedToken());
 		
@@ -287,7 +288,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.now())
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -301,7 +302,7 @@ public class AuthenticationLinkTest {
 
 		when(storage.link(new UserName("baz"), storageRemoteID)).thenReturn(false);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", null);
 		
 		verify(storage).deleteTemporarySessionData(token.getHashedToken());
 		
@@ -344,7 +345,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com")),
 				new RemoteIdentity(
@@ -372,7 +373,7 @@ public class AuthenticationLinkTest {
 		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000)).thenReturn(null);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", null);
 		
 		assertThat("incorrect linktoken", lt, is(new LinkToken(tempToken(
 				tokenID, Instant.ofEpochMilli(10000), 10 * 60 * 1000, "foobar"))));
@@ -391,7 +392,8 @@ public class AuthenticationLinkTest {
 	}
 	
 	@Test
-	public void linkWithTokenForceChoice() throws Exception {
+	public void linkWithTokenForceChoiceWithEnvironment() throws Exception {
+		// tests the non-standard environment
 		final IdentityProvider idp = mock(IdentityProvider.class);
 
 		when(idp.getProviderName()).thenReturn("prov");
@@ -422,7 +424,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, "myenv")).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -437,7 +439,7 @@ public class AuthenticationLinkTest {
 		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000)).thenReturn(null);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", "myenv");
 		
 		assertThat("incorrect linktoken", lt, is(new LinkToken(tempToken(
 				tokenID, Instant.ofEpochMilli(10000), 10 * 60 * 1000, "foobar"))));
@@ -488,7 +490,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -505,7 +507,7 @@ public class AuthenticationLinkTest {
 		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000)).thenReturn(null);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", null);
 		
 		assertThat("incorrect linktoken", lt, is(new LinkToken(tempToken(
 				tokenID, Instant.ofEpochMilli(10000), 10 * 60 * 1000, "foobar"))));
@@ -556,7 +558,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 						new RemoteIdentityDetails("user2", "full2", "f2@g.com")),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id3"),
@@ -587,7 +589,7 @@ public class AuthenticationLinkTest {
 		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000)).thenReturn(null);
 		
-		final LinkToken lt = auth.link(token, "prov", "authcode");
+		final LinkToken lt = auth.link(token, "prov", "authcode", null);
 		
 		assertThat("incorrect linktoken", lt, is(new LinkToken(tempToken(
 				tokenID, Instant.ofEpochMilli(10000), 10 * 60 * 1000, "foobar"))));
@@ -637,13 +639,14 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build());
 		
-		failLinkWithToken(auth, null, "prov", "foo", new NullPointerException("Temporary token"));
-		failLinkWithToken(auth, token, null, "foo", new NullPointerException("provider"));
-		failLinkWithToken(auth, token, "  \t ", "foo",
+		failLinkWithToken(auth, null, "prov", "foo", null,
+				new NullPointerException("Temporary token"));
+		failLinkWithToken(auth, token, null, "foo", null, new NullPointerException("provider"));
+		failLinkWithToken(auth, token, "  \t ", "foo", null,
 				new NoSuchIdentityProviderException("  \t "));
-		failLinkWithToken(auth, token, "prov", null,
+		failLinkWithToken(auth, token, "prov", null, null,
 				new MissingParameterException("authorization code"));
-		failLinkWithToken(auth, token, "prov", "  \n  ",
+		failLinkWithToken(auth, token, "prov", "  \n  ", null,
 				new MissingParameterException("authorization code"));
 	}
 	
@@ -657,7 +660,7 @@ public class AuthenticationLinkTest {
 		
 		final IncomingToken token = new IncomingToken("foobar");
 		
-		failLinkWithToken(auth, token, "prov1", "foo",
+		failLinkWithToken(auth, token, "prov1", "foo", null,
 				new NoSuchIdentityProviderException("prov1"));
 	}
 	
@@ -686,7 +689,7 @@ public class AuthenticationLinkTest {
 						new AuthConfig(false, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		failLinkWithToken(auth, token, "prov", "foo",
+		failLinkWithToken(auth, token, "prov", "foo", null,
 				new NoSuchIdentityProviderException("Prov"));
 	}
 	
@@ -715,7 +718,7 @@ public class AuthenticationLinkTest {
 						new AuthConfig(false, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		failLinkWithToken(auth, token, "prov", "foo",
+		failLinkWithToken(auth, token, "prov", "foo", null,
 				new NoSuchIdentityProviderException("prov"));
 	}
 	
@@ -744,7 +747,7 @@ public class AuthenticationLinkTest {
 		when(storage.getTemporarySessionData(token.getHashedToken())).thenThrow(
 				new NoSuchTokenException("foo"));
 		
-		failLinkWithToken(auth, token, "prov", "foo",
+		failLinkWithToken(auth, token, "prov", "foo", null,
 				new InvalidTokenException("Temporary token"));
 	}
 	
@@ -776,7 +779,7 @@ public class AuthenticationLinkTest {
 				.login(set(REMOTE)))
 				.thenReturn(null);
 		
-		failLinkWithToken(auth, token, "prov", "foo", new InvalidTokenException(
+		failLinkWithToken(auth, token, "prov", "foo", null, new InvalidTokenException(
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
@@ -812,7 +815,7 @@ public class AuthenticationLinkTest {
 				.link(new UserName("whee"), set(REMOTE)))
 				.thenReturn(null);
 		
-		failLinkWithToken(auth, token, "prov", "foo", new InvalidTokenException(
+		failLinkWithToken(auth, token, "prov", "foo", null, new InvalidTokenException(
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
@@ -848,7 +851,7 @@ public class AuthenticationLinkTest {
 		
 		when(storage.getUser(new UserName("baz"))).thenThrow(new NoSuchUserException("baz"));
 		
-		failLinkWithToken(auth, token, "prov", "foo", new RuntimeException(
+		failLinkWithToken(auth, token, "prov", "foo", null, new RuntimeException(
 				"There seems to be an error in the storage system. Token was valid, but no user"));
 	}
 	
@@ -883,7 +886,7 @@ public class AuthenticationLinkTest {
 				.withUserDisabledState(
 						new UserDisabledState("f", new UserName("b"), Instant.now())).build());
 		
-		failLinkWithToken(auth, token, "prov", "foo", new DisabledUserException("baz"));
+		failLinkWithToken(auth, token, "prov", "foo", null, new DisabledUserException("baz"));
 
 		verify(storage).deleteTokens(new UserName("baz"));
 	}
@@ -917,8 +920,45 @@ public class AuthenticationLinkTest {
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
 				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
 		
-		failLinkWithToken(auth, token, "prov", "foo",
+		failLinkWithToken(auth, token, "prov", "foo", null,
 				new LinkFailedException("Cannot link identities to local account foo"));
+	}
+	
+	@Test
+	public void linkWithTokenFailNoSuchEnv() throws Exception {
+		final IdentityProvider idp = mock(IdentityProvider.class);
+
+		when(idp.getProviderName()).thenReturn("Prov");
+		
+		final TestMocks testauth = initTestMocks(set(idp));
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		AuthenticationTester.setConfigUpdateInterval(auth, -1);
+
+		final IncomingToken token = new IncomingToken("foobar");
+		
+		final Map<String, ProviderConfig> providers = ImmutableMap.of(
+				"Prov", new ProviderConfig(true, false, false));
+
+		when(storage.getConfig(isA(CollectingExternalConfigMapper.class)))
+				.thenReturn(new AuthConfigSet<CollectingExternalConfig>(
+						new AuthConfig(false, providers, null),
+						new CollectingExternalConfig(Collections.emptyMap())));
+		
+		when(storage.getTemporarySessionData(token.getHashedToken())).thenReturn(
+				TemporarySessionData.create(UUID.randomUUID(), Instant.now(), Instant.now())
+						.link(new UserName("foo")));
+		
+		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
+				new UserName("foo"), new DisplayName("f"), Instant.now())
+				.withIdentity(REMOTE).build());
+		
+		when(idp.getIdentities("foo", true, "env")).thenThrow(
+				new NoSuchEnvironmentException("env"));
+		
+		failLinkWithToken(auth, token, "prov", "foo", "env",
+				new NoSuchEnvironmentException("env"));
 	}
 	
 	@Test
@@ -951,9 +991,11 @@ public class AuthenticationLinkTest {
 				new UserName("foo"), new DisplayName("f"), Instant.now())
 				.withIdentity(REMOTE).build());
 		
-		when(idp.getIdentities("foo", true)).thenThrow(new IdentityRetrievalException("oh poop"));
+		when(idp.getIdentities("foo", true, null)).thenThrow(
+				new IdentityRetrievalException("oh poop"));
 		
-		failLinkWithToken(auth, token, "prov", "foo", new IdentityRetrievalException("oh poop"));
+		failLinkWithToken(auth, token, "prov", "foo", null,
+				new IdentityRetrievalException("oh poop"));
 	}
 	
 	@Test
@@ -987,7 +1029,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -1001,7 +1043,7 @@ public class AuthenticationLinkTest {
 		doThrow(new NoSuchUserException("baz"))
 				.when(storage).link(new UserName("baz"), storageRemoteID);
 		
-		failLinkWithToken(auth, token, "prov", "authcode", new AuthStorageException(
+		failLinkWithToken(auth, token, "prov", "authcode", null, new AuthStorageException(
 				"User unexpectedly disappeared from the database"));
 	}
 	
@@ -1036,7 +1078,7 @@ public class AuthenticationLinkTest {
 				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
-		when(idp.getIdentities("authcode", true)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("authcode", true, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("Prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"))))
 				.thenReturn(null);
@@ -1050,7 +1092,8 @@ public class AuthenticationLinkTest {
 		doThrow(new LinkFailedException("doodoo"))
 				.when(storage).link(new UserName("baz"), storageRemoteID);
 		
-		failLinkWithToken(auth, token, "prov", "authcode", new LinkFailedException("doodoo"));
+		failLinkWithToken(auth, token, "prov", "authcode", null,
+				new LinkFailedException("doodoo"));
 	}
 	
 	private void failLinkWithToken(
@@ -1058,9 +1101,10 @@ public class AuthenticationLinkTest {
 			final IncomingToken token,
 			final String provider,
 			final String authcode,
+			final String env,
 			final Exception e) {
 		try {
-			auth.link(token, provider, authcode);
+			auth.link(token, provider, authcode, env);
 			fail("exception expected");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
@@ -60,6 +60,7 @@ import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.LinkFailedException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
+import us.kbase.auth2.lib.exceptions.NoSuchEnvironmentException;
 import us.kbase.auth2.lib.exceptions.NoSuchIdentityProviderException;
 import us.kbase.auth2.lib.exceptions.NoSuchRoleException;
 import us.kbase.auth2.lib.exceptions.NoSuchTokenException;
@@ -137,7 +138,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(allowLogin, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("foobar", false, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@g.com"))))
 				.thenReturn(null);
@@ -160,7 +161,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(Instant.ofEpochMilli(30000)).thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", TokenCreationContext.getBuilder()
+		final LoginToken lt = auth.login("prov", "foobar", null, TokenCreationContext.getBuilder()
 				.withNullableAgent("a", "v").build());
 		
 		verify(storage).storeToken(StoredToken.getBuilder(
@@ -225,7 +226,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(allowLogin, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("foobar", false, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@g.com"))))
 				.thenReturn(null);
@@ -252,7 +253,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", CTX);
+		final LoginToken lt = auth.login("prov", "foobar", null, CTX);
 		
 		verify(storage).storeTemporarySessionData(TemporarySessionData.create(
 				tokenID, Instant.ofEpochMilli(20000), 30 * 60 * 1000).login(set(storageRemoteID)),
@@ -269,7 +270,8 @@ public class AuthenticationLoginTest {
 	}
 	
 	@Test
-	public void storeUnlinkedIdentity() throws Exception {
+	public void storeUnlinkedIdentityWithEnvironment() throws Exception {
+		// tests non standard environment
 		final IdentityProvider idp = mock(IdentityProvider.class);
 
 		when(idp.getProviderName()).thenReturn("prov");
@@ -290,7 +292,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("foobar", false, "env2")).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@g.com"))))
 				.thenReturn(null);
@@ -309,7 +311,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", CTX);
+		final LoginToken lt = auth.login("prov", "foobar", "env2", CTX);
 		
 		verify(storage).storeTemporarySessionData(TemporarySessionData.create(
 				tokenID, Instant.ofEpochMilli(20000), 30 * 60 * 1000).login(set(storageRemoteID)),
@@ -347,7 +349,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(new RemoteIdentity(
+		when(idp.getIdentities("foobar", false, null)).thenReturn(set(new RemoteIdentity(
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@g.com")),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
@@ -378,7 +380,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", CTX);
+		final LoginToken lt = auth.login("prov", "foobar", null, CTX);
 		
 		verify(storage).storeTemporarySessionData(TemporarySessionData.create(
 				tokenID, Instant.ofEpochMilli(20000), 30 * 60 * 1000)
@@ -417,7 +419,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(
+		when(idp.getIdentities("foobar", false, null)).thenReturn(set(
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@g.com")),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
@@ -464,7 +466,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", CTX);
+		final LoginToken lt = auth.login("prov", "foobar", null, CTX);
 		
 		verify(storage).storeTemporarySessionData(TemporarySessionData.create(
 				tokenID, Instant.ofEpochMilli(20000), 30 * 60 * 1000)
@@ -503,7 +505,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenReturn(set(
+		when(idp.getIdentities("foobar", false, null)).thenReturn(set(
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@g.com")),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
@@ -539,7 +541,7 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(20000))
 			.thenReturn(null);
 		
-		final LoginToken lt = auth.login("prov", "foobar", CTX);
+		final LoginToken lt = auth.login("prov", "foobar", null, CTX);
 		
 		verify(storage).storeTemporarySessionData(TemporarySessionData.create(
 				tokenID, Instant.ofEpochMilli(20000), 30 * 60 * 1000)
@@ -564,14 +566,14 @@ public class AuthenticationLoginTest {
 		
 		final Authentication auth = initTestMocks(set(idp)).auth;
 		
-		failLogin(auth, null, "foo", CTX, new NullPointerException("provider"));
-		failLogin(auth, "   \t  \n   ", "foo", CTX,
+		failLogin(auth, null, "foo", null, CTX, new NullPointerException("provider"));
+		failLogin(auth, "   \t  \n   ", "foo", null, CTX,
 				new NoSuchIdentityProviderException("   \t  \n   "));
-		failLogin(auth, "prov", null, CTX,
+		failLogin(auth, "prov", null, null, CTX,
 				new MissingParameterException("authorization code"));
-		failLogin(auth, "prov", "    \t \n   ", CTX,
+		failLogin(auth, "prov", "    \t \n   ", null, CTX,
 				new MissingParameterException("authorization code"));
-		failLogin(auth, "prov", "foo", null, new NullPointerException("tokenCtx"));
+		failLogin(auth, "prov", "foo", null, null, new NullPointerException("tokenCtx"));
 	}
 	
 	@Test
@@ -582,7 +584,7 @@ public class AuthenticationLoginTest {
 		
 		final Authentication auth = initTestMocks(set(idp)).auth;
 		
-		failLogin(auth, "prov1", "foo", CTX, new NoSuchIdentityProviderException("prov1"));
+		failLogin(auth, "prov1", "foo", null, CTX, new NoSuchIdentityProviderException("prov1"));
 	}
 	
 	@Test
@@ -605,7 +607,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		failLogin(auth, "prov", "foo", CTX, new NoSuchIdentityProviderException("prov"));
+		failLogin(auth, "prov", "foo", null, CTX, new NoSuchIdentityProviderException("prov"));
 	}
 	
 	@Test
@@ -628,19 +630,47 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, providers, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		when(idp.getIdentities("foobar", false)).thenThrow(new IdentityRetrievalException("foo"));
+		when(idp.getIdentities("foobar", false, null)).thenThrow(
+				new IdentityRetrievalException("foo"));
 		
-		failLogin(auth, "prov", "foobar", CTX, new IdentityRetrievalException("foo"));
+		failLogin(auth, "prov", "foobar", null, CTX, new IdentityRetrievalException("foo"));
+	}
+	
+	@Test
+	public void failLoginNoSuchEnvironment() throws Exception {
+		final IdentityProvider idp = mock(IdentityProvider.class);
+
+		when(idp.getProviderName()).thenReturn("prov");
+		
+		final TestMocks testauth = initTestMocks(set(idp));
+		final AuthStorage storage = testauth.storageMock;
+		final Authentication auth = testauth.auth;
+		
+		AuthenticationTester.setConfigUpdateInterval(auth, -1);
+		
+		final Map<String, ProviderConfig> providers = ImmutableMap.of(
+				"prov", new ProviderConfig(true, false, false));
+
+		when(storage.getConfig(isA(CollectingExternalConfigMapper.class)))
+				.thenReturn(new AuthConfigSet<CollectingExternalConfig>(
+						new AuthConfig(true, providers, null),
+						new CollectingExternalConfig(Collections.emptyMap())));
+		
+		when(idp.getIdentities("foobar", false, "env1")).thenThrow(
+				new NoSuchEnvironmentException("env1"));
+		
+		failLogin(auth, "prov", "foobar", "env1", CTX, new NoSuchEnvironmentException("env1"));
 	}
 	
 	private void failLogin(
 			final Authentication auth,
 			final String provider,
 			final String authcode,
+			final String env,
 			final TokenCreationContext ctx,
 			final Exception e) {
 		try {
-			auth.login(provider, authcode, ctx);
+			auth.login(provider, authcode, env, ctx);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/service/ui/LinkTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest.java
@@ -444,7 +444,7 @@ public class LinkTest {
 		final String state = "foobarstate";
 		
 		final IdentityProvider provmock = MockIdentityProviderFactory.mocks.get("prov1");
-		when(provmock.getIdentities(authcode, true)).thenReturn(set(REMOTE1, REMOTE2));
+		when(provmock.getIdentities(authcode, true, null)).thenReturn(set(REMOTE1, REMOTE2));
 		
 		final NewToken nt = setUpLinkUserAndToken(); //uses REMOTE1
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(
@@ -482,7 +482,7 @@ public class LinkTest {
 		final String state = "foobarstate";
 		
 		final IdentityProvider provmock = MockIdentityProviderFactory.mocks.get("prov1");
-		when(provmock.getIdentities(authcode, true)).thenReturn(set(REMOTE1, REMOTE3));
+		when(provmock.getIdentities(authcode, true, null)).thenReturn(set(REMOTE1, REMOTE3));
 		
 		final NewToken nt = setUpLinkUserAndToken(); //uses REMOTE1
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(
@@ -519,7 +519,7 @@ public class LinkTest {
 		final String state = "foobarstate";
 		
 		final IdentityProvider provmock = MockIdentityProviderFactory.mocks.get("prov1");
-		when(provmock.getIdentities(authcode, true)).thenReturn(set(REMOTE1));
+		when(provmock.getIdentities(authcode, true, null)).thenReturn(set(REMOTE1));
 		
 		final NewToken nt = setUpLinkUserAndToken();
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(
@@ -559,7 +559,8 @@ public class LinkTest {
 		final String state = "foobarstate";
 		
 		final IdentityProvider provmock = MockIdentityProviderFactory.mocks.get("prov1");
-		when(provmock.getIdentities(authcode, true)).thenReturn(set(REMOTE1, REMOTE2, REMOTE3));
+		when(provmock.getIdentities(authcode, true, null)).thenReturn(
+				set(REMOTE1, REMOTE2, REMOTE3));
 		
 		final NewToken nt = setUpLinkUserAndToken(); // uses REMOTE1
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(

--- a/src/us/kbase/test/auth2/service/ui/LoginTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LoginTest.java
@@ -59,7 +59,6 @@ import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.AuthException;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.ErrorType;
-import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -726,13 +725,13 @@ public class LoginTest {
 	}
 
 	private RemoteIdentity loginCompleteSetUpProviderMock(final String authcode)
-			throws IdentityRetrievalException {
+			throws Exception {
 		
 		final IdentityProvider provmock = MockIdentityProviderFactory.mocks.get("prov1");
 		final RemoteIdentity remoteIdentity = new RemoteIdentity(
 				new RemoteIdentityID("prov1", "prov1id"),
 				new RemoteIdentityDetails("user", "full", "email@email.com"));
-		when(provmock.getIdentities(authcode, false)).thenReturn(set(remoteIdentity));
+		when(provmock.getIdentities(authcode, false, null)).thenReturn(set(remoteIdentity));
 		return remoteIdentity;
 	}
 	


### PR DESCRIPTION
Required so the correct redirect url can be selected; otherwise the ID
provider will return an error because the url doesn't match the url
provided when getting the authcode.