### PR TITLE
Minor renaming in prep for adding PKCE to the OAuth flows.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 Authentication Service MKII release notes
 =========================================
 
+0.5.0
+-----
+
+* BACKWARDS INCOMPATIBILITY - any in flight login or link flows will fail after the server is
+  upgraded to 0.5.0.
+* ADMIN ACTION REQUIRED - before starting the upgraded server, remove all data from the `tempdata`
+  collection to avoid server errors for in flight login or link flows.
+* Added PKCE to the login and link OAuth2 flows. See https://www.oauth.com/oauth2-servers/pkce/
+  for details.
+
 0.4.3
 -----
 

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1788,8 +1788,8 @@ public class Authentication {
 	public LoginState getLoginState(final IncomingToken token)
 			throws AuthStorageException, InvalidTokenException, IdentityProviderErrorException,
 				UnauthorizedException {
-		final TemporarySessionData ids = getTemporaryIdentities(
-				Optional.absent(), Operation.LOGIN, token);
+		final TemporarySessionData ids = getTemporarySessionData(
+				Optional.absent(), Operation.LOGINIDENTS, token);
 		logInfo("Accessed temporary login token {} with {} identities", ids.getId(),
 				ids.getIdentities().get().size());
 		return getLoginState(ids.getIdentities().get(), ids.getExpires());
@@ -1811,7 +1811,7 @@ public class Authentication {
 		return builder.build();
 	}
 
-	private TemporarySessionData getTemporaryIdentities(
+	private TemporarySessionData getTemporarySessionData(
 			Optional<UserName> user,
 			final Operation expectedOperation,
 			final IncomingToken token)
@@ -1902,8 +1902,10 @@ public class Authentication {
 		if (!cfg.getAppConfig().isLoginAllowed()) {
 			throw new UnauthorizedException("Account creation is disabled");
 		}
-		final Set<RemoteIdentity> ids = new HashSet<>(getTemporaryIdentities(
-				Optional.absent(), Operation.LOGIN, token).getIdentities().get());
+		// allow mutation of the identity set
+		final Set<RemoteIdentity> ids = new HashSet<>(
+				getTemporarySessionData(Optional.absent(), Operation.LOGINIDENTS, token)
+				.getIdentities().get());
 		storage.deleteTemporarySessionData(token.getHashedToken());
 		final Optional<RemoteIdentity> match = getIdentity(identityID, ids);
 		if (!match.isPresent()) {
@@ -2220,8 +2222,10 @@ public class Authentication {
 		nonNull(policyIDs, "policyIDs");
 		nonNull(tokenCtx, "tokenCtx");
 		noNulls(policyIDs, "null item in policyIDs");
-		final Set<RemoteIdentity> ids = new HashSet<>(getTemporaryIdentities(
-				Optional.absent(), Operation.LOGIN, token).getIdentities().get());
+		// allow mutation of the identity set
+		final Set<RemoteIdentity> ids = new HashSet<>(
+				getTemporarySessionData(Optional.absent(), Operation.LOGINIDENTS, token)
+				.getIdentities().get());
 		storage.deleteTemporarySessionData(token.getHashedToken());
 		final Optional<RemoteIdentity> ri = getIdentity(identityID, ids);
 		if (!ri.isPresent()) {
@@ -2413,7 +2417,7 @@ public class Authentication {
 			throw new MissingParameterException("authorization code");
 		}
 		final IdentityProvider idp = getIdentityProvider(provider);
-		final TemporarySessionData tids = getTemporaryIdentities(
+		final TemporarySessionData tids = getTemporarySessionData(
 				Optional.absent(), Operation.LINKSTART, token);
 		storage.deleteTemporarySessionData(token.getHashedToken());
 		// UI shouldn't allow disabled users to link
@@ -2533,7 +2537,7 @@ public class Authentication {
 			throw new LinkFailedException("Cannot link identities to local account " +
 					u.getUserName().getName());
 		}
-		final TemporarySessionData tids = getTemporaryIdentities(
+		final TemporarySessionData tids = getTemporarySessionData(
 				Optional.of(u.getUserName()), Operation.LINKIDENTS, linkToken);
 		checkIdentityAccess(u.getUserName(), tids);
 		final LinkIdentities linkIdentities = getLinkIdentities(u, tids);
@@ -2608,7 +2612,7 @@ public class Authentication {
 			throw new LinkFailedException("Cannot link identities to local account " +
 					au.getUserName().getName());
 		}
-		final TemporarySessionData tids = getTemporaryIdentities(
+		final TemporarySessionData tids = getTemporarySessionData(
 				Optional.of(au.getUserName()), Operation.LINKIDENTS, linkToken);
 		storage.deleteTemporarySessionData(linkToken.getHashedToken());
 		checkIdentityAccess(au.getUserName(), tids);
@@ -2649,7 +2653,7 @@ public class Authentication {
 			throw new LinkFailedException("Cannot link identities to local account " +
 					au.getUserName().getName());
 		}
-		final TemporarySessionData tids = getTemporaryIdentities(
+		final TemporarySessionData tids = getTemporarySessionData(
 				Optional.of(au.getUserName()), Operation.LINKIDENTS, linkToken);
 		storage.deleteTemporarySessionData(linkToken.getHashedToken());
 		checkIdentityAccess(au.getUserName(), tids);

--- a/src/us/kbase/auth2/lib/TemporarySessionData.java
+++ b/src/us/kbase/auth2/lib/TemporarySessionData.java
@@ -201,8 +201,8 @@ public class TemporarySessionData {
 	 *
 	 */
 	public static enum Operation {
-		/** The login operation. */
-		LOGIN,
+		/** The last step of the login operation, including identities. */
+		LOGINIDENTS,
 		/** The start of the link operation. */
 		LINKSTART,
 		/** The last step of the link operation, including identities. */
@@ -281,13 +281,14 @@ public class TemporarySessionData {
 					Optional.of(error), Optional.of(errorType));
 		}
 		
-		/** Create temporary session data for a login operation.
+		/** Create temporary session data for a login operation where remote identities are
+		 * involved.
 		 * @param identities the remote identities involved in the login.
 		 * @return the temporary session data.
 		 */
 		public TemporarySessionData login(final Set<RemoteIdentity> identities) {
 			return new TemporarySessionData(
-					Operation.LOGIN, id, created, expires, checkIdents(identities), user,
+					Operation.LOGINIDENTS, id, created, expires, checkIdents(identities), user,
 					error, errorType);
 		}
 

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -1622,7 +1622,7 @@ public class MongoStorage implements AuthStorage {
 		if (op.equals(Operation.ERROR)) {
 			tis = b.error(d.getString(Fields.TEMP_SESSION_ERROR),
 					ErrorType.fromErrorCode(d.getInteger(Fields.TEMP_SESSION_ERROR_TYPE)));
-		} else if (op.equals(Operation.LOGIN)) {
+		} else if (op.equals(Operation.LOGINIDENTS)) {
 			tis = b.login(toIdentities(ids));
 		} else if (op.equals(Operation.LINKSTART)) {
 			tis = b.link(getUserName(d.getString(Fields.TEMP_SESSION_USER)));

--- a/src/us/kbase/auth2/service/common/ServiceCommon.java
+++ b/src/us/kbase/auth2/service/common/ServiceCommon.java
@@ -39,7 +39,7 @@ import us.kbase.auth2.service.exceptions.AuthConfigurationException;
  */
 public class ServiceCommon {
 	
-	private static final String VERSION = "0.4.3";
+	private static final String VERSION = "0.5.0-dev1";
 	// TODO FEATURE make configurable. Will need to make this a class & inject into deps
 	private static final String SERVICE_NAME = "Authentication Service";
 	private static final String HEADER_USER_AGENT = "user-agent";

--- a/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
@@ -783,7 +783,7 @@ public class AuthenticationLinkTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"Operation LINKSTART was attempted with a LOGIN temporary token " + tid,
+				"Operation LINKSTART was attempted with a LOGINIDENTS temporary token " + tid,
 				Authentication.class));
 	}
 	
@@ -1448,7 +1448,7 @@ public class AuthenticationLinkTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User baz attempted operation LINKIDENTS with a LOGIN temporary token " +
+				"User baz attempted operation LINKIDENTS with a LOGINIDENTS temporary token " +
 				tempTokenID, Authentication.class));
 	}
 	
@@ -1742,7 +1742,7 @@ public class AuthenticationLinkTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User baz attempted operation LINKIDENTS with a LOGIN temporary token " +
+				"User baz attempted operation LINKIDENTS with a LOGINIDENTS temporary token " +
 				id, Authentication.class));
 	}
 	
@@ -2259,7 +2259,7 @@ public class AuthenticationLinkTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User baz attempted operation LINKIDENTS with a LOGIN temporary token " +
+				"User baz attempted operation LINKIDENTS with a LOGINIDENTS temporary token " +
 				id, Authentication.class));
 	}
 	

--- a/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
@@ -1075,7 +1075,7 @@ public class AuthenticationLoginTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User foo attempted operation LOGIN with a LINKSTART temporary token " + id,
+				"User foo attempted operation LOGINIDENTS with a LINKSTART temporary token " + id,
 						Authentication.class));
 	}
 	
