### PR TITLE
Support mongo auth in TestConfigurator / AuthController

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 Authentication Service MKII release notes
 =========================================
 
+0.4.3
+-----
+
+* Added the ability for the test auth controller to authenticate to MongoDB.
+
 0.4.2
 -----
 

--- a/src/us/kbase/auth2/service/common/ServiceCommon.java
+++ b/src/us/kbase/auth2/service/common/ServiceCommon.java
@@ -39,7 +39,7 @@ import us.kbase.auth2.service.exceptions.AuthConfigurationException;
  */
 public class ServiceCommon {
 	
-	private static final String VERSION = "0.4.2";
+	private static final String VERSION = "0.4.3";
 	// TODO FEATURE make configurable. Will need to make this a class & inject into deps
 	private static final String SERVICE_NAME = "Authentication Service";
 	private static final String HEADER_USER_AGENT = "user-agent";

--- a/src/us/kbase/test/auth2/authcontroller/authjars
+++ b/src/us/kbase/test/auth2/authcontroller/authjars
@@ -1,7 +1,7 @@
-kbase/auth2/kbase-auth2templates-0.4.1.zip
+kbase/auth2/kbase-auth2templates-0.4.3.zip
 
-kbase/auth2/kbase-auth2-0.4.1.jar
-kbase/auth2/kbase-auth2test-0.4.1.jar
+kbase/auth2/kbase-auth2-0.4.3.jar
+kbase/auth2/kbase-auth2test-0.4.3.jar
 
 #lib
 apache_commons/commons-codec-1.8.jar

--- a/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -47,7 +47,7 @@ import us.kbase.test.auth2.TestCommon;
 public class ServiceCommonTest {
 	
 	public static final String SERVICE_NAME = "Authentication Service";
-	public static final String SERVER_VER = "0.4.2";
+	public static final String SERVER_VER = "0.4.3";
 	public static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 	


### PR DESCRIPTION
Allows for support of tests that use authenticated mongo and need to
start up a local test auth service.

Current use case is EE2.

Tested manually with mongo with and without auth.