### PR TITLE
Move token & target link gen inside link / login start methods

### DIFF
--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -1,6 +1,6 @@
 package us.kbase.auth2.lib.identity;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.Set;
 
 import us.kbase.auth2.lib.exceptions.IdentityRetrievalException;
@@ -22,17 +22,17 @@ public interface IdentityProvider {
 	 */
 	String getProviderName();
 	
-	/** Get the url to which a user should be redirected to log in to the identity provider.
+	/** Get the URI to which a user should be redirected to log in to the identity provider.
 	 * @param state the OAuth2 state variable, generally random data large enough to be
-	 * unguessable. The state will be url encoded.
-	 * @param link whether the user should be redirected to a login or link url after completion of
+	 * unguessable. The state will be URL encoded.
+	 * @param link whether the user should be redirected to a login or link URL after completion of
 	 * login at the identity provider.
 	 * @param environment the name of the environment to use when configuring the redirect
-	 * url. Pass null for the default environment.
-	 * @return a login url for the identity provider.
+	 * URL. Pass null for the default environment.
+	 * @return a login URI for the identity provider.
 	 * @throws NoSuchEnvironmentException if there is no such environment configured.
 	 */
-	URL getLoginURL(String state, boolean link, String environment)
+	URI getLoginURI(String state, boolean link, String environment)
 			throws NoSuchEnvironmentException;
 	
 	/** Get a set of identities from an identity provider given an identity provider authcode.
@@ -49,7 +49,7 @@ public interface IdentityProvider {
 			throws IdentityRetrievalException, NoSuchEnvironmentException;
 	
 	/** Get the names of the additional environments beyond the default environment that are
-	 * configured. See {@link #getLoginURL(String, boolean, String)}.
+	 * configured. See {@link #getLoginURI(String, boolean, String)}.
 	 * @return the environments.
 	 */
 	Set<String> getEnvironments();

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -135,6 +135,8 @@ public class MongoStorage implements AuthStorage {
 	 */
 	
 	// TODO CODE switch dates to Instants
+	// Except that as of now the most recent mongo driver version is 4.7 and STILL only has a 
+	// getDate() method and no getInstant() method... not really worth doing until then
 	
 	private static final int SCHEMA_VERSION = 1;
 	

--- a/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
@@ -3,7 +3,6 @@ package us.kbase.auth2.providers;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -104,9 +103,9 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 		
 		// state will be url encoded.
 		@Override
-		public URL getLoginURL(final String state, final boolean link, final String environment)
+		public URI getLoginURI(final String state, final boolean link, final String environment)
 				throws NoSuchEnvironmentException {
-			final URI target = UriBuilder.fromUri(toURI(cfg.getLoginURL()))
+			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)
 					.queryParam("state", state)
@@ -114,7 +113,6 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 					.queryParam("response_type", "code")
 					.queryParam("client_id", cfg.getClientID())
 					.build();
-			return toURL(target);
 		}
 		
 		private URL getRedirectURL(final boolean link, final String environment)
@@ -126,15 +124,6 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 				cfg.getLoginRedirectURL(environment);
 		}
 		
-		//Assumes valid URL in URI form
-		private URL toURL(final URI baseURI) {
-			try {
-				return baseURI.toURL();
-			} catch (MalformedURLException e) {
-				throw new RuntimeException("This should be impossible", e);
-			}
-		}
-	
 		//Assumes valid URI in URL form
 		private URI toURI(final URL loginURL) {
 			try {

--- a/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
@@ -3,7 +3,6 @@ package us.kbase.auth2.providers;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -103,9 +102,9 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 		
 		// state will be url encoded
 		@Override
-		public URL getLoginURL(final String state, final boolean link, final String environment)
+		public URI getLoginURI(final String state, final boolean link, final String environment)
 				throws NoSuchEnvironmentException {
-			final URI target = UriBuilder.fromUri(toURI(cfg.getLoginURL()))
+			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)
 					.queryParam("state", state)
@@ -114,7 +113,6 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 					.queryParam("client_id", cfg.getClientID())
 					.queryParam("prompt", "select_account")
 					.build();
-			return toURL(target);
 		}
 
 		private URL getRedirectURL(final boolean link, final String environment)
@@ -126,15 +124,6 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 				cfg.getLoginRedirectURL(environment);
 		}
 		
-		//Assumes valid URL in URI form
-		private URL toURL(final URI baseURI) {
-			try {
-				return baseURI.toURL();
-			} catch (MalformedURLException e) {
-				throw new RuntimeException("This should be impossible", e);
-			}
-		}
-	
 		//Assumes valid URI in URL form
 		private URI toURI(final URL loginURL) {
 			try {

--- a/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
@@ -3,7 +3,6 @@ package us.kbase.auth2.providers;
 import static us.kbase.auth2.lib.Utils.nonNull;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -98,9 +97,9 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 
 		// state will be url encoded
 		@Override
-		public URL getLoginURL(final String state, final boolean link, final String environment)
+		public URI getLoginURI(final String state, final boolean link, final String environment)
 				throws NoSuchEnvironmentException {
-			final URI target = UriBuilder.fromUri(toURI(cfg.getLoginURL()))
+			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)
 					.queryParam("state", state)
@@ -108,7 +107,6 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 					.queryParam("response_type", "code")
 					.queryParam("client_id", cfg.getClientID())
 					.build();
-			return toURL(target);
 		}
 		
 		private URL getRedirectURL(final boolean link, final String environment)
@@ -120,15 +118,6 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 				cfg.getLoginRedirectURL(environment);
 		}
 		
