### PR TITLE
Use OpenID JWT to get Google user details

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ Admin notes
     * urn:globus:auth:scope:auth.globus.org:view_identities 
     * email
 * Get Google OAuth2 creds [here](https://console.developers.google.com/apis)
-  * Note that the Google People API must be enabled.
 * Get OrcID creds [here](https://orcid.org/content/register-client-application-0)
   * Note that only the public API has been tested with the auth server.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Authentication Service MKII release notes
 =========================================
 
+0.4.0
+-----
+* CONFIGURATION CHANGE - the `identity-provider-Google-custom-people-api-host`
+  configuration key has been removed. (see below).
+* The Google People API does not return the email address for a small subset of users for,
+  at this time, unknown reasons. The Google Identity Provider has been altered to extract
+  user information (the Google unique user ID, the user display name, and the user email address /
+  user name) from the JWT provided at the end of the OAuth2 login flow rather than using the
+  People API.
+
 0.3.0
 -----
 * CONFIGURATION CHANGE - the `identity-provider-Google-custom-people-api-host`

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -87,8 +87,6 @@ identity-provider-Google-client-id =
 identity-provider-Google-client-secret =
 identity-provider-Google-login-redirect-url = https://kbase.us/services/auth/login/complete/google
 identity-provider-Google-link-redirect-url = https://kbase.us/services/auth/link/complete/google
-# this custom parameter is required for Google
-identity-provider-Google-custom-people-api-host=https://people.googleapis.com
 
 identity-provider-OrcID-factory = us.kbase.auth2.providers.OrcIDIdentityProviderFactory
 identity-provider-OrcID-login-url = https://sandbox.orcid.org/

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -26,7 +26,6 @@ identity-provider-Globus-env-{{ default .Env.env1 "" }}-link-redirect-url={{ def
 identity-provider-Google-factory = {{ default .Env.idp_Google_factory "us.kbase.auth2.providers.GoogleIdentityProviderFactory" }}
 identity-provider-Google-login-url={{ default .Env.idp_Google_login_url "https://accounts.google.com/" }}
 identity-provider-Google-api-url={{ default .Env.idp_Google_api_url "https://www.googleapis.com/" }}
-identity-provider-Google-custom-people-api-host={{default .Env.idp_Google_custom_people_api_host "https://people.googleapis.com" }}
 identity-provider-Google-client-id={{ default .Env.idp_Google_client_id "kbaseauth" }}
 identity-provider-Google-client-secret={{ default .Env.idp_Google_client_secret "mocksecret" }}
 identity-provider-Google-login-redirect-url={{ default .Env.auth_base_url "https://ci.kbase.us/services/auth" }}/login/complete/google


### PR DESCRIPTION
For an unknown reason, the email address list is missing from a subset
of users of the Google People API. The email address and display name
are also contained in the OpenID JWT included in the OAuth2 response, so
try extracting from there instead.