### PR TITLE
Add a /testmode endpoint that mimics /

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Test mode data is only accessible via endpoints under the `/testmode` root endpo
 These endpoints mimic the behavior of the standard API endpoints above, but only interact with
 test mode data.
 
+GET /testmode  
+
 GET /testmode/api/V2/me  
 
 GET /testmode/api/V2/token  
@@ -261,7 +263,8 @@ Developer notes
 * Releases
   * The master branch is the stable branch. Releases are made from the develop branch to the master
     branch.
-  * Update the version as per the semantic version rules in `src/us/kbase/auth2/ui/Root.java`.
+  * Update the version as per the semantic version rules in
+    `src/us/kbase/auth2/service/common/ServiceCommon.java`.
   * Tag the version in git and github.
 
 ### Running tests

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@ Authentication Service MKII release notes
 0.4.1
 -----
 
+* Added a `/testmode` endpoint that mimics the standard root endpoint.
 * The service is now tested against OpenJDK 8 and 11.
   * Note that the compiler compliance level must still be set at 1.8. The server fails to
     start if the compliance level is 11, likely due to out of date jars, including, possibly,

--- a/src/us/kbase/auth2/service/api/TestMode.java
+++ b/src/us/kbase/auth2/service/api/TestMode.java
@@ -54,6 +54,7 @@ import us.kbase.auth2.lib.token.TokenName;
 import us.kbase.auth2.lib.token.TokenType;
 import us.kbase.auth2.service.common.Fields;
 import us.kbase.auth2.service.common.IncomingJSON;
