### PR TITLE
SCT-1512 Allow sending the environment via header.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,14 +3,17 @@ Authentication Service MKII release notes
 
 0.2.6
 -----
+* CONFIGURATION CHANGE - there is a new required `deploy.cfg` parameter, `environment-header`
+  (see below).
 * The service can now support multiple alternate environments with different redirect urls
   along with the default environment.
-  When starting a login or link flow, an `environment` form parameter can be sent to the 
-  endpoint to specify the environment to use for the flow.
+  When starting a login or link flow, a custom header or an `environment` form parameter can
+  be sent to the endpoint to specify the environment to use for the flow. The header takes
+  precedence over the form parameter and is specified in the `deploy.cfg` file.
   Environments are configured in the `deploy.cfg` file - see `deploy.cfg.example` for an
   example. Each identity provider will need to specify login and link redirect urls for each
   environment. Additionally, in the `/admin/config/` configuration endpoint, optional redirect
-  urls equivalent to the default environment redirect urls can be configured.
+  URLs equivalent to the default environment redirect urls can be configured.
 
 0.2.5
 -----

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -24,7 +24,7 @@ public class Root {
 	
 	//TODO JAVADOC or swagger
 	
-	private static final String VERSION = "0.2.6-dev1";
+	private static final String VERSION = "0.2.6-dev2";
 	
 	@GET
 	@Template(name = "/root")

--- a/src/us/kbase/auth2/service/ui/UIUtils.java
+++ b/src/us/kbase/auth2/service/ui/UIUtils.java
@@ -260,6 +260,34 @@ public class UIUtils {
 		}
 	}
 	
+	/** Get a header value from a header or an optional default.
+	 * Returns, in order of precedence, the value of the header given by headerName if not
+	 * null or whitespace only, the value of the stringValue if not null or whitespace only, or
+	 * {@link Optional#absent()}.
+	 * 
+	 * All values are {@link String#trim()}ed before returning.
+	 * 
+	 * @param headers the headers to interrogate.
+	 * @param headerName the name of the header to retrieve.
+	 * @param stringValue the value to return if the header value is absent.
+	 * @return the header value, string value, or {@link Optional#absent()}.
+	 */
+	public static Optional<String> getValueFromHeaderOrString(
+			final HttpHeaders headers,
+			final String headerName,
+			final String stringValue) {
+		nonNull(headers, "headers");
+		checkStringNoCheckedException(headerName, "headerName");
+		final String headerEnv = headers.getHeaderString(headerName);
+		if (!nullOrEmpty(headerEnv)) {
+			return Optional.of(headerEnv.trim());
+		} else if (!nullOrEmpty(stringValue)) {
+			return Optional.of(stringValue.trim());
+		} else {
+			return Optional.absent();
+		}
+	}
+	
 	/** Given a multivalued map as form input, return the set of roles that are contained as keys
 	 * in the form and have non-null values (e.g. the form contains a list for that value).
 	 * @param form the form to process.

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
@@ -112,7 +112,7 @@ public class SimpleEndpointsTest {
 	 * an error message or a git commit hash depending on the test environment, so both are
 	 * allowed
 	 */
-	private static final String SERVER_VER = "0.2.6-dev1";
+	private static final String SERVER_VER = "0.2.6-dev2";
 	private static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 

--- a/src/us/kbase/test/auth2/service/ui/UIUtilsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/UIUtilsTest.java
@@ -346,6 +346,64 @@ public class UIUtilsTest {
 	}
 	
 	@Test
+	public void getValueFromHeaderNullInput() throws Exception {
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		when(headers.getHeaderString("myheader")).thenReturn(null);
+		final Optional<String> res = UIUtils.getValueFromHeaderOrString(headers, "myheader", null);
+		assertThat("incorrect value", res, is(Optional.absent()));
+	}
+	
+	@Test
+	public void getValueFromHeaderWhitespaceInput() throws Exception {
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		when(headers.getHeaderString("myheader")).thenReturn("    \t    ");
+		final Optional<String> res = UIUtils.getValueFromHeaderOrString(
+				headers, "myheader", "    \t    ");
+		assertThat("incorrect value", res, is(Optional.absent()));
+	}
+	
+	@Test
+	public void getValueFromHeaderHeaderValue() throws Exception {
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		when(headers.getHeaderString("myheader")).thenReturn("       my value"    );
+		final Optional<String> res = UIUtils.getValueFromHeaderOrString(
+				headers, "myheader", "my other value");
+		assertThat("incorrect value", res, is(Optional.of("my value")));
+	}
+	
+	@Test
+	public void getValueFromHeaderStringValue() throws Exception {
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		when(headers.getHeaderString("myheader")).thenReturn(null);
+		final Optional<String> res = UIUtils.getValueFromHeaderOrString(
+				headers, "myheader", "      my other value      ");
+		assertThat("incorrect value", res, is(Optional.of("my other value")));
+	}
+	
+	@Test
+	public void getValueFromHeadersFail() throws Exception {
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		
+		failGetValueFromHeader(null, "s", new NullPointerException("headers"));
+		failGetValueFromHeader(headers, null, new IllegalArgumentException(
+				"Missing argument: headerName"));
+		failGetValueFromHeader(headers, "    \t    ", new IllegalArgumentException(
+				"Missing argument: headerName"));
+	}
+	
+	private void failGetValueFromHeader(
+			final HttpHeaders headers,
+			final String headerName,
+			final Exception expected) {
+		try {
+			UIUtils.getValueFromHeaderOrString(headers, headerName, null);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+	
+	@Test
 	public void getMaxCookieAge() throws Exception {
 		final TemporaryToken tt = tempToken(
 				UUID.randomUUID(), Instant.ofEpochMilli(10000),


### PR DESCRIPTION
The /login/start and /link/start endpoints now accept the environment
parameter as either a header parameter or form parameter, with the
header parameter taking precedence.

The header name is configured in the deploy.cfg file.