-		//Assumes valid URL in URI form
-		private URL toURL(final URI baseURI) {
-			try {
-				return baseURI.toURL();
-			} catch (MalformedURLException e) {
-				throw new RuntimeException("This should be impossible", e);
-			}
-		}
-	
 		//Assumes valid URI in URL form
 		private URI toURI(final URL loginURL) {
 			try {

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import static us.kbase.test.auth2.TestCommon.set;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
@@ -148,7 +149,7 @@ public class AuthenticationConstructorTest {
 		}
 
 		@Override
-		public URL getLoginURL(final String state, final boolean link, final String environment) {
+		public URI getLoginURI(final String state, final boolean link, final String environment) {
 			return null;
 		}
 

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -320,17 +320,6 @@ public class AuthenticationTokenTest {
 	}
 	
 	@Test
-	public void getBareToken() throws Exception {
-		final TestMocks testauth = initTestMocks();
-		final Authentication auth = testauth.auth;
-		final RandomDataGenerator rand = testauth.randGenMock;
-		
-		when(rand.getToken()).thenReturn("foobar");
-		
-		assertThat("incorrect token", auth.getBareToken(), is("foobar"));
-	}
-	
-	@Test
 	public void logout() throws Exception {
 		final TestMocks testauth = initTestMocks();
 		final AuthStorage storage = testauth.storageMock;

--- a/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
@@ -7,6 +7,7 @@ import static org.mockserver.model.NottableString.not;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -121,24 +122,24 @@ public class GlobusIdentityProviderTest {
 		final IdentityProvider gip = gc.configure(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Globus"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURL("foo2", false, null),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo2", false, null),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Floginredir.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURL("foo3", true, null),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo3", true, null),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Flinkredir.com" +
 						"&response_type=code&client_id=foo")));
 		
-		assertThat("incorrect login url", gip.getLoginURL("foo2", false, "myenv"),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo2", false, "myenv"),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Fmyloginred.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURL("foo3", true, "myenv"),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo3", true, "myenv"),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Fmylinkred.com" +
 						"&response_type=code&client_id=foo")));
@@ -151,24 +152,24 @@ public class GlobusIdentityProviderTest {
 		final IdentityProvider gip = new GlobusIdentityProvider(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Globus"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURL("foo2", false, null),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo2", false, null),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Floginredir.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURL("foo3", true, null),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo3", true, null),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Flinkredir.com" +
 						"&response_type=code&client_id=foo")));
 		
-		assertThat("incorrect login url", gip.getLoginURL("foo2", false, "myenv"),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo2", false, "myenv"),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Fmyloginred.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURL("foo3", true, "myenv"),
-				is(new URL("https://login.com/v2/oauth2/authorize?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo3", true, "myenv"),
+				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Fmylinkred.com" +
 						"&response_type=code&client_id=foo")));

--- a/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.fail;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Base64;
@@ -120,24 +121,24 @@ public class GoogleIdentityProviderTest {
 		final IdentityProvider gip = gc.configure(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Google"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURL("foo3", false, null),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo3", false, null),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fgloginredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURL("foo4", true, null),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo4", true, null),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fglinkredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
 		
-		assertThat("incorrect login url", gip.getLoginURL("foo3", false, "myenv"),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo3", false, "myenv"),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmygloginred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURL("foo4", true, "myenv"),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo4", true, "myenv"),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyglinkred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
@@ -149,24 +150,24 @@ public class GoogleIdentityProviderTest {
 		final IdentityProvider gip = new GoogleIdentityProvider(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Google"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURL("foo5", false, null),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo5", false, null),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo5&redirect_uri=https%3A%2F%2Fgloginredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURL("foo6", true, null),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo6", true, null),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo6&redirect_uri=https%3A%2F%2Fglinkredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
 		
-		assertThat("incorrect login url", gip.getLoginURL("foo3", false, "myenv"),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect login url", gip.getLoginURI("foo3", false, "myenv"),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmygloginred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURL("foo4", true, "myenv"),
-				is(new URL("https://glogin.com/o/oauth2/v2/auth?" +
+		assertThat("incorrect link url", gip.getLoginURI("foo4", true, "myenv"),
+				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyglinkred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));

--- a/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Arrays;
@@ -116,24 +117,24 @@ public class OrcIDIdentityProviderTest {
 		final IdentityProvider oip = gc.configure(CFG);
 		assertThat("incorrect provider name", oip.getProviderName(), is("OrcID"));
 		assertThat("incorrect environments", oip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", oip.getLoginURL("foo3", false, null),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect login url", oip.getLoginURI("foo3", false, null),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fologinredir.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURL("foo4", true, null),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect link url", oip.getLoginURI("foo4", true, null),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Folinkredir.com" +
 						"&response_type=code&client_id=ofoo")));
 		
-		assertThat("incorrect login url", oip.getLoginURL("foo3", false, "myenv"),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect login url", oip.getLoginURI("foo3", false, "myenv"),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmyologinred.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURL("foo4", true, "myenv"),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect link url", oip.getLoginURI("foo4", true, "myenv"),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyolinkred.com" +
 						"&response_type=code&client_id=ofoo")));
@@ -145,24 +146,24 @@ public class OrcIDIdentityProviderTest {
 		final IdentityProvider oip = new OrcIDIdentityProvider(CFG);
 		assertThat("incorrect provider name", oip.getProviderName(), is("OrcID"));
 		assertThat("incorrect environments", oip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", oip.getLoginURL("foo5", false, null),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect login url", oip.getLoginURI("foo5", false, null),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo5&redirect_uri=https%3A%2F%2Fologinredir.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURL("foo6", true, null),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect link url", oip.getLoginURI("foo6", true, null),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo6&redirect_uri=https%3A%2F%2Folinkredir.com" +
 						"&response_type=code&client_id=ofoo")));
 		
