### PR TITLE
Add a LOGINSTART temporary session data operation

### DIFF
--- a/src/us/kbase/auth2/lib/TemporarySessionData.java
+++ b/src/us/kbase/auth2/lib/TemporarySessionData.java
@@ -201,6 +201,8 @@ public class TemporarySessionData {
 	 *
 	 */
 	public static enum Operation {
+		/** The start of the login operation. */
+		LOGINSTART,
 		/** The last step of the login operation, including identities. */
 		LOGINIDENTS,
 		/** The start of the link operation. */
@@ -279,6 +281,15 @@ public class TemporarySessionData {
 			return new TemporarySessionData(
 					Operation.ERROR, id, created, expires, identities, user,
 					Optional.of(error), Optional.of(errorType));
+		}
+		
+		/** Create temporary session data for the start of a login operation.
+		 * @return the temporary session data.
+		 */
+		public TemporarySessionData login() {
+			return new TemporarySessionData(
+					Operation.LOGINSTART, id, created, expires, identities, Optional.absent(),
+					error, errorType);
 		}
 		
 		/** Create temporary session data for a login operation where remote identities are

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -135,6 +135,7 @@ public class MongoStorage implements AuthStorage {
 	 */
 	
 	// TODO CODE switch dates to Instants
+	// TODO CODE switch optionals to java standard library implementation
 	
 	private static final int SCHEMA_VERSION = 1;
 	
@@ -1622,6 +1623,8 @@ public class MongoStorage implements AuthStorage {
 		if (op.equals(Operation.ERROR)) {
 			tis = b.error(d.getString(Fields.TEMP_SESSION_ERROR),
 					ErrorType.fromErrorCode(d.getInteger(Fields.TEMP_SESSION_ERROR_TYPE)));
+		} else if (op.equals(Operation.LOGINSTART)) {
+			tis = b.login();
 		} else if (op.equals(Operation.LOGINIDENTS)) {
 			tis = b.login(toIdentities(ids));
 		} else if (op.equals(Operation.LINKSTART)) {

--- a/src/us/kbase/test/auth2/TestCommon.java
+++ b/src/us/kbase/test/auth2/TestCommon.java
@@ -98,6 +98,10 @@ public class TestCommon {
 				.setLevel(ch.qos.logback.classic.Level.OFF);
 	}
 	
+	public static Instant inst(final long epochMillis) {
+		return Instant.ofEpochMilli(epochMillis);
+	}
+	
 	public static void assertExceptionCorrect(
 			final Exception got,
 			final Exception expected) {

--- a/src/us/kbase/test/auth2/lib/TemporarySessionDataTest.java
+++ b/src/us/kbase/test/auth2/lib/TemporarySessionDataTest.java
@@ -3,6 +3,7 @@ package us.kbase.test.auth2.lib;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.time.Instant;
@@ -36,6 +37,23 @@ public class TemporarySessionDataTest {
 	@Test
 	public void equals() {
 		EqualsVerifier.forClass(TemporarySessionData.class).usingGetClass().verify();
+	}
+	
+	@Test
+	public void constructLoginStart() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final TemporarySessionData ti = TemporarySessionData.create(id, inst(10000), inst(20000))
+				.login();
+		
+		assertThat("incorrect op", ti.getOperation(), is(Operation.LOGINSTART));
+		assertThat("incorrect id", ti.getId(), is(id));
+		assertThat("incorrect created", ti.getCreated(), is(inst(10000)));
+		assertThat("incorrect expires", ti.getExpires(), is(inst(20000)));
+		assertThat("incorrect user", ti.getUser(), is(Optional.absent()));
+		assertThat("incorrect idents", ti.getIdentities(), is(Optional.absent()));
+		assertThat("incorrect error", ti.getError(), is(Optional.absent()));
+		assertThat("incorrect error type", ti.getErrorType(), is(Optional.absent()));
+		assertThat("incorrect has error", ti.hasError(), is(false));
 	}
 	
 	@Test
@@ -188,15 +206,14 @@ public class TemporarySessionDataTest {
 	}
 	
 	@Test
-	public void constructLoginFailNulls() throws Exception {
-		failConstructLogin(null, new NullPointerException("identities"));
-		failConstructLogin(set(REMOTE1, null),
-				new NullPointerException("null item in identities"));
-		failConstructLogin(set(),
-				new IllegalArgumentException("empty identities"));
+	public void constructLoginIdentsFailNulls() throws Exception {
+		failConstructLoginIdents(null, new NullPointerException("identities"));
+		failConstructLoginIdents(
+				set(REMOTE1, null), new NullPointerException("null item in identities"));
+		failConstructLoginIdents(set(), new IllegalArgumentException("empty identities"));
 	}
 	
-	private void failConstructLogin(
+	private void failConstructLoginIdents(
 			final Set<RemoteIdentity> idents,
 			final Exception e) {
 		try {

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTempSessionDataTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTempSessionDataTest.java
@@ -3,7 +3,6 @@ package us.kbase.test.auth2.lib.storage.mongo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.time.Instant;
@@ -38,7 +37,20 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 			new RemoteIdentityDetails("user2", "full2", "email2"));
 	
 	@Test
-	public void storeAndGetLogin() throws Exception {
+	public void storeAndGetLoginStart() throws Exception {
+		final UUID id = UUID.randomUUID();
+		final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS); // mongo truncates
+		final TemporarySessionData tsd = TemporarySessionData.create(id, now, now.plusSeconds(10))
+				.login();
+		storage.storeTemporarySessionData(tsd, IncomingToken.hash("whoo"));
+		
+		assertThat("incorrect session data", storage.getTemporarySessionData(
+						new IncomingToken("whoo").getHashedToken()),
+				is(TemporarySessionData.create(id, now, now.plusSeconds(10)).login()));
+	}
+	
+	@Test
+	public void storeAndGetLoginIdents() throws Exception {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS); // mongo truncates
 		final TemporarySessionData tsd = TemporarySessionData.create(id, now, now.plusSeconds(10))

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
@@ -18,7 +18,7 @@ public class MongoStorageTester {
 	
 	static MongoStorageTestManager manager;
 
-	//keeping these so the tests don't have to be refactored. Should really just use the manager
+	// TODO TEST remove these proxies and just access via the manager
 	static MongoController mongo;
 	static MongoClient mc;
 	static MongoDatabase db;
@@ -38,6 +38,7 @@ public class MongoStorageTester {
 		mockClock = manager.mockClock;
 		mongoDBVer = manager.mongoDBVer;
 		indexVer = manager.indexVer;
+		// TODO MONGO stop supporting mongo 2 and remove mongo 2 specific code
 		includeSystemIndexes = mongoDBVer.lessThan(Version.forIntegers(3, 2)) &&
 				!manager.wiredTiger;
 	}


### PR DESCRIPTION
Next step: Save the temporary session data on login start and set a cookie, then store the proof key in the session data and provide it to the 3rd party identity providers.