+import us.kbase.auth2.service.common.ServiceCommon;
 
 @Path(APIPaths.TESTMODE)
 public class TestMode {
@@ -65,6 +66,12 @@ public class TestMode {
 	@Inject
 	public TestMode(final Authentication auth) {
 		this.auth = auth;
+	}
+	
+	@GET
+	@Produces(MediaType.APPLICATION_JSON)
+	public Map<String, Object> testRoot() {
+		return ServiceCommon.root();
 	}
 	
 	public static class CreateTestUser extends IncomingJSON {

--- a/src/us/kbase/auth2/service/common/Fields.java
+++ b/src/us/kbase/auth2/service/common/Fields.java
@@ -19,6 +19,8 @@ public class Fields {
 	
 	/** The version of the service. */
 	public static final String VERSION = "version";
+	/** The service name. */
+	public static final String SERVICE_NAME = "servicename";
 	/** The time, in milliseconds since the epoch, at the service. */
 	public static final String SERVER_TIME = "servertime";
 	/** The Git commit from which the service was built. */

--- a/src/us/kbase/auth2/service/common/ServiceCommon.java
+++ b/src/us/kbase/auth2/service/common/ServiceCommon.java
@@ -3,6 +3,7 @@ package us.kbase.auth2.service.common;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -12,6 +13,9 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.auth2.GitCommit;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
@@ -35,10 +39,24 @@ import us.kbase.auth2.service.exceptions.AuthConfigurationException;
  */
 public class ServiceCommon {
 	
+	private static final String VERSION = "0.4.1";
+	// TODO FEATURE make configurable. Will need to make this a class & inject into deps
+	private static final String SERVICE_NAME = "Authentication Service";
 	private static final String HEADER_USER_AGENT = "user-agent";
 	private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 	private static final String X_REAL_IP = "X-Real-IP";
 
+	//TODO ZLATER ROOT add paths to endpoints
+	//TODO ZLATER ROOT add configurable contact email or link
+	
+	public static Map<String, Object> root() {
+		return ImmutableMap.of(
+				Fields.VERSION, VERSION,
+				Fields.SERVICE_NAME, SERVICE_NAME,
+				Fields.SERVER_TIME, Instant.now().toEpochMilli(),
+				Fields.GIT_HASH, GitCommit.COMMIT);
+	}
+	
 	/** Create an incoming token from a string, throwing an appropriate exception if the token is
 	 * null or empty.
 	 * @param token the token.

--- a/src/us/kbase/auth2/service/ui/Root.java
+++ b/src/us/kbase/auth2/service/ui/Root.java
@@ -1,6 +1,5 @@
 package us.kbase.auth2.service.ui;
 
-import java.time.Instant;
 import java.util.Map;
 
 import javax.ws.rs.GET;
@@ -10,40 +9,23 @@ import javax.ws.rs.core.MediaType;
 
 import org.glassfish.jersey.server.mvc.Template;
 
-import com.google.common.collect.ImmutableMap;
-
-import us.kbase.auth2.GitCommit;
-import us.kbase.auth2.service.common.Fields;
+import us.kbase.auth2.service.common.ServiceCommon;
 
 @Path(UIPaths.ROOT)
 public class Root {
 	
-	//TODO ZLATER ROOT add configurable server name
-	//TODO ZLATER ROOT add paths to endpoints
-	//TODO ZLATER ROOT add configurable contact email or link
-	
 	//TODO JAVADOC or swagger
-	
-	private static final String VERSION = "0.4.0";
 	
 	@GET
 	@Template(name = "/root")
 	@Produces(MediaType.TEXT_HTML)
 	public Map<String, Object> rootHTML() {
-		return root();
+		return ServiceCommon.root();
 	}
 	
 	@GET
 	@Produces(MediaType.APPLICATION_JSON)
 	public Map<String, Object> rootJSON() {
-		return root();
+		return ServiceCommon.root();
 	}
-	
-	private Map<String, Object> root() {
-		return ImmutableMap.of(
-				Fields.VERSION, VERSION,
-				Fields.SERVER_TIME, Instant.now().toEpochMilli(),
-				Fields.GIT_HASH, GitCommit.COMMIT);
-	}
-
 }

--- a/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
+++ b/src/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
@@ -2,6 +2,7 @@ package us.kbase.test.auth2.service.api;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static us.kbase.test.auth2.service.common.ServiceCommonTest.assertRootJSONCorrect;
 
 import java.net.URI;
 import java.nio.file.Path;
@@ -89,6 +90,28 @@ public class TestModeIntegrationTest {
 	@Before
 	public void beforeTest() throws Exception {
 		ServiceTestUtils.resetServer(manager, host, COOKIE_NAME);
+	}
+	
+	/* the value of the git commit from the root endpoint could either be
+	 * an error message or a git commit hash depending on the test environment, so both are
+	 * allowed
+	 */
+	@Test
+	public void rootJSON() throws Exception {
+		final URI target = UriBuilder.fromUri(host).path("/testmode").build();
+		
+		final WebTarget wt = CLI.target(target);
+		
+		final Builder req = wt.request()
+				.accept(MediaType.APPLICATION_JSON);
+
+		final Response res = req.get();
+		@SuppressWarnings("unchecked")
+		final Map<String, Object> json = res.readEntity(Map.class);
+		
+		assertThat("incorrect response code", res.getStatus(), is(200));
+		
+		assertRootJSONCorrect(json);
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/service/api/TestModeTest.java
+++ b/src/us/kbase/test/auth2/service/api/TestModeTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static us.kbase.test.auth2.TestCommon.set;
+import static us.kbase.test.auth2.service.common.ServiceCommonTest.assertRootJSONCorrect;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -63,6 +64,19 @@ public class TestModeTest {
 	/* Since the TestMode class is only intended to be instantiated by the Jersey framework,
 	 * we do not test for null constructor inputs.
 	 */
+	
+	
+	/* the value of the git commit from the root endpoint could either be
+	 * an error message or a git commit hash depending on the test environment, so both are
+	 * allowed
+	 */
+	@Test
+	public void root() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		final TestMode tm = new TestMode(auth);
+		
+		assertRootJSONCorrect(tm.testRoot());
+	}
 	
 	@Test
 	public void createUser() throws Exception {

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest_rootHTML.testdata
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest_rootHTML.testdata
@@ -2,6 +2,7 @@
 <body>
 
 Auth Server<br/>
+Service name: (.+)<br/>
 Version: ([\w\.-]+)<br/>
 Server time: (\d+)<br/>
 Git commit hash: (.+)<br/>

--- a/templates/root.mustache
+++ b/templates/root.mustache
@@ -2,6 +2,7 @@
 <body>
 
 Auth Server<br/>
+Service name: {{servicename}}<br/>
 Version: {{version}}<br/>
 Server time: {{servertime}}<br/>
 Git commit hash: {{gitcommithash}}<br/>


### PR DESCRIPTION
When starting services, it's good practice to ensure their dependecies
are up - e.g. when starting the workspace it checks that it can contact
auth.

The simplest and cheapest way to do this is to GET / on auth and check that the
response is as expected. However, since there is no corresponding
endpoint at /testmode, it's impossible to test this strategy. This PR
fixes that.