### PR TITLE
Generate / save / pass PKCE verifier and challenge

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@ Auth2 TODO list
 
 Auth service work
 -----------------
+* When OrcID supports PKCE, implement: https://github.com/ORCID/ORCID-Source/issues/5977
 * Include users's identities in admin user view
 * Complete rich UI (code not in this repo)
   * Currently only covers login, link, me, and tokens.

--- a/src/us/kbase/auth2/lib/identity/IdentityProvider.java
+++ b/src/us/kbase/auth2/lib/identity/IdentityProvider.java
@@ -25,6 +25,8 @@ public interface IdentityProvider {
 	/** Get the URI to which a user should be redirected to log in to the identity provider.
 	 * @param state the OAuth2 state variable, generally random data large enough to be
 	 * unguessable. The state will be URL encoded.
+	 * @param pkceCodeChallenge the OAuth2 PKCE code challenge.
+	 * See https://www.oauth.com/oauth2-servers/pkce/authorization-request/
 	 * @param link whether the user should be redirected to a login or link URL after completion of
 	 * login at the identity provider.
 	 * @param environment the name of the environment to use when configuring the redirect
@@ -32,7 +34,7 @@ public interface IdentityProvider {
 	 * @return a login URI for the identity provider.
 	 * @throws NoSuchEnvironmentException if there is no such environment configured.
 	 */
-	URI getLoginURI(String state, boolean link, String environment)
+	URI getLoginURI(String state, String pkceCodeChallenge, boolean link, String environment)
 			throws NoSuchEnvironmentException;
 	
 	/** Get a set of identities from an identity provider given an identity provider authcode.

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -151,6 +151,8 @@ public class Fields {
 	public static final String TEMP_SESSION_CREATION = "create";
 	/** The OAuth2 request state associated with the temporary session. */
 	public static final String TEMP_SESSION_OAUTH2STATE = "oa2state";
+	/** The OAuth2 PKCE code verifier associated with the temporary session. */
+	public static final String TEMP_SESSION_PKCE_CODE_VERIFIER = "pkcecode";
 	/** The user associated with the temporary token. */
 	public static final String TEMP_SESSION_USER = "user";
 	/** The remote identities associated with the temporary token. */

--- a/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/MongoStorage.java
@@ -1557,6 +1557,8 @@ public class MongoStorage implements AuthStorage {
 				.append(Fields.TEMP_SESSION_EXPIRY, Date.from(data.getExpires()))
 				.append(Fields.TEMP_SESSION_CREATION, Date.from(data.getCreated()))
 				.append(Fields.TEMP_SESSION_OAUTH2STATE, data.getOAuth2State().orElse(null))
+				.append(Fields.TEMP_SESSION_PKCE_CODE_VERIFIER,
+						data.getPKCECodeVerifier().orElse(null))
 				.append(Fields.TEMP_SESSION_ERROR,
 						data.getError().isPresent() ? data.getError().get() : null)
 				.append(Fields.TEMP_SESSION_ERROR_TYPE, data.getErrorType().isPresent() ?
@@ -1626,12 +1628,16 @@ public class MongoStorage implements AuthStorage {
 			tis = b.error(d.getString(Fields.TEMP_SESSION_ERROR),
 					ErrorType.fromErrorCode(d.getInteger(Fields.TEMP_SESSION_ERROR_TYPE)));
 		} else if (op.equals(Operation.LOGINSTART)) {
-			tis = b.login(d.getString(Fields.TEMP_SESSION_OAUTH2STATE));
+			tis = b.login(
+					d.getString(Fields.TEMP_SESSION_OAUTH2STATE),
+					d.getString(Fields.TEMP_SESSION_PKCE_CODE_VERIFIER)
+			);
 		} else if (op.equals(Operation.LOGINIDENTS)) {
 			tis = b.login(toIdentities(ids));
 		} else if (op.equals(Operation.LINKSTART)) {
 			tis = b.link(
 					d.getString(Fields.TEMP_SESSION_OAUTH2STATE),
+					d.getString(Fields.TEMP_SESSION_PKCE_CODE_VERIFIER),
 					getUserName(d.getString(Fields.TEMP_SESSION_USER))
 			);
 		} else if (op.equals(Operation.LINKIDENTS)) {

--- a/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GlobusIdentityProviderFactory.java
@@ -103,8 +103,13 @@ public class GlobusIdentityProviderFactory implements IdentityProviderFactory {
 		
 		// state will be url encoded.
 		@Override
-		public URI getLoginURI(final String state, final boolean link, final String environment)
+		public URI getLoginURI(
+				final String state,
+				final String pkceCodeChallenge,
+				final boolean link,
+				final String environment)
 				throws NoSuchEnvironmentException {
+			// TODO PKCE include code challenge here & accept code verifier below
 			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)

--- a/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/GoogleIdentityProviderFactory.java
@@ -102,8 +102,13 @@ public class GoogleIdentityProviderFactory implements IdentityProviderFactory {
 		
 		// state will be url encoded
 		@Override
-		public URI getLoginURI(final String state, final boolean link, final String environment)
+		public URI getLoginURI(
+				final String state,
+				final String pkceCodeChallenge,
+				final boolean link,
+				final String environment)
 				throws NoSuchEnvironmentException {
+			// TODO PKCE include code challenge here & accept code verifier below
 			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)

--- a/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
+++ b/src/us/kbase/auth2/providers/OrcIDIdentityProviderFactory.java
@@ -97,8 +97,14 @@ public class OrcIDIdentityProviderFactory implements IdentityProviderFactory {
 
 		// state will be url encoded
 		@Override
-		public URI getLoginURI(final String state, final boolean link, final String environment)
+		public URI getLoginURI(
+				final String state,
+				final String pkceCodeChallenge,
+				final boolean link,
+				final String environment)
 				throws NoSuchEnvironmentException {
+			// note that OrcID does not currently implement PKCE so we ignore the code
+			// challenge: https://github.com/ORCID/ORCID-Source/issues/5977
 			return UriBuilder.fromUri(toURI(cfg.getLoginURL()))
 					.path(LOGIN_PATH)
 					.queryParam("scope", SCOPE)

--- a/src/us/kbase/test/auth2/TestCommon.java
+++ b/src/us/kbase/test/auth2/TestCommon.java
@@ -11,10 +11,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -288,6 +291,13 @@ public class TestCommon {
 		return IOUtils.toString(is);
 	}
 	
+	public static String calculatePKCEChallenge(final String pkceVerifier) throws Exception{
+		final MessageDigest digest = MessageDigest.getInstance("SHA-256");
+		final byte[] hash = digest.digest(pkceVerifier.getBytes(StandardCharsets.UTF_8));
+		final String prestrip = Base64.getUrlEncoder().encodeToString(hash);
+		return prestrip.replace("=", "");
+	}
+	
 	public static void assertCloseToNow(final long epochMillis) {
 		final long now = Instant.now().toEpochMilli();
 		assertThat(String.format("time (%s) not within 10000ms of now: %s", epochMillis, now),
@@ -311,7 +321,7 @@ public class TestCommon {
 			final String token)
 			throws Exception {
 		final TemporarySessionData data = TemporarySessionData.create(id, created, lifetimeMS)
-				.link("fakestate", new UserName("foo"));
+				.link("fakestate", "fakepkce", new UserName("foo"));
 		return new TemporaryToken(data, token);
 	}
 }

--- a/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationConstructorTest.java
@@ -149,7 +149,11 @@ public class AuthenticationConstructorTest {
 		}
 
 		@Override
-		public URI getLoginURI(final String state, final boolean link, final String environment) {
+		public URI getLoginURI(
+				final String state,
+				final String pckeChallenge,
+				final boolean link,
+				final String environment) {
 			return null;
 		}
 

--- a/src/us/kbase/test/auth2/lib/OAuth2StartDataTest.java
+++ b/src/us/kbase/test/auth2/lib/OAuth2StartDataTest.java
@@ -27,7 +27,7 @@ public class OAuth2StartDataTest {
 	public void construct() throws Exception {
 		final UUID id = UUID.randomUUID();
 		final TemporaryToken tt = new TemporaryToken(
-				TemporarySessionData.create(id, inst(40000), inst(70000)).login("state"),
+				TemporarySessionData.create(id, inst(40000), inst(70000)).login("state", "pkce"),
 				"sometoken");
 		final OAuth2StartData oa2sd = OAuth2StartData.build(
 				new URI("https://loldemocracy.com"), tt);
@@ -35,7 +35,8 @@ public class OAuth2StartDataTest {
 		assertThat("incorrect uri", oa2sd.getRedirectURI(),
 				is(new URI("https://loldemocracy.com")));
 		assertThat("incorrect token", oa2sd.getTemporaryToken(), is(new TemporaryToken(
-				TemporarySessionData.create(id, inst(40000), inst(70000)).login("otherstate"),
+				TemporarySessionData.create(id, inst(40000), inst(70000))
+					.login("otherstate", "otherpkce"),
 				"sometoken")));
 	}
 	
@@ -43,7 +44,7 @@ public class OAuth2StartDataTest {
 	public void constructFail() throws Exception {
 		final TemporaryToken tt = new TemporaryToken(
 				TemporarySessionData.create(UUID.randomUUID(), inst(40000), inst(70000))
-						.login("state"),
+						.login("state", "pkce"),
 				"sometoken");
 		failConstruct(null, tt, new NullPointerException("redirectURI"));
 		failConstruct(

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTempSessionDataTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTempSessionDataTest.java
@@ -40,13 +40,13 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS); // mongo truncates
 		final TemporarySessionData tsd = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.login("stateystate");
+				.login("stateystate", "pkcecode");
 		storage.storeTemporarySessionData(tsd, IncomingToken.hash("whoo"));
 		
 		assertThat("incorrect session data", storage.getTemporarySessionData(
 						new IncomingToken("whoo").getHashedToken()),
 				is(TemporarySessionData.create(
-						id, now, now.plusSeconds(10)).login("stateystate")));
+						id, now, now.plusSeconds(10)).login("stateystate", "pkcecode")));
 	}
 	
 	@Test
@@ -82,13 +82,13 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS); // mongo truncates
 		final TemporarySessionData tsd = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("otherstate", new UserName("whee"));
+				.link("otherstate", "pkceothercode", new UserName("whee"));
 		storage.storeTemporarySessionData(tsd, IncomingToken.hash("foobar"));
 		
 		assertThat("incorrect session data", storage.getTemporarySessionData(
 				new IncomingToken("foobar").getHashedToken()), is(
 						TemporarySessionData.create(id, now, now.plusSeconds(10))
-							.link("otherstate", new UserName("whee"))));
+							.link("otherstate", "pkceothercode", new UserName("whee"))));
 	}
 	
 	@Test
@@ -110,7 +110,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData tsd = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 		failStoreTemporarySessionData(null, "foo", new NullPointerException("data"));
 		failStoreTemporarySessionData(tsd, null,
 				new IllegalArgumentException("Missing argument: hash"));
@@ -123,9 +123,9 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData data = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 		final TemporarySessionData data2 = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee2"));
+				.link("state", "pkce", new UserName("whee2"));
 		storage.storeTemporarySessionData(data, "whee");
 		failStoreTemporarySessionData(data2, "whee2", new IllegalArgumentException(
 				"Temporary token ID " + id + " already exists in the database"));
@@ -137,10 +137,10 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id2 = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData data = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 		final TemporarySessionData data2 = TemporarySessionData
 				.create(id2, now, now.plusSeconds(10))
-				.link("state", new UserName("whee2"));
+				.link("state", "pkce", new UserName("whee2"));
 		storage.storeTemporarySessionData(data, "whee");
 		failStoreTemporarySessionData(data2, "whee", new IllegalArgumentException(
 				"Token hash for temporary token ID " + id2 +
@@ -179,7 +179,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		 */
 		final UUID id = UUID.randomUUID();
 		final TemporarySessionData data = TemporarySessionData.create(id, Instant.now(), 0)
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 
 		storage.storeTemporarySessionData(data, IncomingToken.hash("foobar"));
 		
@@ -206,7 +206,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id2 = UUID.randomUUID();
 		final TemporarySessionData tsd2 = TemporarySessionData
 				.create(id2, now, now.plusSeconds(10))
-				.link("state", new UserName("foo"));
+				.link("state", "pkce", new UserName("foo"));
 		storage.storeTemporarySessionData(tsd2, IncomingToken.hash("foobar2"));
 		
 		db.getCollection("tempdata").updateOne(new Document("id", id2.toString()),
@@ -233,7 +233,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData data = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 
 		storage.storeTemporarySessionData(data, IncomingToken.hash("foobar"));
 		
@@ -262,7 +262,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData data = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 
 		storage.storeTemporarySessionData(data, IncomingToken.hash("foobar"));
 		// check token is there
@@ -280,7 +280,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 		final UUID id = UUID.randomUUID();
 		final Instant now = Instant.now();
 		final TemporarySessionData data = TemporarySessionData.create(id, now, now.plusSeconds(10))
-				.link("state", new UserName("whee"));
+				.link("state", "pkce", new UserName("whee"));
 
 		storage.storeTemporarySessionData(data, IncomingToken.hash("foobar"));
 		// check token is there
@@ -297,7 +297,7 @@ public class MongoStorageTempSessionDataTest extends MongoStorageTester {
 	public void deleteTwoTempDatasByUser() throws Exception {
 		final Instant now = Instant.now();
 		final TemporarySessionData data1 = TemporarySessionData.create(UUID.randomUUID(),
-				now, now.plusSeconds(10)).link("state", new UserName("whee"));
+				now, now.plusSeconds(10)).link("state", "pkce", new UserName("whee"));
 		final TemporarySessionData data2 = TemporarySessionData.create(UUID.randomUUID(),
 				now, now.plusSeconds(10)).link(new UserName("whee"), set(REMOTE1));
 		

--- a/src/us/kbase/test/auth2/lib/token/TokenTest.java
+++ b/src/us/kbase/test/auth2/lib/token/TokenTest.java
@@ -131,7 +131,7 @@ public class TokenTest {
 		final Instant i = Instant.ofEpochMilli(4000);
 		final UUID id = UUID.randomUUID();
 		final TemporarySessionData data = TemporarySessionData.create(id, i, 5)
-				.link("state", new UserName("a"));
+				.link("state", "pkce", new UserName("a"));
 		final TemporaryToken tt = new TemporaryToken(data, "foobar");
 		assertThat("incorrect token string", tt.getToken(), is("foobar"));
 		assertThat("incorrect ID", tt.getId(), is(UUID.fromString(id.toString())));

--- a/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GlobusIdentityProviderTest.java
@@ -122,23 +122,23 @@ public class GlobusIdentityProviderTest {
 		final IdentityProvider gip = gc.configure(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Globus"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURI("foo2", false, null),
+		assertThat("incorrect login url", gip.getLoginURI("foo2", "pkce", false, null),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Floginredir.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURI("foo3", true, null),
+		assertThat("incorrect link url", gip.getLoginURI("foo3", "pkce", true, null),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Flinkredir.com" +
 						"&response_type=code&client_id=foo")));
 		
-		assertThat("incorrect login url", gip.getLoginURI("foo2", false, "myenv"),
+		assertThat("incorrect login url", gip.getLoginURI("foo2", "pkce", false, "myenv"),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Fmyloginred.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURI("foo3", true, "myenv"),
+		assertThat("incorrect link url", gip.getLoginURI("foo3", "pkce", true, "myenv"),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Fmylinkred.com" +
@@ -152,23 +152,23 @@ public class GlobusIdentityProviderTest {
 		final IdentityProvider gip = new GlobusIdentityProvider(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Globus"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURI("foo2", false, null),
+		assertThat("incorrect login url", gip.getLoginURI("foo2", "pkce", false, null),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Floginredir.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURI("foo3", true, null),
+		assertThat("incorrect link url", gip.getLoginURI("foo3", "pkce", true, null),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Flinkredir.com" +
 						"&response_type=code&client_id=foo")));
 		
-		assertThat("incorrect login url", gip.getLoginURI("foo2", false, "myenv"),
+		assertThat("incorrect login url", gip.getLoginURI("foo2", "pkce", false, "myenv"),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo2&redirect_uri=https%3A%2F%2Fmyloginred.com" +
 						"&response_type=code&client_id=foo")));
-		assertThat("incorrect link url", gip.getLoginURI("foo3", true, "myenv"),
+		assertThat("incorrect link url", gip.getLoginURI("foo3", "pkce", true, "myenv"),
 				is(new URI("https://login.com/v2/oauth2/authorize?" +
 						"scope=urn%3Aglobus%3Aauth%3Ascope%3Aauth.globus.org%3Aview_identities+" +
 						"email&state=foo3&redirect_uri=https%3A%2F%2Fmylinkred.com" +

--- a/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/GoogleIdentityProviderTest.java
@@ -121,23 +121,23 @@ public class GoogleIdentityProviderTest {
 		final IdentityProvider gip = gc.configure(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Google"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURI("foo3", false, null),
+		assertThat("incorrect login url", gip.getLoginURI("foo3", "pkce", false, null),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fgloginredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURI("foo4", true, null),
+		assertThat("incorrect link url", gip.getLoginURI("foo4", "pkce", true, null),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fglinkredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
 		
-		assertThat("incorrect login url", gip.getLoginURI("foo3", false, "myenv"),
+		assertThat("incorrect login url", gip.getLoginURI("foo3", "pkce", false, "myenv"),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmygloginred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURI("foo4", true, "myenv"),
+		assertThat("incorrect link url", gip.getLoginURI("foo4", "pkce", true, "myenv"),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyglinkred.com" +
@@ -150,23 +150,23 @@ public class GoogleIdentityProviderTest {
 		final IdentityProvider gip = new GoogleIdentityProvider(CFG);
 		assertThat("incorrect provider name", gip.getProviderName(), is("Google"));
 		assertThat("incorrect environments", gip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", gip.getLoginURI("foo5", false, null),
+		assertThat("incorrect login url", gip.getLoginURI("foo5", "pkce", false, null),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo5&redirect_uri=https%3A%2F%2Fgloginredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURI("foo6", true, null),
+		assertThat("incorrect link url", gip.getLoginURI("foo6", "pkce", true, null),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo6&redirect_uri=https%3A%2F%2Fglinkredir.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
 		
-		assertThat("incorrect login url", gip.getLoginURI("foo3", false, "myenv"),
+		assertThat("incorrect login url", gip.getLoginURI("foo3", "pkce", false, "myenv"),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmygloginred.com" +
 						"&response_type=code&client_id=gfoo&prompt=select_account")));
-		assertThat("incorrect link url", gip.getLoginURI("foo4", true, "myenv"),
+		assertThat("incorrect link url", gip.getLoginURI("foo4", "pkce", true, "myenv"),
 				is(new URI("https://glogin.com/o/oauth2/v2/auth?" +
 						"scope=profile+email" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyglinkred.com" +

--- a/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
+++ b/src/us/kbase/test/auth2/providers/OrcIDIdentityProviderTest.java
@@ -117,23 +117,23 @@ public class OrcIDIdentityProviderTest {
 		final IdentityProvider oip = gc.configure(CFG);
 		assertThat("incorrect provider name", oip.getProviderName(), is("OrcID"));
 		assertThat("incorrect environments", oip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", oip.getLoginURI("foo3", false, null),
+		assertThat("incorrect login url", oip.getLoginURI("foo3", "pkce", false, null),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fologinredir.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURI("foo4", true, null),
+		assertThat("incorrect link url", oip.getLoginURI("foo4", "pkce", true, null),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Folinkredir.com" +
 						"&response_type=code&client_id=ofoo")));
 		
-		assertThat("incorrect login url", oip.getLoginURI("foo3", false, "myenv"),
+		assertThat("incorrect login url", oip.getLoginURI("foo3", "pkce", false, "myenv"),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmyologinred.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURI("foo4", true, "myenv"),
+		assertThat("incorrect link url", oip.getLoginURI("foo4", "pkce", true, "myenv"),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyolinkred.com" +
@@ -146,23 +146,23 @@ public class OrcIDIdentityProviderTest {
 		final IdentityProvider oip = new OrcIDIdentityProvider(CFG);
 		assertThat("incorrect provider name", oip.getProviderName(), is("OrcID"));
 		assertThat("incorrect environments", oip.getEnvironments(), is(set("myenv")));
-		assertThat("incorrect login url", oip.getLoginURI("foo5", false, null),
+		assertThat("incorrect login url", oip.getLoginURI("foo5", "pkce", false, null),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo5&redirect_uri=https%3A%2F%2Fologinredir.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURI("foo6", true, null),
+		assertThat("incorrect link url", oip.getLoginURI("foo6", "pkce", true, null),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo6&redirect_uri=https%3A%2F%2Folinkredir.com" +
 						"&response_type=code&client_id=ofoo")));
 		
-		assertThat("incorrect login url", oip.getLoginURI("foo3", false, "myenv"),
+		assertThat("incorrect login url", oip.getLoginURI("foo3", "pkce", false, "myenv"),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo3&redirect_uri=https%3A%2F%2Fmyologinred.com" +
 						"&response_type=code&client_id=ofoo")));
-		assertThat("incorrect link url", oip.getLoginURI("foo4", true, "myenv"),
+		assertThat("incorrect link url", oip.getLoginURI("foo4", "pkce", true, "myenv"),
 				is(new URI("https://ologin.com/oauth/authorize?" +
 						"scope=%2Fauthenticate" +
 						"&state=foo4&redirect_uri=https%3A%2F%2Fmyolinkred.com" +

--- a/src/us/kbase/test/auth2/service/ui/PKCEChallengeMatcher.java
+++ b/src/us/kbase/test/auth2/service/ui/PKCEChallengeMatcher.java
@@ -13,7 +13,7 @@ public class PKCEChallengeMatcher implements ArgumentMatcher<String> {
 	@Override
 	public boolean matches(final String pkceChallenge) {
 		assertThat("invalid PKCE challenge value",
-				pkceChallenge, RegexMatcher.matches("[a-zA-Z0-9-_]{43}"));
+				pkceChallenge, RegexMatcher.matches("^[a-zA-Z0-9-_]{43}$"));
 		capturedChallenge = pkceChallenge;
 		return true;
 	}

--- a/src/us/kbase/test/auth2/service/ui/PKCEChallengeMatcher.java
+++ b/src/us/kbase/test/auth2/service/ui/PKCEChallengeMatcher.java
@@ -1,0 +1,21 @@
+package us.kbase.test.auth2.service.ui;
+
+import static org.junit.Assert.assertThat;
+
+import org.mockito.ArgumentMatcher;
+
+import us.kbase.common.test.RegexMatcher;
+
+public class PKCEChallengeMatcher implements ArgumentMatcher<String> {
+	
+	public String capturedChallenge = null; 
+
+	@Override
+	public boolean matches(final String pkceChallenge) {
+		assertThat("invalid PKCE challenge value",
+				pkceChallenge, RegexMatcher.matches("[a-zA-Z0-9-_]{43}"));
+		capturedChallenge = pkceChallenge;
+		return true;
+	}
+
+}

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
@@ -320,7 +320,7 @@ public class SimpleEndpointsTest {
 		
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(
 				UUID.randomUUID(), Instant.now(), Instant.now().plusSeconds(10))
-				.link("state", new UserName("whoo")), IncomingToken.hash("foo"));
+				.link("state", "pkce", new UserName("whoo")), IncomingToken.hash("foo"));
 		
 		final WebTarget wt = CLI.target(target);
 		
@@ -351,7 +351,7 @@ public class SimpleEndpointsTest {
 	
 		manager.storage.storeTemporarySessionData(TemporarySessionData.create(
 				UUID.randomUUID(), Instant.now(), Instant.now().plusSeconds(10))
-				.link("state", new UserName("whoo")), IncomingToken.hash("foo"));
+				.link("state", "pkce", new UserName("whoo")), IncomingToken.hash("foo"));
 		
 		final WebTarget wt = CLI.target(target);
 		

--- a/src/us/kbase/test/auth2/service/ui/StateMatcher.java
+++ b/src/us/kbase/test/auth2/service/ui/StateMatcher.java
@@ -12,7 +12,7 @@ public class StateMatcher implements ArgumentMatcher<String> {
 	
 	@Override
 	public boolean matches(String state) {
-		assertThat("invalid state value", state, RegexMatcher.matches("[A-Z2-7]{32}"));
+		assertThat("invalid state value", state, RegexMatcher.matches("^[A-Z2-7]{32}$"));
 		capturedState = state;
 		return true;
 	}


### PR DESCRIPTION
For now the identity provider wrappers just ignore the challenge, that'll come later (other than OrcID, which doesn't support it)