-		assertThat("incorrect login url", oip.getLoginURL("foo3", false, "myenv"),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect login url", oip.getLoginURI("foo3", false, "myenv"),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmyologinred.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURL("foo4", true, "myenv"),
-				is(new URL("https://ologin.com/oauth/authorize?" +
+		assertThat("incorrect link url", oip.getLoginURI("foo4", true, "myenv"),
+				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyolinkred.com" +
 						"&response_type=code&client_id=ofoo")));

--- a/src/us/kbase/test/auth2/service/ui/LinkTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest.java
@@ -14,7 +14,6 @@ import static us.kbase.test.auth2.service.ServiceTestUtils.setLinkCompleteRedire
 import static us.kbase.test.auth2.service.ServiceTestUtils.setPostLinkRedirect;
 
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Arrays;
@@ -80,7 +79,8 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 
 public class LinkTest {
 	
-	//TODO TEST convert most of these to unit tests
+	//TODO TEST convert most of these to unit tests (but make sure to leave reasonable
+	// integration tests)
 	
 	private static final String DB_NAME = "test_link_ui";
 	private static final String COOKIE_NAME = "login-cookie";
@@ -293,8 +293,8 @@ public class LinkTest {
 		final String url = "https://foo.com/someurlorother";
 		
 		final StateMatcher stateMatcher = new StateMatcher();
-		when(provmock.getLoginURL(argThat(stateMatcher), eq(true), eq(expectedEnvVal)))
-				.thenReturn(new URL(url));
+		when(provmock.getLoginURI(argThat(stateMatcher), eq(true), eq(expectedEnvVal)))
+				.thenReturn(new URI(url));
 		
 		final WebTarget wt = CLI.target(host + "/link/start");
 		final Builder b = wt.request();
@@ -342,8 +342,8 @@ public class LinkTest {
 		final String url = "https://foo.com/someurlorother";
 		
 		final StateMatcher stateMatcher = new StateMatcher();
-		when(provmock.getLoginURL(argThat(stateMatcher), eq(true), eq("myenv")))
-				.thenReturn(new URL(url));
+		when(provmock.getLoginURI(argThat(stateMatcher), eq(true), eq("myenv")))
+				.thenReturn(new URI(url));
 		
 		final WebTarget wt = CLI.target(host + "/link/start");
 		final Response res = wt.request()
@@ -391,8 +391,8 @@ public class LinkTest {
 		final String url = "https://foo.com/someurlorother";
 		
 		final StateMatcher stateMatcher = new StateMatcher();
-		when(provmock.getLoginURL(argThat(stateMatcher), eq(true), eq(null)))
-				.thenReturn(new URL(url));
+		when(provmock.getLoginURI(argThat(stateMatcher), eq(true), eq(null)))
+				.thenReturn(new URI(url));
 		
 		final WebTarget wt = CLI.target(host + "/link/start");
 		final Response res = wt.request()


### PR DESCRIPTION
To implement PKCE, will need to generate and store a secret in the DB at link / login start and include the hashed secret in the target URI. This is step one towards that:

* for linking, move the state and URI generation inside the core logic, which is also where we'll generate the PKCE secret and add it to the URI. The unhashed secret shouldn't be exposed outside the core logic.
* for login, create a new method that is the equivalent of the link start method except that the user is unknown (which is enough of a difference it makes merging the methods problematic, so they're separate for now, although their constiuent parts are reasonably DRY)

This also means we can store the state value in the DB rather than a cookie for link / login, which'll be in the next PR.