### PR TITLE
Base64 decoder -> URL decoder for Google JWT decode

### DIFF
--- a/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
@@ -187,8 +187,12 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 			}
 			final Map<String, Object> payload;
 			try {
+				// presumably we can trust the token given we just got it from Google
+				// presumably we can assume the email is verified since this is a Google account
+				// should really use a lib here but reading docs they all look like such a pain
+				// to use, given the operations here are so simple
 				// 2nd part of the JSON Web Token (between `.`) contains payload
-				final byte[] jsontoken = Base64.getDecoder().decode(idtoken.split("\\.")[1]);
+				final byte[] jsontoken = Base64.getUrlDecoder().decode(idtoken.split("\\.")[1]);
 				@SuppressWarnings("unchecked")
 				final Map<String, Object> temppayload = MAPPER.readValue(jsontoken, Map.class);
 				payload = temppayload;

--- a/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
@@ -367,7 +367,7 @@ public class GoogleIdentityProviderTest {
 	
 	private String b64json(final Map<String, String> payload) throws Exception {
 		final String json = MAPPER.writeValueAsString(payload);
-		return Base64.getEncoder().encodeToString(json.getBytes());
+		return Base64.getUrlEncoder().encodeToString(json.getBytes());
 	}
 
 	@Test


### PR DESCRIPTION
JWT tokens use the URL variant of Base64:
https://github.com/jwtk/jjwt#what-is-a-json-web-token

Possible fix for:
https://kbase-jira.atlassian.net/browse/PUBLIC-1054