### PR TITLE
Decouple logger and exception handler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,9 @@ Authentication Service MKII release notes
 -----
 
 * The service is now tested against OpenJDK 8 and 11.
+  * Note that the compiler compliance level must still be set at 1.8. The server fails to
+    start if the compliance level is 11, likely due to out of date jars, including, possibly,
+    jersey repackaged asm jars.
 
 0.4.0
 -----

--- a/build.xml
+++ b/build.xml
@@ -135,6 +135,16 @@
     <fileset file="${dist}/${testjar.file}"/>
   </path>
 	
+  <target name="print-classpath">
+    <pathconvert property="classpathInName" refid="compile.classpath"/>
+    <echo>Classpath is ${classpathInName}</echo>
+  </target>
+
+  <target name="print-test-classpath">
+    <pathconvert property="classpathInName" refid="test.classpath"/>
+    <echo>Classpath is ${classpathInName}</echo>
+  </target>
+	
   <target name="build" depends="compile,buildwar,script,javadoc"
     description="build everything"/>
 

--- a/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -234,11 +234,6 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 		public void setCallInfo(String method, String id, String ipAddress) {
 			//  do nothing
 		}
-
-		@Override
-		public String getCallID() {
-			return null;
-		}
 	}
 
 	private static class JsonServerSysLogAutoLogger implements SLF4JAutoLogger {
@@ -260,11 +255,6 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 			rpc.setId(id);
 			rpc.setIp(ipAddress);
 			rpc.setMethod(method);
-		}
-
-		@Override
-		public String getCallID() {
-			return JsonServerSyslog.getCurrentRpcInfo().getId();
 		}
 	}
 	

--- a/src/us/kbase/auth2/service/ContextFields.java
+++ b/src/us/kbase/auth2/service/ContextFields.java
@@ -1,0 +1,17 @@
+package us.kbase.auth2.service;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+
+/** Field names for items added to request or response context objects.
+ * 
+ * @see ContainerRequestContext
+ * @see ContainerResponseContext
+ *
+ */
+public class ContextFields {
+
+	/** The ID of a request. Type must be String. */
+	public final static String REQUEST_ID = "request_id";
+	
+}

--- a/src/us/kbase/auth2/service/LoggingFilter.java
+++ b/src/us/kbase/auth2/service/LoggingFilter.java
@@ -1,6 +1,7 @@
 package us.kbase.auth2.service;
 
 import static us.kbase.auth2.service.common.ServiceCommon.nullOrEmpty;
+import static us.kbase.auth2.service.ContextFields.REQUEST_ID; 
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -56,10 +57,10 @@ public class LoggingFilter implements ContainerRequestFilter,
 					"An error occurred in the logger when attempting " +
 					"to get the server configuration", e); 
 		}
-		logger.setCallInfo(reqcon.getMethod(),
-				(String.format("%.16f", Math.random())).substring(2),
-				getIpAddress(reqcon, ignoreIPheaders));
 		
+		final String requestID = (String.format("%.16f", Math.random())).substring(2);
+		logger.setCallInfo(reqcon.getMethod(), requestID, getIpAddress(reqcon, ignoreIPheaders));
+		reqcon.setProperty(REQUEST_ID, requestID);
 		logHeaders(reqcon, ignoreIPheaders);
 	}
 	

--- a/src/us/kbase/auth2/service/SLF4JAutoLogger.java
+++ b/src/us/kbase/auth2/service/SLF4JAutoLogger.java
@@ -18,9 +18,4 @@ public interface SLF4JAutoLogger {
 			final String method,
 			final String id,
 			final String ipAddress);
-	
-	/** Get the call ID for the call being handled in this thread.
-	 * @return the call ID.
-	 */
-	public String getCallID();
 }

--- a/src/us/kbase/test/auth2/TestConfigurator.java
+++ b/src/us/kbase/test/auth2/TestConfigurator.java
@@ -82,10 +82,6 @@ public class TestConfigurator implements AuthStartupConfig {
 			rpc.setMethod(method);
 		}
 
-		@Override
-		public String getCallID() {
-			return JsonServerSyslog.getCurrentRpcInfo().getId();
-		}
 	}
 	
 	public TestConfigurator() {

--- a/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
+++ b/src/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
@@ -53,10 +53,8 @@ public class KBaseAuthConfigTest {
 	}
 	
 	private void testLogger(final SLF4JAutoLogger logger, final boolean nullLogger) {
-		// too much of a pain to really test. Just test manually which is trivial.
+		// too much of a pain to really test. Just test it accepts the call
 		logger.setCallInfo("GET", "foo", "0.0.0.0");
-		
-		assertThat("incorrect ID", logger.getCallID(), is(nullLogger ? (String) null : "foo"));
 	}
 
 	@Test


### PR DESCRIPTION
1) Makes it easier to change the logger without having to futz with the
exception handler
2) Makes it easier to reuse this code in the WS