### PR TITLE
Add environment header name to config

### DIFF
--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -17,6 +17,12 @@ mongo-pwd =
 # The name of the cookie in which tokens should be stored in the browser.
 token-cookie-name = kbase_session
 
+# The name of the header to be used to pass the environment name (see below) to the server at the 
+# /login/start and /link/start endpoints. The header takes precedence over form submission
+# of the environment name.
+# The header must start with 'X-' and consist of only capital letters and hyphens.
+environment-header=X-AUTH2-ENVIRONMENT
+
 # The name of the service to report when logging to syslog.
 log-name = KBaseAuthServ2
 

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -5,6 +5,7 @@ mongo-user={{ default .Env.mongo_user "" }}
 mongo-pwd={{ default .Env.mongo_pwd "" }}
 # The name of the cookie in which tokens should be stored in the browser.
 token-cookie-name = {{ default .Env.token_cookie_name "kbase_session" }}
+environment-header={{ default .Env.environment_header "X-DOEKBASE-ENVIRONMENT" }}
 # the name of the service to report when logging to syslog.
 log-name={{ default .Env.log_name "KBaseAuthServ2" }}
 test-mode-enabled={{ .Env.test_mode_enabled }}

--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -129,7 +129,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private String getEnvironmentHeader(final Map<String, String> cfg)
 			throws AuthConfigurationException {
 		final String eh = getString(KEY_ENVIRONMENT_HEADER, cfg, true);
-		if (!eh.startsWith("X-")) {
+		if (!eh.startsWith(ENVIRONMENT_HEADER_PREFIX)) {
 			throw new AuthConfigurationException(String.format(
 					"Parameter %s must start with %s in configuration file %s, section %s",
 					KEY_ENVIRONMENT_HEADER, ENVIRONMENT_HEADER_PREFIX,

--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -10,6 +10,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.ini4j.Ini;
 import org.slf4j.LoggerFactory;
@@ -43,6 +45,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private static final String KEY_MONGO_USER = "mongo-user";
 	private static final String KEY_MONGO_PWD = "mongo-pwd";
 	private static final String KEY_COOKIE_NAME = "token-cookie-name";
+	private static final String KEY_ENVIRONMENT_HEADER = "environment-header";
 	private static final String KEY_TEMPLATE_DIR = "template-dir";
 	private static final String KEY_ID_PROV = "identity-providers";
 	private static final String KEY_ID_PROV_ENVS = "identity-provider-envs";
@@ -60,6 +63,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private static final String KEY_SUFFIX_ID_PROVS_ENV = "-env-";
 	private static final String KEY_SUFFIX_ID_PROVS_CUSTOM = "-custom-";
 	private static final String TRUE = "true";
+	private static final String ENVIRONMENT_HEADER_PREFIX = "X-";
 	private static final String KEY_TEST_MODE_ENABLED = "test-mode-enabled";
 	
 	private final SLF4JAutoLogger logger;
@@ -68,6 +72,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private final Optional<String> mongoUser;
 	private final Optional<char[]> mongoPwd;
 	private final String cookieName;
+	private final String environmentHeader;
 	private final Set<IdentityProviderConfig> providers;
 	private final boolean isTestModeEnabled;
 	private final Path templateDir;
@@ -107,6 +112,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 					Optional.of(mongop.get().toCharArray()) : Optional.absent();
 			mongop = null; //GC
 			cookieName = getString(KEY_COOKIE_NAME, cfg, true);
+			environmentHeader = getEnvironmentHeader(cfg);
 			providers = getProviders(cfg);
 		} catch (AuthConfigurationException e) {
 			if (!nullLogger) {
@@ -117,6 +123,28 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 		}
 	}
 	
+	private static final String INVALID_CHARS_REGEX = "[^A-Z-]+";
+	private static final Pattern INVALID_CHARS = Pattern.compile(INVALID_CHARS_REGEX);
+	
+	private String getEnvironmentHeader(final Map<String, String> cfg)
+			throws AuthConfigurationException {
+		final String eh = getString(KEY_ENVIRONMENT_HEADER, cfg, true);
+		if (!eh.startsWith("X-")) {
+			throw new AuthConfigurationException(String.format(
+					"Parameter %s must start with %s in configuration file %s, section %s",
+					KEY_ENVIRONMENT_HEADER, ENVIRONMENT_HEADER_PREFIX,
+					cfg.get(TEMP_KEY_CFG_FILE), CFG_LOC));
+		}
+		final Matcher m = INVALID_CHARS.matcher(eh);
+		if (m.find()) {
+			throw new AuthConfigurationException(String.format(
+					"Illegal character in %s %s in configuration file %s, section %s: %s",
+					KEY_ENVIRONMENT_HEADER, eh, cfg.get(TEMP_KEY_CFG_FILE), CFG_LOC,
+					m.group()));
+		}
+		return eh;
+	}
+
 	private Set<IdentityProviderConfig> getProviders(
 			final Map<String, String> cfg)
 			throws AuthConfigurationException {
@@ -338,6 +366,11 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	@Override
 	public String getTokenCookieName() {
 		return cookieName;
+	}
+	
+	@Override
+	public String getEnvironmentHeaderName() {
+		return environmentHeader;
 	}
 	
 	@Override

--- a/src/us/kbase/auth2/service/AuthAPIStaticConfig.java
+++ b/src/us/kbase/auth2/service/AuthAPIStaticConfig.java
@@ -9,15 +9,24 @@ public class AuthAPIStaticConfig {
 	//TODO TEST
 	
 	private final String cookieName;
+	private final String environmentHeaderName;
 
-	public AuthAPIStaticConfig(final String tokenCookieName) {
+	public AuthAPIStaticConfig(final String tokenCookieName, final String environmentHeader) {
 		if (tokenCookieName == null || tokenCookieName.trim().isEmpty()) {
 			throw new IllegalArgumentException("tokenCookieName cannot be null or empty");
 		}
+		if (environmentHeader == null || environmentHeader.trim().isEmpty()) {
+			throw new IllegalArgumentException("environmentHeader cannot be null or empty");
+		}
 		this.cookieName = tokenCookieName;
+		this.environmentHeaderName = environmentHeader;
 	}
 
 	public String getTokenCookieName() {
 		return cookieName;
+	}
+
+	public String getEnvironmentHeaderName() {
+		return environmentHeaderName;
 	}
 }

--- a/src/us/kbase/auth2/service/AuthStartupConfig.java
+++ b/src/us/kbase/auth2/service/AuthStartupConfig.java
@@ -19,6 +19,7 @@ public interface AuthStartupConfig {
 	Optional<String> getMongoUser();
 	Optional<char[]> getMongoPwd();
 	String getTokenCookieName();
+	String getEnvironmentHeaderName();
 	Path getPathToTemplateDirectory();
 	boolean isTestModeEnabled();
 	Set<String> getEnvironments();

--- a/src/us/kbase/auth2/service/AuthenticationService.java
+++ b/src/us/kbase/auth2/service/AuthenticationService.java
@@ -95,7 +95,7 @@ public class AuthenticationService extends ResourceConfig {
 				bind(new MustacheProcessor(c.getPathToTemplateDirectory().toAbsolutePath()))
 					.to(TemplateProcessor.class);
 				bind(c.getLogger()).to(SLF4JAutoLogger.class);
-				bind(new AuthAPIStaticConfig(c.getTokenCookieName()))
+				bind(new AuthAPIStaticConfig(c.getTokenCookieName(), c.getEnvironmentHeaderName()))
 						.to(AuthAPIStaticConfig.class);
 				bind(new UserAgentParser()).to(UserAgentParser.class);
 			}

--- a/src/us/kbase/test/auth2/TestConfigurator.java
+++ b/src/us/kbase/test/auth2/TestConfigurator.java
@@ -126,6 +126,11 @@ public class TestConfigurator implements AuthStartupConfig {
 	public String getTokenCookieName() {
 		return "some_cookie";
 	}
+	
+	@Override
+	public String getEnvironmentHeaderName() {
+		return "X-SUPERFAKEHEADER";
+	}
 
 	@Override
 	public boolean isTestModeEnabled() {

--- a/src/us/kbase/test/auth2/cli/AuthCLITest.java
+++ b/src/us/kbase/test/auth2/cli/AuthCLITest.java
@@ -149,6 +149,7 @@ public class AuthCLITest {
 		sec.add("mongo-db", DB_NAME);
 		sec.add("token-cookie-name", "foobar");
 		sec.add("template-dir", "templates");
+		sec.add("environment-header", "X-MEN");
 		final Path temp = TestCommon.getTempDir();
 		final Path deploy = temp.resolve(Files.createTempFile(temp, "cli_test_deploy", ".cfg"));
 		ini.store(deploy.toFile());

--- a/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
+++ b/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
@@ -66,6 +66,7 @@ public class KBaseAuthConfigTest {
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
+				"environment-header=    X-FOO-BAR     ",
 				"token-cookie-name=cookiename"
 				);
 		final KBaseAuthConfig cfg;
@@ -88,6 +89,7 @@ public class KBaseAuthConfigTest {
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
 		assertThat("incorrect cookie name", cfg.getTokenCookieName(), is("cookiename"));
+		assertThat("incorrect env header", cfg.getEnvironmentHeaderName(), is("X-FOO-BAR"));
 		testLogger(cfg.getLogger(), false);
 	}
 	
@@ -103,6 +105,7 @@ public class KBaseAuthConfigTest {
 				"log-name = logname", // this is annoying to test
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=    X-FOO-BAR     ",
 				"identity-provider-envs =   env1  \t   ,    , env2    ",
 				"identity-providers = prov1   \t   ,    \t , prov2   ",
 				"identity-provider-prov1-factory = facclass",
@@ -179,6 +182,7 @@ public class KBaseAuthConfigTest {
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
 		assertThat("incorrect cookie name", cfg.getTokenCookieName(), is("cookiename"));
+		assertThat("incorrect env header", cfg.getEnvironmentHeaderName(), is("X-FOO-BAR"));
 		testLogger(cfg.getLogger(), false);
 	}
 	
@@ -216,6 +220,7 @@ public class KBaseAuthConfigTest {
 				"template-dir = somedir",
 				"test-mode-enabled = false",
 				"token-cookie-name=cookiename",
+				"environment-header=    X-FOO-BAR-BAZ     ",
 				"identity-providers =      \t    "
 				);
 		final KBaseAuthConfig cfg = new KBaseAuthConfig(cfgfile, true);
@@ -230,6 +235,7 @@ public class KBaseAuthConfigTest {
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
 		assertThat("incorrect cookie name", cfg.getTokenCookieName(), is("cookiename"));
+		assertThat("incorrect env header", cfg.getEnvironmentHeaderName(), is("X-FOO-BAR-BAZ"));
 		testLogger(cfg.getLogger(), true);
 	}
 	
@@ -245,6 +251,7 @@ public class KBaseAuthConfigTest {
 				"log-name = logname", // this is annoying to test
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-provider-envs =        ",
 				"identity-providers = prov1   \t   ,    \t , prov2   ",
 				"identity-provider-prov1-factory = facclass",
@@ -299,6 +306,7 @@ public class KBaseAuthConfigTest {
 		assertThat("incorrect template dir", cfg.getPathToTemplateDirectory(),
 				is(Paths.get("somedir")));
 		assertThat("incorrect cookie name", cfg.getTokenCookieName(), is("cookiename"));
+		assertThat("incorrect env header", cfg.getEnvironmentHeaderName(), is("X-FOO-BAR"));
 		testLogger(cfg.getLogger(), false);
 	}
 	
@@ -324,6 +332,7 @@ public class KBaseAuthConfigTest {
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=cookiename"
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
@@ -341,6 +350,7 @@ public class KBaseAuthConfigTest {
 				"[authserv2]",
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=cookiename"
 				);
 		failConstruct(cfgfile, false, new AuthConfigurationException(String.format(
@@ -355,6 +365,7 @@ public class KBaseAuthConfigTest {
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     \t   ",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=cookiename"
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
@@ -369,6 +380,7 @@ public class KBaseAuthConfigTest {
 				"[authserv2]",
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     db   ",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=cookiename"
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
@@ -384,11 +396,60 @@ public class KBaseAuthConfigTest {
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     db   ",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=     \t  "
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
 				"Required parameter token-cookie-name not provided in configuration file %s, " +
 				"section authserv2", cfgfile)));
+	}
+	
+	@Test
+	public void constructWithPathFailWhitespaceEnvHeader() throws Exception {
+		final Path cfgfile = writeTempFile(
+				"[authserv2]",
+				"mongo-host=  localhost:50000    ",
+				"mongo-db   =     db   ",
+				"template-dir = somedir",
+				"environment-header=   \t     ",
+				"token-cookie-name=nomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnom"
+				);
+		failConstruct(cfgfile, new AuthConfigurationException(String.format(
+				"Required parameter environment-header not provided in configuration file %s, " +
+				"section authserv2", cfgfile)));
+	}
+	
+	@Test
+	public void constructWithPathFailEnvHeaderBadPrefix() throws Exception {
+		final Path cfgfile = writeTempFile(
+				"[authserv2]",
+				"mongo-host=  localhost:50000    ",
+				"mongo-db   =     db   ",
+				"template-dir = somedir",
+				"environment-header=   Y-FOO-BAR",
+				"token-cookie-name=nomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnom"
+				);
+		failConstruct(cfgfile, new AuthConfigurationException(String.format(
+				"Parameter environment-header must start with X- in configuration file %s, " +
+				"section authserv2", cfgfile)));
+	}
+	
+	@Test
+	public void constructWithPathFailEnvHeaderBadCharacter() throws Exception {
+		for (final String test: Arrays.asList("X-FOO_BAR/_", "X-FO0-BAR/0", "X-FOo-BAR/o")) {
+			final String[] headerChar = test.split("/");
+			final Path cfgfile = writeTempFile(
+					"[authserv2]",
+					"mongo-host=  localhost:50000    ",
+					"mongo-db   =     db   ",
+					"template-dir = somedir",
+					"environment-header=   " + headerChar[0],
+					"token-cookie-name=nomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnomnom"
+					);
+			failConstruct(cfgfile, new AuthConfigurationException(String.format(
+					"Illegal character in environment-header %s in configuration file " +
+					"%s, section authserv2: %s", headerChar[0], cfgfile, headerChar[1])));
+		}
 	}
 	
 	@Test
@@ -399,6 +460,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     db   ",
 				"mongo-pwd = mypwd",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name= coooooooooookieeeee  "
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
@@ -415,6 +477,7 @@ public class KBaseAuthConfigTest {
 				"mongo-user = user",
 				"mongo-pwd =  ",
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name= coooooooooookieeeee  "
 				);
 		failConstruct(cfgfile, new AuthConfigurationException(String.format(
@@ -430,6 +493,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				//"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -452,6 +516,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = htps://login.prov1.com",
@@ -474,6 +539,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -498,6 +564,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -520,6 +587,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -542,6 +610,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -564,6 +633,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-prov1-factory = facclass",
 				"identity-provider-prov1-login-url = https://login.prov1.com",
@@ -586,6 +656,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-envs=foo",
 				"identity-provider-prov1-factory = facclass",
@@ -610,6 +681,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-envs=foo",
 				"identity-provider-prov1-factory = facclass",
@@ -636,6 +708,7 @@ public class KBaseAuthConfigTest {
 				"mongo-db   =     mydb   ",
 				"template-dir = somedir",
 				"token-cookie-name=cookiename",
+				"environment-header=X-FOO-BAR",
 				"identity-providers = prov1",
 				"identity-provider-envs=foo",
 				"identity-provider-prov1-factory = facclass",
@@ -682,6 +755,7 @@ public class KBaseAuthConfigTest {
 				"test-mode-enabled= true",
 				"log-name = logname", // this is annoying to test
 				"template-dir = somedir",
+				"environment-header=X-FOO-BAR",
 				"token-cookie-name=cookiename",
 				"identity-providers = prov1   \t   ,    \t    ",
 				"identity-provider-prov1-factory = facclass",

--- a/src/us/kbase/test/auth2/service/LoggingFilterTest.java
+++ b/src/us/kbase/test/auth2/service/LoggingFilterTest.java
@@ -105,6 +105,11 @@ public class LoggingFilterTest {
 		}
 		
 		@Override
+		public String getEnvironmentHeaderName() {
+			return "X-SUPERFAKEHEADER";
+		}
+		
+		@Override
 		public boolean isTestModeEnabled() {
 			return false;
 		}

--- a/src/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -392,6 +392,7 @@ public class ServiceTestUtils {
 		sec.add("mongo-host", "localhost:" + manager.mongo.getServerPort());
 		sec.add("mongo-db", dbName);
 		sec.add("token-cookie-name", cookieName);
+		sec.add("environment-header", "X-DOEKBASE-ENVIRONMENT");
 		sec.add("template-dir", "templates");
 		// don't bother with logger name
 		

--- a/src/us/kbase/test/auth2/service/ui/AdminTest.java
+++ b/src/us/kbase/test/auth2/service/ui/AdminTest.java
@@ -62,7 +62,7 @@ public class AdminTest {
 	@Test
 	public void getConfigMinimal() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		final UriInfo uriInfo = mock(UriInfo.class);
 		
@@ -117,7 +117,7 @@ public class AdminTest {
 	@Test
 	public void getConfigMaximal() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		final UriInfo uriInfo = mock(UriInfo.class);
 		
@@ -219,7 +219,7 @@ public class AdminTest {
 	@Test
 	public void getConfigFailNoTokenProvided() {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		final UriInfo uriInfo = mock(UriInfo.class);
 		
@@ -235,7 +235,7 @@ public class AdminTest {
 	@Test
 	public void getConfigFailMapping() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		final UriInfo uriInfo = mock(UriInfo.class);
 		
@@ -254,7 +254,7 @@ public class AdminTest {
 	@Test
 	public void getConfigFailUnauthorized() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		final UriInfo uriInfo = mock(UriInfo.class);
 		
@@ -285,7 +285,7 @@ public class AdminTest {
 	@Test
 	public void updateBasicNulls() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -314,7 +314,7 @@ public class AdminTest {
 	@Test
 	public void updateBasicWhitespace() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -344,7 +344,7 @@ public class AdminTest {
 	@Test
 	public void updateBasicMaximal() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -377,7 +377,7 @@ public class AdminTest {
 		final String b = "htp://u.com";
 		
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -398,7 +398,7 @@ public class AdminTest {
 		final String b = "http://u^u.com";
 		
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -416,7 +416,7 @@ public class AdminTest {
 	@Test
 	public void updateBasicFailNoTokenProvided() {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -433,7 +433,7 @@ public class AdminTest {
 	@Test
 	public void updateBasicFailInvalidToken() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -480,7 +480,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigNulls() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -506,7 +506,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigWhitespace() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -533,7 +533,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigRemove() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -566,7 +566,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigSetTrue() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -592,7 +592,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigSetFalse() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -618,7 +618,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailNullBody() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -628,7 +628,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailUnexpectedProperties() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -652,7 +652,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailBadURL() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -673,7 +673,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailBadURI() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -694,7 +694,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailNoToken() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -711,7 +711,7 @@ public class AdminTest {
 	@Test
 	public void updateConfigFailInvalidToken() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		
 		final Admin admin = new Admin(auth, cfg);
 		
@@ -753,7 +753,7 @@ public class AdminTest {
 	@Test
 	public void configEnvironmentNulls() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -778,7 +778,7 @@ public class AdminTest {
 	@Test
 	public void configEnvironmentWhitespace() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -803,7 +803,7 @@ public class AdminTest {
 	@Test
 	public void configEnvironmentMaximal() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -836,7 +836,7 @@ public class AdminTest {
 		final String b = "htp://u.com";
 		
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		when(auth.getEnvironments()).thenReturn(set("e"));
@@ -859,7 +859,7 @@ public class AdminTest {
 		final String b = "http://u^u.com";
 		
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		when(auth.getEnvironments()).thenReturn(set("e"));
@@ -879,7 +879,7 @@ public class AdminTest {
 	@Test
 	public void configEnvBadEnvironment() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -898,7 +898,7 @@ public class AdminTest {
 	@Test
 	public void configEnvironmentFailNoTokenProvided() {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);
@@ -917,7 +917,7 @@ public class AdminTest {
 	@Test
 	public void configEnvironmentFailInvalidToken() throws Exception {
 		final Authentication auth = mock(Authentication.class);
-		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie");
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
 		final HttpHeaders headers = mock(HttpHeaders.class);
 		
 		final Admin admin = new Admin(auth, cfg);


### PR DESCRIPTION
Will be used as an alternative to form input for the environment when
starting login or link process.

Currently in config only, actually using it is next.