### PR TITLE
Handle environments throughout the login and linking process.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@ Auth service work
   * Code documentation
   * Try swagger again - go from code -> docs vs. other way around
   * Server manual, incl user and admin coverage
+  * Interaction diagram for login and link flow w/ I/O, cookies, etc. noted.
 * General
   * Lock local account for X m after Y failed logins - use sshguard or something here
   * Make server root return endpoints

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -27,6 +27,13 @@ template-dir = templates
 # below that start with identity-provider-<provider name> that must be correctly set.
 identity-providers = Globus, Google, OrcID
 
+# A comma separated list of names of alternate environments in which the service operates in
+# addition to the environment served by the default login and link redirect urls.
+# Each environment must specify its own login and link redirect urls. These URLs must be
+# registered with the identity provider as usual. The environment to use for a particular login
+# or link request can be specified via the service interface at login or link start time.
+identity-provider-envs=
+
 # Below are the list of configuration variables for each identity provider. The keys are:
 
 # identity-provider-<provider name>-factory - the java class for the factory that builds the
@@ -50,20 +57,12 @@ identity-providers = Globus, Google, OrcID
 # options will be provided to the identity provider as a set of keys and values where X is the key
 # any Y is the value.
 
-# identity-provider-envs - a comma separated list of names of alternate
-# environments in which the service operates in addition to the environment served by the default
-# login and link redirect urls. Each environment must specify its own login and link redirect
-# urls. These URLs must be registered with the identity provider as usual. The environment
-# to use for a particular login or link request can be specified via the service interface at
-# login or link start time.
-
 # Alternate environment configuration variables:
 # <env> is the environment name as specified in the identity-provider-envs
 # configuration variable.
 #
 # identity-provider-<provider name>-env-<env>-link-redirect - the alternate link redirect url.
 # identity-provider-<provider name>-env-<env>-login-redirect - the alternate login redirect url.
-
 
 identity-provider-Globus-factory = us.kbase.auth2.providers.GlobusIdentityProviderFactory
 identity-provider-Globus-login-url = https://auth.globus.org

--- a/src/us/kbase/auth2/service/AuthExternalConfig.java
+++ b/src/us/kbase/auth2/service/AuthExternalConfig.java
@@ -80,6 +80,15 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 		return environments.get(environment);
 	}
 	
+	// null == return default
+	public URLSet<T> getURLSetOrDefault(final String environment)
+			throws NoSuchEnvironmentException {
+		if (environment == null) {
+			return urlSet;
+		}
+		return getURLSet(environment);
+	}
+	
 	public ConfigItem<Boolean, T> isIgnoreIPHeaders() {
 		return ignoreIPHeaders;
 	}