@@ -1561,8 +1561,8 @@ public class AuthenticationLoginTest {
 						"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User foo attempted operation LOGIN with a LINKSTART temporary token " + tokenID,
-						Authentication.class));
+				"User foo attempted operation LOGINIDENTS with a LINKSTART temporary token "
+				+ tokenID, Authentication.class));
 	}
 	
 	@Test
@@ -2260,8 +2260,8 @@ public class AuthenticationLoginTest {
 				"Temporary token operation type does not match expected operation"));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.ERROR,
-				"User whee attempted operation LOGIN with a LINKSTART temporary token " + tokenID,
-						Authentication.class));
+				"User whee attempted operation LOGINIDENTS with a LINKSTART temporary token "
+				+ tokenID, Authentication.class));
 	}
 	
 	@Test

--- a/src/us/kbase/test/auth2/lib/TemporarySessionDataTest.java
+++ b/src/us/kbase/test/auth2/lib/TemporarySessionDataTest.java
@@ -39,13 +39,13 @@ public class TemporarySessionDataTest {
 	}
 	
 	@Test
-	public void constructLogin() throws Exception {
+	public void constructLoginIdents() throws Exception {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData ti = TemporarySessionData.create(
 				id, now, now.plusMillis(100000)).login(set(REMOTE1, REMOTE2));
 		
-		assertThat("incorrect op", ti.getOperation(), is(Operation.LOGIN));
+		assertThat("incorrect op", ti.getOperation(), is(Operation.LOGINIDENTS));
 		assertThat("incorrect id", ti.getId(), is(id));
 		assertThat("incorrect created", ti.getCreated(), is(now));
 		assertThat("incorrect expires", ti.getExpires(), is(now.plusMillis(100000)));

--- a/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -47,7 +47,7 @@ import us.kbase.test.auth2.TestCommon;
 public class ServiceCommonTest {
 	
 	public static final String SERVICE_NAME = "Authentication Service";
-	public static final String SERVER_VER = "0.4.3";
+	public static final String SERVER_VER = "0.5.0-dev1";
 	public static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 	


### PR DESCRIPTION
In particular, there will soon be a LOGINSTART operation like LINKSTART and so the LOGIN op has been renamed to match the equivalent link op.