### PR TITLE
Refactor to prep for multi-token user searches

### DIFF
--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -1092,7 +1092,7 @@ public class Authentication {
 			final UserSearchSpec spec)
 			throws InvalidTokenException, UnauthorizedException, AuthStorageException {
 		nonNull(spec, "spec");
-		if (spec.isRegex()) {
+		if (spec.hasSearchRegex()) {
 			throw new UnauthorizedException("Regex search is currently for internal use only");
 		}
 		final AuthUser user = getUser(token, new OpReqs("search users"));
@@ -1100,7 +1100,7 @@ public class Authentication {
 			if (spec.isCustomRoleSearch() || spec.isRoleSearch()) {
 				throw new UnauthorizedException("Only admins may search on roles");
 			}
-			if (!spec.getSearchPrefix().isPresent()) {
+			if (!spec.hasSearchPrefixes()) {
 				throw new UnauthorizedException("Only admins may search without a prefix");
 			}
 			if (spec.isRootIncluded() || spec.isDisabledIncluded()) {

--- a/src/us/kbase/auth2/lib/DisplayName.java
+++ b/src/us/kbase/auth2/lib/DisplayName.java
@@ -31,14 +31,14 @@ public class DisplayName extends Name {
 		super(name, "display name", MAX_NAME_LENGTH);
 	}
 	
-	/** Get the canonical display name for a string. Returns a list of the whitespace separated
-	 * tokens in the name. The tokens are lowercased, punctuation in the token is removed, and
-	 * non-unique elements are removed.
+	/** Get the canonical display name for a string. Returns a list of the whitespace and hyphen
+	 * separated tokens in the name. The tokens are lowercased, punctuation in the token is
+	 * removed, and non-unique elements are removed.
 	 * @return the canonical display name.
 	 */
 	public static List<String> getCanonicalDisplayName(final String name) {
 		checkStringNoCheckedException(name, "name");
-		final String[] tokens = name.toLowerCase().split("\\s+");
+		final String[] tokens = name.toLowerCase().split("[-\\s]");
 		final Set<String> ret = new LinkedHashSet<>();
 		for (final String t: tokens) {
 			final StringBuilder sb = new StringBuilder();
@@ -51,9 +51,9 @@ public class DisplayName extends Name {
 		return new LinkedList<>(ret);
 	}
 	
-	/** Get the canonical display name for this name. Returns a list of the whitespace separated
-	 * tokens in the display name. The tokens are lowercased, punctuation in the token is removed,
-	 * and non-unique elements are removed.
+	/** Get the canonical display name for this name. Returns a list of the whitespace and hyphen
+	 * separated tokens in the display name. The tokens are lowercased, punctuation in the token
+	 * is removed, and non-unique elements are removed.
 	 * @return the canonical display name.
 	 */
 	public List<String> getCanonicalDisplayName() {

--- a/src/us/kbase/auth2/lib/DisplayName.java
+++ b/src/us/kbase/auth2/lib/DisplayName.java
@@ -1,7 +1,11 @@
 package us.kbase.auth2.lib;
 
+import static us.kbase.auth2.lib.Utils.checkStringNoCheckedException;
+
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.MissingParameterException;
@@ -27,37 +31,33 @@ public class DisplayName extends Name {
 		super(name, "display name", MAX_NAME_LENGTH);
 	}
 	
-	/** Get the canonical display name for this name. Returns a list of the whitespace separated
-	 * tokens in the display name. The tokens are lowercased and punctuation on either side of the
-	 * token is removed.
+	/** Get the canonical display name for a string. Returns a list of the whitespace separated
+	 * tokens in the name. The tokens are lowercased, punctuation in the token is removed, and
+	 * non-unique elements are removed.
 	 * @return the canonical display name.
 	 */
-	public List<String> getCanonicalDisplayName() {
-		final String[] tokens = getName().toLowerCase().split("\\s+");
-		final List<String> ret = new LinkedList<>();
+	public static List<String> getCanonicalDisplayName(final String name) {
+		checkStringNoCheckedException(name, "name");
+		final String[] tokens = name.toLowerCase().split("\\s+");
+		final Set<String> ret = new LinkedHashSet<>();
 		for (final String t: tokens) {
-			final int[] codepoints = t.codePoints().toArray();
-			int start;
-			for (start = 0; start < codepoints.length; start++) {
-				if (Character.isLetterOrDigit(codepoints[start])) {
-					break;
-				}
-			}
-			int end;
-			for (end = codepoints.length - 1; end > start; end--) {
-				if (Character.isLetterOrDigit(codepoints[end])) {
-					break;
-				}
-			}
-			if (start <= end) {
-				final StringBuilder sb = new StringBuilder();
-				for (int i = start; i <= end; i++) {
-					sb.appendCodePoint(codepoints[i]);
-				}
+			final StringBuilder sb = new StringBuilder();
+			t.codePoints().filter(cp -> Character.isLetterOrDigit(cp))
+					.forEach(cp -> sb.appendCodePoint(cp));
+			if (sb.length() > 0) {
 				ret.add(sb.toString());
 			}
 		}
-		return ret;
+		return new LinkedList<>(ret);
+	}
+	
+	/** Get the canonical display name for this name. Returns a list of the whitespace separated
+	 * tokens in the display name. The tokens are lowercased, punctuation in the token is removed,
+	 * and non-unique elements are removed.
+	 * @return the canonical display name.
+	 */
+	public List<String> getCanonicalDisplayName() {
+		return getCanonicalDisplayName(getName());
 	}
 	
 	@Override

--- a/src/us/kbase/auth2/lib/UserSearchSpec.java
+++ b/src/us/kbase/auth2/lib/UserSearchSpec.java
@@ -249,8 +249,8 @@ public class UserSearchSpec {
 		/** Set a prefix by which the user name and / or tokenized display name will be searched.
 		 * The prefix will replace the search regex, if any.
 		 * The prefix matches the start of the username or the start of any part of the whitespace
-		 * tokenized display name.
-		 * The prefix is always split by whitespace, punctuation removed, and
+		 * and hyphen tokenized display name.
+		 * The prefix is always split by whitespace and hyphens, punctuation removed, and
 		 * converted to lower case.
 		 * Once the prefix or search regex is set in this builder it cannot be removed.
 		 * @param prefix the prefix.

--- a/src/us/kbase/auth2/lib/UserSearchSpec.java
+++ b/src/us/kbase/auth2/lib/UserSearchSpec.java
@@ -1,9 +1,13 @@
 package us.kbase.auth2.lib;
 
 import static us.kbase.auth2.lib.Utils.nonNull;
+import static us.kbase.auth2.lib.Utils.checkStringNoCheckedException;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,75 +25,91 @@ public class UserSearchSpec {
 	
 	//TODO ZLATER CODE don't expose regex externally. Not sure how best to do this without duplicating a lot of the class. For now setting regex is default access (package only).
 	
-	private final Optional<String> prefix;
+	private final List<String> prefixes;
+	private final String regex;
 	private final boolean searchUser;
 	private final boolean searchDisplayName;
 	private final Set<Role> searchRoles;
 	private final Set<String> searchCustomRoles;
-	private final boolean isRegex;
 	private final boolean includeRoot;
 	private final boolean includeDisabled;
 
 	private UserSearchSpec(
-			final Optional<String> prefix,
+			final List<String> prefixes,
+			final String regex,
 			final boolean searchUser,
 			final boolean searchDisplayName,
 			final Set<Role> searchRoles,
 			final Set<String> searchCustomRoles,
-			final boolean isRegex,
 			final boolean includeRoot,
 			final boolean includeDisabled) {
-		this.prefix = prefix;
+		this.prefixes = prefixes == null ? null : Collections.unmodifiableList(prefixes);
+		this.regex = regex;
 		this.searchUser = searchUser;
 		this.searchDisplayName = searchDisplayName;
 		this.searchRoles = searchRoles;
 		this.searchCustomRoles = searchCustomRoles;
-		this.isRegex = isRegex;
 		this.includeRoot = includeRoot;
 		this.includeDisabled = includeDisabled;
 	}
 
-	/** Returns the user and/or display name prefix or regex for the search, if any.
-	 * The prefix matches the start of the username or the start of any part of the whitespace
+	/** Returns the user and/or display name prefixes for the search, if any.
+	 * The prefixes match the start of the username or the start of any part of the whitespace
 	 * tokenized display name.
-	 * 
-	 * A regex should be applied as is. isRegex() will be true if the prefix is actually a regex.
 	 * @return the search prefix.
 	 */
-	public Optional<String> getSearchPrefix() {
-		return prefix;
+	public List<String> getSearchPrefixes() {
+		return prefixes == null ? Collections.emptyList() : prefixes;
 	}
 	
-	/** Returns true if a search prefix is set and that prefix should be treated as a regular
-	 * expression rather than just a prefix, false otherwise.
-	 * @return true if the search prefix is a regex
+	/** Returns the user and/or display name regex for the search, if any.
+	 * A regex should be applied as is.
+	 * @return the search prefix.
 	 */
-	public boolean isRegex() {
-		return isRegex;
+	public Optional<String> getSearchRegex() {
+		return Optional.ofNullable(regex);
+	}
+	
+	/** Returns true if the regex is set. This means the search prefix is not set.
+	 * @return true if the regex is set.
+	 */
+	public boolean hasSearchRegex() {
+		return regex != null;
+	}
+	
+	/** Returns true if the search prefixes are set. This means the search regex is not set.
+	 * @ return true if the search prefixes are set.
+	 */
+	public boolean hasSearchPrefixes() {
+		return prefixes != null;
+	}
+	
+	private boolean hasSearchString() {
+		return prefixes != null || regex != null;
 	}
 
 	/** Returns true if a search should occur on the user's user name.
 	 * 
 	 * True when a) a prefix or regex is provided and b) withSearchOnUserName() was called with a
-	 * true argument or neither searchOnUserName() nor searchOnDisplayName() were called with a
-	 * true argument.
+	 * true argument or neither withSearchOnUserName() nor withSearchOnDisplayName() were called
+	 * with a true argument.
 	 * @return whether the search should occur on the user's user name with the provided prefix or
 	 * regex.
 	 */
 	public boolean isUserNameSearch() {
-		return searchUser || (prefix.isPresent() && !searchDisplayName);
+		return searchUser || (hasSearchString() && !searchDisplayName);
 	}
 
 	/** Returns true if a search should occur on the user's tokenized display name.
 	 * 
 	 * True when a) a prefix or regex is provided and b) withSearchOnDisplayName() was called with
-	 * a true argument or neither searchOnUserName() nor searchOnDisplayName() were called with a
-	 * true argument.
+	 * a true argument or neither withSearchOnUserName() nor withSearchOnDisplayName() were
+	 * called with a true argument.
 	 * @return whether the search should occur on the users's display name with the provided
 	 * prefix or regex.
 	 */
 	public boolean isDisplayNameSearch() {
-		return searchDisplayName || (prefix.isPresent() && !searchUser);
+		return searchDisplayName || (hasSearchString() && !searchUser);
 	}
 	
 	/** Returns true if a search should occur on the user's roles.
@@ -183,17 +203,8 @@ public class UserSearchSpec {
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + (includeDisabled ? 1231 : 1237);
-		result = prime * result + (includeRoot ? 1231 : 1237);
-		result = prime * result + (isRegex ? 1231 : 1237);
-		result = prime * result + ((prefix == null) ? 0 : prefix.hashCode());
-		result = prime * result + ((searchCustomRoles == null) ? 0 : searchCustomRoles.hashCode());
-		result = prime * result + (searchDisplayName ? 1231 : 1237);
-		result = prime * result + ((searchRoles == null) ? 0 : searchRoles.hashCode());
-		result = prime * result + (searchUser ? 1231 : 1237);
-		return result;
+		return Objects.hash(includeDisabled, includeRoot, prefixes, regex,
+				searchCustomRoles, searchDisplayName, searchRoles, searchUser);
 	}
 
 	@Override
@@ -208,43 +219,14 @@ public class UserSearchSpec {
 			return false;
 		}
 		UserSearchSpec other = (UserSearchSpec) obj;
-		if (includeDisabled != other.includeDisabled) {
-			return false;
-		}
-		if (includeRoot != other.includeRoot) {
-			return false;
-		}
-		if (isRegex != other.isRegex) {
-			return false;
-		}
-		if (prefix == null) {
-			if (other.prefix != null) {
-				return false;
-			}
-		} else if (!prefix.equals(other.prefix)) {
-			return false;
-		}
-		if (searchCustomRoles == null) {
-			if (other.searchCustomRoles != null) {
-				return false;
-			}
-		} else if (!searchCustomRoles.equals(other.searchCustomRoles)) {
-			return false;
-		}
-		if (searchDisplayName != other.searchDisplayName) {
-			return false;
-		}
-		if (searchRoles == null) {
-			if (other.searchRoles != null) {
-				return false;
-			}
-		} else if (!searchRoles.equals(other.searchRoles)) {
-			return false;
-		}
-		if (searchUser != other.searchUser) {
-			return false;
-		}
-		return true;
+		return includeDisabled == other.includeDisabled
+				&& includeRoot == other.includeRoot
+				&& Objects.equals(prefixes, other.prefixes)
+				&& Objects.equals(regex, other.regex)
+				&& Objects.equals(searchCustomRoles, other.searchCustomRoles)
+				&& searchDisplayName == other.searchDisplayName
+				&& Objects.equals(searchRoles, other.searchRoles)
+				&& searchUser == other.searchUser;
 	}
 
 	/** A builder for a UserSearchSpec.
@@ -253,12 +235,12 @@ public class UserSearchSpec {
 	 */
 	public static class Builder {
 		
-		private Optional<String> prefix = Optional.empty();
+		private List<String> prefixes = null;
+		private String regex = null;
 		private boolean searchUser = false;
 		private boolean searchDisplayName = false;
 		private final Set<Role> searchRoles = new HashSet<>();
 		private final Set<String> searchCustomRoles = new HashSet<>();
-		private boolean isRegex = false;
 		private boolean includeRoot = false;
 		private boolean includeDisabled = false;
 		
@@ -268,17 +250,20 @@ public class UserSearchSpec {
 		 * The prefix will replace the search regex, if any.
 		 * The prefix matches the start of the username or the start of any part of the whitespace
 		 * tokenized display name.
-		 * The prefix is always converted to lower case.
+		 * The prefix is always split by whitespace, punctuation removed, and
+		 * converted to lower case.
 		 * Once the prefix or search regex is set in this builder it cannot be removed.
 		 * @param prefix the prefix.
 		 * @return this builder.
 		 */
 		public Builder withSearchPrefix(final String prefix) {
-			if (prefix == null || prefix.trim().isEmpty()) {
-				throw new IllegalArgumentException("Prefix cannot be null or the empty string");
-			}
-			this.prefix = Optional.of(prefix.toLowerCase());
-			this.isRegex = false;
+			checkStringNoCheckedException(prefix, "prefix");
+			this.prefixes = Arrays.asList(prefix.toLowerCase());
+			// TODO NAMESEARCHBUGFIX use this line instead & update tests.
+			//this.prefixes = DisplayName.getCanonicalDisplayName(prefix);
+			// TODO NAMESEARCHBUGFIX add a cli command to update canonical names in the db.
+			// TODO NAMESEARCHBUGFIX release notes & version bump
+			this.regex = null;
 			return this;
 		}
 		
@@ -292,11 +277,8 @@ public class UserSearchSpec {
 		 * @return this builder.
 		 */
 		Builder withSearchRegex(final String regex) {
-			if (regex == null || regex.trim().isEmpty()) {
-				throw new IllegalArgumentException("Regex cannot be null or the empty string");
-			}
-			this.prefix = Optional.of(regex);
-			this.isRegex = true;
+			this.regex = checkStringNoCheckedException(regex, "regex");
+			this.prefixes = null;
 			return this;
 		}
 		
@@ -323,9 +305,9 @@ public class UserSearchSpec {
 		}
 
 		private void checkSearchPrefix(final boolean search) {
-			if (search && !this.prefix.isPresent()) {
+			if (search && prefixes == null && regex == null) {
 				throw new IllegalStateException(
-						"Must provide a prefix if a name search is to occur");
+						"Must provide a prefix or regex if a name search is to occur");
 			}
 		}
 		
@@ -378,8 +360,8 @@ public class UserSearchSpec {
 		 * @return a UserSearchSpec.
 		 */
 		public UserSearchSpec build() {
-			return new UserSearchSpec(prefix, searchUser, searchDisplayName, searchRoles,
-					searchCustomRoles, isRegex, includeRoot, includeDisabled);
+			return new UserSearchSpec(prefixes, regex, searchUser, searchDisplayName, searchRoles,
+					searchCustomRoles, includeRoot, includeDisabled);
 		}
 	}
 }

--- a/src/us/kbase/auth2/lib/Utils.java
+++ b/src/us/kbase/auth2/lib/Utils.java
@@ -59,13 +59,15 @@ public class Utils {
 	/** As checkString(), but doesn't throw a checked exception.
 	 * @param s the string to check.
 	 * @param name the name of the string to use in any error messages.
+	 * @return The string, trimmed.
 	 */
-	public static void checkStringNoCheckedException(
+	public static String checkStringNoCheckedException(
 			final String s,
 			final String name) {
 		if (s == null || s.trim().isEmpty()) {
 			throw new IllegalArgumentException("Missing argument: " + name);
 		}
+		return s.trim();
 	}
 
 	/** Adds two longs, returning Long.MAX_VALUE or Long.MIN_VALUE, as appropriate, if the

--- a/src/us/kbase/test/auth2/TestCommon.java
+++ b/src/us/kbase/test/auth2/TestCommon.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -159,6 +160,11 @@ public class TestCommon {
 	@SafeVarargs
 	public static <T> Set<T> set(T... objects) {
 		return new HashSet<T>(Arrays.asList(objects));
+	}
+	
+	@SafeVarargs
+	public static <T> List<T> list(T... objects) {
+		return Arrays.asList(objects);
 	}
 	
 	public static final Optional<String> ES = Optional.empty();

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
@@ -281,10 +281,10 @@ public class AuthenticationGetUserDisplayNamesTest {
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
-		final UserSearchSpec spec = UserSearchSpec.getBuilder().withSearchPrefix("foo").build();
-		final Field m = spec.getClass().getDeclaredField("isRegex");
+		final UserSearchSpec spec = UserSearchSpec.getBuilder().withIncludeDisabled(true).build();
+		final Field m = spec.getClass().getDeclaredField("regex");
 		m.setAccessible(true);
-		m.set(spec, true);
+		m.set(spec, "foo");
 		
 		failGetDisplayNamesSpec(user, spec, new UnauthorizedException(ErrorType.UNAUTHORIZED,
 				"Regex search is currently for internal use only"));

--- a/src/us/kbase/test/auth2/lib/DisplayNameTest.java
+++ b/src/us/kbase/test/auth2/lib/DisplayNameTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -50,10 +51,29 @@ public class DisplayNameTest {
 	}
 	
 	@Test
-	public void canonical() throws Exception {
-		final DisplayName dn = new DisplayName("whEe   ΅·   +΅BA՞+R·   (bleΔah)  ՞  wuΞgga");
-		assertThat("incorrect canonical name", dn.getCanonicalDisplayName(),
-				is(Arrays.asList("whee", "ba՞+r", "bleδah", "wuξgga")));
+	public void getCanonicalDisplayName() throws Exception {
+		final String input = "whEe1   ΅·   +΅BA՞+R·   (bleΔah)  ՞  wuΞgga    bA()*&R";
+		final List<String> expected = Arrays.asList("whee1", "bar", "bleδah", "wuξgga");
+		final DisplayName dn = new DisplayName(input);
+		assertThat("incorrect canonical name", dn.getCanonicalDisplayName(), is(expected));
+		assertThat("incorrect canonical name", DisplayName.getCanonicalDisplayName(input),
+			is(expected));
+	}
+	
+	@Test
+	public void getCanonicalDisplayNameFail() throws Exception {
+		failGetCanonicalDisplayName(null);
+		failGetCanonicalDisplayName("   \t    ");
+	}
+	
+	private void failGetCanonicalDisplayName(final String name) {
+		try {
+			DisplayName.getCanonicalDisplayName(name);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(
+					got, new IllegalArgumentException("Missing argument: name"));
+		}
 	}
 
 }

--- a/src/us/kbase/test/auth2/lib/DisplayNameTest.java
+++ b/src/us/kbase/test/auth2/lib/DisplayNameTest.java
@@ -52,8 +52,10 @@ public class DisplayNameTest {
 	
 	@Test
 	public void getCanonicalDisplayName() throws Exception {
-		final String input = "whEe1   ΅·   +΅BA՞+R·   (bleΔah)  ՞  wuΞgga    bA()*&R";
-		final List<String> expected = Arrays.asList("whee1", "bar", "bleδah", "wuξgga");
+		final String input =
+				"whEe1   ΅·   +΅BA՞+R·   (bleΔah)  ՞  wuΞgga  wentworth-fungus   bA()*&R";
+		final List<String> expected = Arrays.asList(
+				"whee1", "bar", "bleδah", "wuξgga", "wentworth", "fungus");
 		final DisplayName dn = new DisplayName(input);
 		assertThat("incorrect canonical name", dn.getCanonicalDisplayName(), is(expected));
 		assertThat("incorrect canonical name", DisplayName.getCanonicalDisplayName(input),

--- a/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
+++ b/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
@@ -5,10 +5,13 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import static us.kbase.test.auth2.TestCommon.set;
+import static us.kbase.test.auth2.TestCommon.list;
+import static us.kbase.test.auth2.TestCommon.opt;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.junit.Test;
 
@@ -21,6 +24,8 @@ import us.kbase.test.auth2.TestCommon;
 
 public class UserSearchSpecTest {
 	
+	private static final Optional<String> MT = Optional.empty();
+	
 	@Test
 	public void equals() {
 		EqualsVerifier.forClass(UserSearchSpec.class).usingGetClass().verify();
@@ -29,7 +34,7 @@ public class UserSearchSpecTest {
 	@Test
 	public void buildWithEverything() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
-				.withSearchPrefix("Foo")
+				.withSearchPrefix("Foo bar")
 				.withSearchOnUserName(true)
 				.withSearchOnDisplayName(true)
 				.withSearchOnRole(Role.ADMIN)
@@ -40,8 +45,10 @@ public class UserSearchSpecTest {
 				.withIncludeDisabled(true)
 				.build();
 		
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo bar")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(true));
@@ -59,8 +66,10 @@ public class UserSearchSpecTest {
 	@Test
 	public void buildWithNothing() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder().build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().isPresent(), is(false));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(false));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(false));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -77,8 +86,10 @@ public class UserSearchSpecTest {
 	public void buildWithPrefixOnly() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchPrefix("foO").build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -96,8 +107,10 @@ public class UserSearchSpecTest {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchPrefix("foo")
 				.withSearchOnUserName(true).build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(false));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -117,8 +130,10 @@ public class UserSearchSpecTest {
 				.withSearchOnDisplayName(true)
 				.withSearchOnCustomRole("bar")
 				.withSearchOnRole(Role.SERV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(false));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(true));
@@ -135,8 +150,10 @@ public class UserSearchSpecTest {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnCustomRole("foo")
 				.withSearchOnRole(Role.DEV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().isPresent(), is(false));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(false));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(false));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(true));
@@ -152,8 +169,10 @@ public class UserSearchSpecTest {
 	public void buildRoleSearch() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnRole(Role.DEV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().isPresent(), is(false));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(false));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(false));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(true));
@@ -170,8 +189,10 @@ public class UserSearchSpecTest {
 	public void resetSearch() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder().withSearchPrefix("foo")
 				.withSearchOnUserName(false).withSearchOnDisplayName(false).build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -189,8 +210,10 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder();
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("\\Qfoo.bar\\E"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(true));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(opt("\\Qfoo.bar\\E")));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(true));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -215,8 +238,10 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder().withSearchPrefix("foo");
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("\\Qfoo.bar\\E"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(true));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(opt("\\Qfoo.bar\\E")));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(true));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -234,8 +259,10 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder();
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.withSearchPrefix("foo").build();
-		assertThat("incorrect prefix", uss.getSearchPrefix().get(), is("foo"));
-		assertThat("incorrect isRegex()", uss.isRegex(), is(false));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
+		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
+		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
 		assertThat("incorrect user search", uss.isUserNameSearch(), is(true));
 		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
 		assertThat("incorrect role search", uss.isRoleSearch(), is(false));
@@ -246,6 +273,17 @@ public class UserSearchSpecTest {
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
 		assertThat("incorrect include root", uss.isRootIncluded(), is(false));
 		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(false));
+	}
+	
+	@Test
+	public void immutablePrefixes() {
+		final UserSearchSpec uss = UserSearchSpec.getBuilder().withSearchPrefix("foo bar").build();
+		try {
+			uss.getSearchPrefixes().add("baz");
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			//test passed
+		}
 	}
 	
 	@Test
@@ -275,9 +313,11 @@ public class UserSearchSpecTest {
 	@Test
 	public void addPrefixFail() {
 		failAddPrefix(null, new IllegalArgumentException(
-				"Prefix cannot be null or the empty string"));
+				// TODO CODE change to cannot be null or a whitespace only string
+				//           this has huge repercussions though, later
+				"Missing argument: prefix"));
 		failAddPrefix("   \t   \n  ", new IllegalArgumentException(
-				"Prefix cannot be null or the empty string"));
+				"Missing argument: prefix"));
 	}
 	
 	private void failAddPrefix(final String prefix, final Exception e) {
@@ -292,9 +332,9 @@ public class UserSearchSpecTest {
 	@Test
 	public void addRegexFail() throws Exception {
 		failAddRegex(null, new IllegalArgumentException(
-				"Regex cannot be null or the empty string"));
+				"Missing argument: regex"));
 		failAddRegex("   \t   \n  ", new IllegalArgumentException(
-				"Regex cannot be null or the empty string"));
+				"Missing argument: regex"));
 	}
 	
 	private void failAddRegex(final String regex, final Exception e) throws Exception {
@@ -313,7 +353,7 @@ public class UserSearchSpecTest {
 			fail("expected exception");
 		} catch (IllegalStateException e) {
 			assertThat("incorrect exception message", e.getMessage(),
-					is("Must provide a prefix if a name search is to occur"));
+					is("Must provide a prefix or regex if a name search is to occur"));
 		}
 	}
 	
@@ -324,7 +364,7 @@ public class UserSearchSpecTest {
 			fail("expected exception");
 		} catch (IllegalStateException e) {
 			assertThat("incorrect exception message", e.getMessage(),
-					is("Must provide a prefix if a name search is to occur"));
+					is("Must provide a prefix or regex if a name search is to occur"));
 		}
 	}
 	

--- a/src/us/kbase/test/auth2/lib/UtilsTest.java
+++ b/src/us/kbase/test/auth2/lib/UtilsTest.java
@@ -48,7 +48,12 @@ public class UtilsTest {
 	@Test
 	public void checkString() throws Exception {
 		Utils.checkString(TestCommon.LONG1001, "name");
-		Utils.checkStringNoCheckedException(TestCommon.LONG1001, "name");
+		assertThat("incorrect response",
+				Utils.checkStringNoCheckedException(" \t   no whitespace   \t ", "name"),
+				is("no whitespace"));
+		assertThat("incorrect response",
+				Utils.checkStringNoCheckedException(TestCommon.LONG1001, "name"),
+				is(TestCommon.LONG1001));
 		Utils.checkString("ok", "name", 2);
 		Utils.checkString(" \n  ok   \t", "name", 2);
 	}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -593,8 +593,9 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		expected.put(new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"));
 		expected.put(new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "));
 		
+		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("wh+").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("wh").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -610,8 +611,9 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"));
 		
+		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("wh+e").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("whe").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -627,8 +629,9 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "));
 		
+		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("wh+o").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("who").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -641,11 +644,9 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 				new UserName("whee"), new DisplayName("*&wbar#@  wh+oo;; "), NOW, REMOTE2)
 				.build());
 		
-		final Map<UserName, DisplayName> expected = new HashMap<>();
-		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
 				.withSearchPrefix("fwhe").withSearchOnDisplayName(true).build(), -1),
-				is(expected));
+				is(Collections.emptyMap()));
 	}
 	
 	@Test


### PR DESCRIPTION
Objective here is to allow searches like "Dave Smi" to match "Dave Smith", etc. Currently it matches nothing as the entire string is treated as a single token. These changes make multiple tokens possible while not yet changing behavior (mostly).

Next steps:
* Tokenize the query and update and add tests
* Add a CLI option to run through all the users in the DB and recanonicalize the display names

Step towards fixing #351 