@@ -487,6 +496,36 @@ public class AuthExternalConfig<T extends ConfigAction> implements ExternalConfi
 						TRUE, FALSE, key));
 			}
 			return ret;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ((environments == null) ? 0 : environments.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			AuthExternalConfigMapper other = (AuthExternalConfigMapper) obj;
+			if (environments == null) {
+				if (other.environments != null) {
+					return false;
+				}
+			} else if (!environments.equals(other.environments)) {
+				return false;
+			}
+			return true;
 		}
 	}
 

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -181,37 +181,34 @@ public class Login {
 	
 	private URL getRedirectURL(final String environment, final String redirect)
 			throws AuthStorageException, IllegalParameterException, NoSuchEnvironmentException {
-		final URL retRedirect;
 		if (nullOrEmpty(redirect)) {
-			retRedirect = null;
-		} else {
-			final URL url;
-			try {
-				url = new URL(redirect);
-				url.toURI();
-			} catch (MalformedURLException | URISyntaxException e) {
-				throw new IllegalParameterException("Illegal redirect URL: " + redirect);
-			}
-			final AuthExternalConfig<State> ext;
-			try {
-				ext = auth.getExternalConfig(new AuthExternalConfigMapper(auth.getEnvironments()));
-			} catch (ExternalConfigMappingException e) {
-				throw new RuntimeException("Dude, like, what just happened?", e);
-			}
-			final ConfigItem<URL, State> login = ext.getURLSetOrDefault(environment)
-					.getAllowedLoginRedirectPrefix();
-			if (login.hasItem()) {
-				if (!redirect.startsWith(login.getItem().toString())) {
-					throw new IllegalParameterException(
-							"Illegal redirect URL: " + redirect);
-				}
-			} else {
-				throw new IllegalParameterException("Post-login redirects are not enabled" +
-						(environment == null ? "" : " for environment " + environment));
-			}
-			retRedirect = url;
+			return null;
 		}
-		return retRedirect;
+		final URL url;
+		try {
+			url = new URL(redirect);
+			url.toURI();
+		} catch (MalformedURLException | URISyntaxException e) {
+			throw new IllegalParameterException("Illegal redirect URL: " + redirect);
+		}
+		final AuthExternalConfig<State> ext;
+		try {
+			ext = auth.getExternalConfig(new AuthExternalConfigMapper(auth.getEnvironments()));
+		} catch (ExternalConfigMappingException e) {
+			throw new RuntimeException("Dude, like, what just happened?", e);
+		}
+		final ConfigItem<URL, State> login = ext.getURLSetOrDefault(environment)
+				.getAllowedLoginRedirectPrefix();
+		if (login.hasItem()) {
+			if (!redirect.startsWith(login.getItem().toString())) {
+				throw new IllegalParameterException(
+						"Illegal redirect URL: " + redirect);
+			}
+		} else {
+			throw new IllegalParameterException("Post-login redirects are not enabled" +
+					(environment == null ? "" : " for environment " + environment));
+		}
+		return url;
 	}
 
 	private NewCookie getRedirectCookie(final String redirect, final int expirationTimeSec) {

--- a/src/us/kbase/auth2/service/ui/Login.java
+++ b/src/us/kbase/auth2/service/ui/Login.java
@@ -6,7 +6,9 @@ import static us.kbase.auth2.service.common.ServiceCommon.isIgnoreIPsInHeaders;
 import static us.kbase.auth2.service.common.ServiceCommon.nullOrEmpty;
 import static us.kbase.auth2.service.ui.UIConstants.PROVIDER_RETURN_EXPIRATION_SEC;
 import static us.kbase.auth2.service.ui.UIConstants.IN_PROCESS_LOGIN_COOKIE;
+import static us.kbase.auth2.service.ui.UIUtils.ENVIRONMENT_COOKIE;
 import static us.kbase.auth2.service.ui.UIUtils.checkState;
+import static us.kbase.auth2.service.ui.UIUtils.getEnvironmentCookie;
 import static us.kbase.auth2.service.ui.UIUtils.getExternalConfigURI;
 import static us.kbase.auth2.service.ui.UIUtils.getLoginCookie;
 import static us.kbase.auth2.service.ui.UIUtils.getLoginInProcessCookie;
@@ -64,6 +66,7 @@ import us.kbase.auth2.lib.TokenCreationContext;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.Utils;
 import us.kbase.auth2.lib.config.ConfigAction.State;
+import us.kbase.auth2.lib.config.ConfigItem;
 import us.kbase.auth2.lib.exceptions.AuthenticationException;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
@@ -161,7 +164,7 @@ public class Login {
 		}
 		Utils.checkString(provider, Fields.PROVIDER);
 		
-		getRedirectURL(redirect); // check redirect url is ok
+		getRedirectURL(environment, redirect); // check redirect url is ok
 		final String state = auth.getBareToken();
 		final URI target = toURI(auth.getIdentityProviderURL(provider, state, false, environment));
 		
@@ -171,21 +174,17 @@ public class Login {
 						PROVIDER_RETURN_EXPIRATION_SEC))
 				// will remove redirect cookie if redirect isn't set and one exists
 				.cookie(getRedirectCookie(redirect, PROVIDER_RETURN_EXPIRATION_SEC))
+				.cookie(getEnvironmentCookie(environment, UIPaths.LOGIN_ROOT,
+						PROVIDER_RETURN_EXPIRATION_SEC))
 				.build();
 	}
 	
