### PR TITLE
Make Dockerfile build self-sufficient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+FROM kbase/sdkbase2 as build
+
+COPY . /tmp/auth2
+RUN cd /tmp \
+    && git clone https://github.com/kbase/jars \
+    && cd auth2 \
+    && ant buildwar
+
 FROM kbase/kb_jre:latest
 
 # These ARGs values are passed in via the docker build command
@@ -5,8 +13,8 @@ ARG BUILD_DATE
 ARG VCS_REF
 ARG BRANCH=develop
 
-COPY deployment/ /kb/deployment/
-COPY jettybase/ /kb/deployment/jettybase/
+COPY --from=build /tmp/auth2/deployment/ /kb/deployment/
+COPY --from=build /tmp/auth2/jettybase/ /kb/deployment/jettybase/
 
 # The BUILD_DATE value seem to bust the docker cache when the timestamp changes, move to
 # the end

--- a/build.xml
+++ b/build.xml
@@ -216,13 +216,6 @@
     </copy>
   </target>
 
-  <target name="docker_image" depends="buildwar" description="build the docker image">
-    <!-- make the docker image that for auth2 -->
-    <exec executable="./build/build_docker_image.sh">
-    </exec>
-
-  </target>
-
   <target name="javadoc" description="build javadocs">
     <javadoc access="protected"
              author="false"


### PR DESCRIPTION
The Dockerfile previously depended on the build being run prior to the docker build step