-	private URL getRedirectURL(final String redirect)
-			throws AuthStorageException, IllegalParameterException {
+	private URL getRedirectURL(final String environment, final String redirect)
+			throws AuthStorageException, IllegalParameterException, NoSuchEnvironmentException {
 		final URL retRedirect;
 		if (nullOrEmpty(redirect)) {
 			retRedirect = null;
 		} else {
-			final AuthExternalConfig<State> ext;
-			try {
-				ext = auth.getExternalConfig(new AuthExternalConfigMapper());
-			} catch (ExternalConfigMappingException e) {
-				throw new RuntimeException("Dude, like, what just happened?", e);
-			}
 			final URL url;
 			try {
 				url = new URL(redirect);
@@ -193,14 +192,22 @@ public class Login {
 			} catch (MalformedURLException | URISyntaxException e) {
 				throw new IllegalParameterException("Illegal redirect URL: " + redirect);
 			}
-			if (ext.getURLSet().getAllowedLoginRedirectPrefix().hasItem()) {
-				if (!redirect.startsWith(
-						ext.getURLSet().getAllowedLoginRedirectPrefix().getItem().toString())) {
+			final AuthExternalConfig<State> ext;
+			try {
+				ext = auth.getExternalConfig(new AuthExternalConfigMapper(auth.getEnvironments()));
+			} catch (ExternalConfigMappingException e) {
+				throw new RuntimeException("Dude, like, what just happened?", e);
+			}
+			final ConfigItem<URL, State> login = ext.getURLSetOrDefault(environment)
+					.getAllowedLoginRedirectPrefix();
+			if (login.hasItem()) {
+				if (!redirect.startsWith(login.getItem().toString())) {
 					throw new IllegalParameterException(
 							"Illegal redirect URL: " + redirect);
 				}
 			} else {
-				throw new IllegalParameterException("Post-login redirects are not enabled");
+				throw new IllegalParameterException("Post-login redirects are not enabled" +
+						(environment == null ? "" : " for environment " + environment));
 			}
 			retRedirect = url;
 		}
@@ -251,13 +258,15 @@ public class Login {
 			@CookieParam(LOGIN_STATE_COOKIE) final String state,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
 			@CookieParam(SESSION_CHOICE_COOKIE) final String session,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			@Context final UriInfo uriInfo)
 			throws MissingParameterException, AuthStorageException,
 				IllegalParameterException, UnauthorizedException, NoSuchIdentityProviderException,
-				IdentityRetrievalException, AuthenticationException, NoSuchEnvironmentException{
+				IdentityRetrievalException, AuthenticationException, NoSuchEnvironmentException {
 		
 		// provider cannot be null or empty since it's a path param
-		final URI redirectURI = getPostLoginRedirectURI(redirect, UIPaths.ME_ROOT); // fail early
+		// fail early
+		final URI redirectURI = getPostLoginRedirectURI(environment, redirect, UIPaths.ME_ROOT);
 		final MultivaluedMap<String, String> qps = uriInfo.getQueryParameters();
 		final String authcode = qps.getFirst(Fields.PROVIDER_CODE); //may need to be configurable
 		final String retstate = qps.getFirst(Fields.PROVIDER_STATE); //may need to be configurable
@@ -269,7 +278,7 @@ public class Login {
 			checkState(state, retstate);
 			final TokenCreationContext tcc = getTokenContext(
 					userAgentParser, req, isIgnoreIPsInHeaders(auth), Collections.emptyMap());
-			lr = auth.login(provider, authcode, null, tcc); //TODO NOW pass environment
+			lr = auth.login(provider, authcode, environment, tcc);
 		}
 		final Response r;
 		// always redirect so the authcode doesn't remain in the title bar
@@ -279,13 +288,16 @@ public class Login {
 			r = createLoginResponse(redirectURI, lr.getToken().get(), !FALSE.equals(session));
 		} else {
 			final int age = getMaxCookieAge(lr.getTemporaryToken().get());
-			final URI completeURI = getExternalConfigURI(auth,
-					cfg -> cfg.getURLSet().getCompleteLoginRedirect(), UIPaths.LOGIN_ROOT_CHOICE);
+			final URI completeURI = getExternalConfigURI(
+					auth,
+					cfg -> cfg.getURLSetOrDefault(environment).getCompleteLoginRedirect(),
+					UIPaths.LOGIN_ROOT_CHOICE);
 			r = Response.seeOther(completeURI)
 					.cookie(getLoginInProcessCookie(lr.getTemporaryToken().get()))
 					.cookie(getStateCookie(null))
 					.cookie(getRedirectCookie(redirect, age))
 					.cookie(getSessionChoiceCookie(session, age))
+					.cookie(getEnvironmentCookie(environment, UIPaths.LOGIN_ROOT, age))
 					.build();
 		}
 		return r;
@@ -310,6 +322,7 @@ public class Login {
 	
 	private ResponseBuilder removeLoginProcessCookies(final ResponseBuilder resp) {
 		return resp.cookie(getSessionChoiceCookie((Boolean) null, 0))
+				.cookie(getEnvironmentCookie(null, UIPaths.LOGIN_ROOT, 0))
 				.cookie(getLoginInProcessCookie(null))
 				.cookie(getStateCookie(null))
 				.cookie(getRedirectCookie(null, 0));
@@ -327,9 +340,12 @@ public class Login {
 		return removeLoginProcessCookies(Response.status(status)).entity(ret).build();
 	}
 	
-	private URI getPostLoginRedirectURI(final String redirect, final String deflt)
-			throws IllegalParameterException, AuthStorageException {
-		final URL redirURL = getRedirectURL(redirect);
+	private URI getPostLoginRedirectURI(
+			final String environment,
+			final String redirect,
+			final String deflt)
+			throws IllegalParameterException, AuthStorageException, NoSuchEnvironmentException {
+		final URL redirURL = getRedirectURL(environment, redirect);
 		if (redirURL != null) {
 			return toURI(redirURL);
 		}
@@ -343,10 +359,12 @@ public class Login {
 	public Map<String, Object> loginChoiceHTML(
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException,
-				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException {
-		return loginChoice(token, uriInfo, redirect);
+				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException,
+				NoSuchEnvironmentException {
+		return loginChoice(token, uriInfo, redirect, environment);
 	}
 
 	@GET
@@ -355,19 +373,23 @@ public class Login {
 	public Map<String, Object> loginChoiceJSON(
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			@Context final UriInfo uriInfo)
 			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException,
-				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException {
-		return loginChoice(token, uriInfo, redirect);
+				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException,
+				NoSuchEnvironmentException {
+		return loginChoice(token, uriInfo, redirect, environment);
 	}
 	
 	private Map<String, Object> loginChoice(
 			final String token,
 			final UriInfo uriInfo,
-			final String redirect)
+			final String redirect,
+			final String environment)
 			throws NoTokenProvidedException, AuthStorageException, InvalidTokenException,
-				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException {
-		final URL redirectURL = getRedirectURL(redirect); // fail early
+				IllegalParameterException, IdentityProviderErrorException, UnauthorizedException,
+				NoSuchEnvironmentException {
+		final URL redirectURL = getRedirectURL(environment, redirect); // fail early
 		final LoginState loginState = auth.getLoginState(getLoginInProcessToken(token));
 		
 		final Map<String, Object> ret = new HashMap<>();
@@ -473,15 +495,17 @@ public class Login {
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
 			@CookieParam(SESSION_CHOICE_COOKIE) final String session,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			@FormParam(Fields.ID) final String identityID,
 			@FormParam(Fields.POLICY_IDS) final String policyIDs,
 			@FormParam(Fields.CUSTOM_CONTEXT) final String customContext,
 			@FormParam(Fields.LINK_ALL) final String linkAll)
 			throws NoTokenProvidedException, AuthenticationException,
-			AuthStorageException, UnauthorizedException, IllegalParameterException,
-			LinkFailedException, MissingParameterException {
+				AuthStorageException, UnauthorizedException, IllegalParameterException,
+				LinkFailedException, MissingParameterException, NoSuchEnvironmentException {
 		
-		final URI redirectURI = getPostLoginRedirectURI(redirect, UIPaths.ME_ROOT); // fail early
+		// fail early
+		final URI redirectURI = getPostLoginRedirectURI(environment, redirect, UIPaths.ME_ROOT);
 		final TokenCreationContext tcc = getTokenContext(userAgentParser, req,
 				isIgnoreIPsInHeaders(auth), getCustomContextFromString(customContext));
 		final NewToken newtoken = auth.login(getLoginInProcessToken(token),
@@ -565,16 +589,17 @@ public class Login {
 			@Context final HttpServletRequest req,
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			final PickChoice pick)
 			throws AuthenticationException, UnauthorizedException, NoTokenProvidedException,
-			AuthStorageException, IllegalParameterException, MissingParameterException,
-			LinkFailedException {
+				AuthStorageException, IllegalParameterException, MissingParameterException,
+				LinkFailedException, NoSuchEnvironmentException {
 		if (pick == null) {
 			throw new MissingParameterException("JSON body missing");
 		}
 		pick.exceptOnAdditionalProperties();
 		
-		final URL redirectURI = getRedirectURL(redirect); // fail early
+		final URL redirectURI = getRedirectURL(environment, redirect); // fail early
 		final TokenCreationContext tcc = getTokenContext(
 				userAgentParser, req, isIgnoreIPsInHeaders(auth), pick.getCustomContext());
 		final NewToken newtoken = auth.login(getLoginInProcessToken(token),
@@ -590,6 +615,7 @@ public class Login {
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
 			@CookieParam(SESSION_CHOICE_COOKIE) final String session,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			@FormParam(Fields.ID) final String identityID,
 			@FormParam(Fields.USER) final String userName,
 			@FormParam(Fields.DISPLAY) final String displayName,
@@ -597,12 +623,13 @@ public class Login {
 			@FormParam(Fields.POLICY_IDS) final String policyIDs,
 			@FormParam(Fields.CUSTOM_CONTEXT) final String customContext,
 			@FormParam(Fields.LINK_ALL) final String linkAll)
-			throws AuthenticationException, AuthStorageException,
-				UserExistsException, NoTokenProvidedException,
-				MissingParameterException, IllegalParameterException,
-				UnauthorizedException, IdentityLinkedException, LinkFailedException {
+			throws AuthenticationException, AuthStorageException, UserExistsException,
+				NoTokenProvidedException, MissingParameterException, IllegalParameterException,
+				UnauthorizedException, IdentityLinkedException, LinkFailedException,
+				NoSuchEnvironmentException {
 	
-		final URI redirectURI = getPostLoginRedirectURI(redirect, UIPaths.ME_ROOT); // fail early
+		// fail early
+		final URI redirectURI = getPostLoginRedirectURI(environment, redirect, UIPaths.ME_ROOT);
 		final TokenCreationContext tcc = getTokenContext(userAgentParser, req,
 				isIgnoreIPsInHeaders(auth), getCustomContextFromString(customContext));
 
@@ -649,17 +676,18 @@ public class Login {
 			@Context final HttpServletRequest req,
 			@CookieParam(IN_PROCESS_LOGIN_COOKIE) final String token,
 			@CookieParam(REDIRECT_COOKIE) final String redirect,
+			@CookieParam(ENVIRONMENT_COOKIE) final String environment,
 			final CreateChoice create)
-			throws AuthenticationException, AuthStorageException,
-				UserExistsException, NoTokenProvidedException,
-				MissingParameterException, IllegalParameterException,
-				UnauthorizedException, IdentityLinkedException, LinkFailedException {
+			throws AuthenticationException, AuthStorageException, UserExistsException,
+				NoTokenProvidedException, MissingParameterException, IllegalParameterException,
+				UnauthorizedException, IdentityLinkedException, LinkFailedException,
+				NoSuchEnvironmentException {
 		if (create == null) {
 			throw new MissingParameterException("JSON body missing");
 		}
 		create.exceptOnAdditionalProperties();
 		
-		final URL redirectURI = getRedirectURL(redirect); // fail early
+		final URL redirectURI = getRedirectURL(environment, redirect); // fail early
 		final TokenCreationContext tcc = getTokenContext(
 				userAgentParser, req, isIgnoreIPsInHeaders(auth), create.getCustomContext());
 		

--- a/src/us/kbase/test/auth2/MockIdentityProviderFactory.java
+++ b/src/us/kbase/test/auth2/MockIdentityProviderFactory.java
@@ -4,8 +4,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import us.kbase.auth2.lib.identity.IdentityProvider;
@@ -14,16 +12,17 @@ import us.kbase.auth2.lib.identity.IdentityProviderFactory;
 
 public class MockIdentityProviderFactory implements IdentityProviderFactory {
 
-	public static final Map<String, IdentityProvider> mocks = new HashMap<>();
-	public static final List<IdentityProviderConfig> configs = new LinkedList<>();
+	public static final Map<String, IdentityProvider> MOCKS = new HashMap<>();
+	public static final Map<String, IdentityProviderConfig> CONFIGS = new HashMap<>();
 	
 	@Override
 	public IdentityProvider configure(final IdentityProviderConfig cfg) {
-		configs.add(cfg);
 		final IdentityProvider prov = mock(IdentityProvider.class);
-		final String provname = "prov" + (mocks.size() + 1);
+		final String provname = "prov" + (MOCKS.size() + 1);
 		when(prov.getProviderName()).thenReturn(provname);
-		mocks.put(provname, prov);
+		when(prov.getEnvironments()).thenReturn(cfg.getEnvironments());
+		MOCKS.put(provname, prov);
+		CONFIGS.put(provname, cfg);
 		return prov;
 	}
 }

--- a/src/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.ws.rs.client.Client;
@@ -351,22 +352,25 @@ public class ServiceTestUtils {
 		// This is very bad form but it takes too long to start the server up for every test
 		// The alternative is to use concrete IdentityProvider implementations with 
 		// a mock server they talk to, but that seems like an even bigger pita
-		for (final IdentityProvider mock: MockIdentityProviderFactory.mocks.values()) {
+		for (final IdentityProvider mock: MockIdentityProviderFactory.MOCKS.values()) {
 			final String name = mock.getProviderName();
+			final Set<String> envs = mock.getEnvironments();
 			reset(mock);
 			when(mock.getProviderName()).thenReturn(name);
+			when(mock.getEnvironments()).thenReturn(envs);
 		}
 	}
 	
 	// inserts the config that would result on server startup per the config file below
 	private static void insertStandardConfig(final MongoStorageTestManager manager)
 			throws Exception {
+		// note these providers and this auth instance are DOA and don't affect the running service
 		final IdentityProvider prov1 = mock(IdentityProvider.class);
 		final IdentityProvider prov2 = mock(IdentityProvider.class);
 		when(prov1.getProviderName()).thenReturn("prov1");
 		when(prov2.getProviderName()).thenReturn("prov2");
 		new Authentication(manager.storage, set(prov1, prov2),
-				AuthExternalConfig.getDefaultConfig(set()), false);
+				AuthExternalConfig.getDefaultConfig(set("env1", "env2")), false);
 	}
 	
 	public static Path generateTempConfigFile(
@@ -396,6 +400,7 @@ public class ServiceTestUtils {
 		}
 		
 		sec.add("identity-providers", "prov1, prov2");
+		sec.add("identity-provider-envs", "env1, env2");
 		
 		sec.add("identity-provider-prov1-factory", MockIdentityProviderFactory.class.getName());
 		sec.add("identity-provider-prov1-login-url", "https://login.prov1.com");
@@ -406,6 +411,14 @@ public class ServiceTestUtils {
 				"https://loginredirectforprov1.kbase.us");
 		sec.add("identity-provider-prov1-link-redirect-url",
 				"https://linkredirectforprov1.kbase.us");
+		sec.add("identity-provider-prov1-env-env1-login-redirect-url",
+				"https://loginredirectforprov1env1.kbase.us");
+		sec.add("identity-provider-prov1-env-env1-link-redirect-url",
+				"https://linkredirectforprov1env1.kbase.us");
+		sec.add("identity-provider-prov1-env-env2-login-redirect-url",
+				"https://loginredirectforprov1env2.kbase.us");
+		sec.add("identity-provider-prov1-env-env2-link-redirect-url",
+				"https://linkredirectforprov1env2.kbase.us");
 
 		sec.add("identity-provider-prov2-factory", MockIdentityProviderFactory.class.getName());
 		sec.add("identity-provider-prov2-login-url", "https://login.prov2.com");
@@ -416,6 +429,14 @@ public class ServiceTestUtils {
 				"https://loginredirectforprov2.kbase.us");
 		sec.add("identity-provider-prov2-link-redirect-url",
 				"https://linkredirectforprov2.kbase.us");
+		sec.add("identity-provider-prov2-env-env1-login-redirect-url",
+				"https://loginredirectforprov2env1.kbase.us");
+		sec.add("identity-provider-prov2-env-env1-link-redirect-url",
+				"https://linkredirectforprov2env1.kbase.us");
+		sec.add("identity-provider-prov2-env-env2-login-redirect-url",
+				"https://loginredirectforprov2env2.kbase.us");
+		sec.add("identity-provider-prov2-env-env2-link-redirect-url",
+				"https://linkredirectforprov2env2.kbase.us");
 
 		final Path temp = TestCommon.getTempDir();
 		final Path deploy = temp.resolve(Files.createTempFile(temp, "cli_test_deploy", ".cfg"));
@@ -442,6 +463,30 @@ public class ServiceTestUtils {
 				.post(Entity.json(json));
 		assertThat("failed to set config", r.getStatus(), is(204));
 	}
+	
+	private static void setEnvironment(
+			final String host,
+			final String cookieName,
+			final IncomingToken admintoken,
+			final String environment,
+			final String linkkey,
+			final String url) {
+		final Form form = new Form();
+		form.param("environment", environment);
+		form.param(linkkey, url);
+		setEnvironment(host, cookieName, admintoken, form);
+	}
+	
+	public static void setEnvironment(
+			final String host,
+			final String cookieName,
+			final IncomingToken admintoken,
+			final Form form) {
+		final Response r = CLI.target(host + "/admin/config/environment").request()
+				.cookie(cookieName, admintoken.getToken())
+				.post(Entity.form(form));
+		assertThat("failed to set config", r.getStatus(), is(204));
+	}
 
 	public static void enableProvider(
 			final String host,
@@ -465,12 +510,33 @@ public class ServiceTestUtils {
 		setAdmin(host, adminToken, ImmutableMap.of("allowedloginredirect", redirectURLPrefix));
 	}
 	
+	public static void enableRedirect(
+			final String host,
+			final String cookieName,
+			final IncomingToken adminToken,
+			final String redirectURLPrefix,
+			final String environment) {
+		setEnvironment(host, cookieName, adminToken, environment, "allowedloginredirect",
+				redirectURLPrefix);
+	}
+	
 	public static void setLoginCompleteRedirect(
 			final String host,
 			final IncomingToken adminToken,
 			final String loginCompleteRedirectURL) {
 		setAdmin(host, adminToken,
 				ImmutableMap.of("completeloginredirect", loginCompleteRedirectURL));
+	}
+	
+
+	public static void setLoginCompleteRedirect(
+			final String host,
+			final String cookieName,
+			final IncomingToken adminToken,
+			final String postLinkRedirectURL,
+			final String environment) {
+		setEnvironment(host, cookieName, adminToken, environment, "completeloginredirect",
+				postLinkRedirectURL);
 	}
 	
 	public static void setLinkCompleteRedirect(
@@ -481,11 +547,31 @@ public class ServiceTestUtils {
 				ImmutableMap.of("completelinkredirect", linkCompleteRedirectURL));
 	}
 	
+	public static void setLinkCompleteRedirect(
+			final String host,
+			final String cookieName,
+			final IncomingToken adminToken,
+			final String linkCompleteRedirectURL,
+			final String environment) {
+		setEnvironment(host, cookieName, adminToken, environment, "completelinkredirect",
+				linkCompleteRedirectURL);
+	}
+	
 	public static void setPostLinkRedirect(
 			final String host,
 			final IncomingToken adminToken,
 			final String postLinkRedirectURL) {
 		setAdmin(host, adminToken,
 				ImmutableMap.of("postlinkredirect", postLinkRedirectURL));
+	}
+
+	public static void setPostLinkRedirect(
+			final String host,
+			final String cookieName,
+			final IncomingToken adminToken,
+			final String postLinkRedirectURL,
+			final String environment) {
+		setEnvironment(host, cookieName, adminToken, environment, "postlinkredirect",
+				postLinkRedirectURL);
 	}
 }


### PR DESCRIPTION
Err... this is a lot bigger than I though it was going to be. Sorry. The actual code changes are < 200 lines.

Process flow for login/link (LL):

* Client sends form to LL start with environment or null for default
environment.
* For login, if a user redirect url is sent it's checked against the
configured prefix for the appropriate environment.
* The environment is passed though the application to the appropriate
identity provider implementation to get the redirect url to the 3rd
party identity provider. The env-specific return redirect url is added
to the redirect url as a param.
* Redirect occurs to 3rd party. A cookie is set with the environment
name and another with the user redirect url, if any (login only).
* 3rd party redirects to the auth server with an auth token.
* The user redirect url cookie is checked as previously described.
* The environment and auth token are passed through the application to
the appropriate identity provider implementation to retrieve the user
identities. The environment is necessary so the implementation can pass
the correct return redirect url to the 3rd party identity provider,
which is required.
* If LL are done at this point, all process cookies are nuked, a
login token is set (or a new identity is linked), and redirect occurs to
the user login redirect url, the configured final link redirect url for
the environment, or a default url.
* If not, the cookies are refreshed and redirect occurs to the
configured intermediate redirect url for the environment or a default
url.
* The user redirect url is checked again.
* The user then picks an account (login or link) or creates an account
(login only).
* The final check of the user redirect url occurs.
* All process tokens are nuked, a login token is set (or a new identity
is linked), and redirect occurs to the user login redirect url, the
configured final link redirect url for the environment, or a default
url.