### PR TITLE
Tokenize display name search query

### DIFF
--- a/src/us/kbase/auth2/lib/UserSearchSpec.java
+++ b/src/us/kbase/auth2/lib/UserSearchSpec.java
@@ -3,7 +3,6 @@ package us.kbase.auth2.lib;
 import static us.kbase.auth2.lib.Utils.nonNull;
 import static us.kbase.auth2.lib.Utils.checkStringNoCheckedException;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -258,9 +257,7 @@ public class UserSearchSpec {
 		 */
 		public Builder withSearchPrefix(final String prefix) {
 			checkStringNoCheckedException(prefix, "prefix");
-			this.prefixes = Arrays.asList(prefix.toLowerCase());
-			// TODO NAMESEARCHBUGFIX use this line instead & update tests.
-			//this.prefixes = DisplayName.getCanonicalDisplayName(prefix);
+			this.prefixes = DisplayName.getCanonicalDisplayName(prefix);
 			// TODO NAMESEARCHBUGFIX add a cli command to update canonical names in the db.
 			// TODO NAMESEARCHBUGFIX release notes & version bump
 			this.regex = null;

--- a/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
+++ b/src/us/kbase/test/auth2/lib/UserSearchSpecTest.java
@@ -34,7 +34,7 @@ public class UserSearchSpecTest {
 	@Test
 	public void buildWithEverything() {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
-				.withSearchPrefix("Foo bar")
+				.withSearchPrefix("F*oo bar  *()")
 				.withSearchOnUserName(true)
 				.withSearchOnDisplayName(true)
 				.withSearchOnRole(Role.ADMIN)
@@ -45,7 +45,7 @@ public class UserSearchSpecTest {
 				.withIncludeDisabled(true)
 				.build();
 		
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo bar")));
+		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo", "bar")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -445,8 +445,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		
 
 		final Map<UserName, DisplayName> expected = new HashMap<>();
-		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
-		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"));
 		expected.put(new UserName("u3"), new DisplayName("al douglas"));
 		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
 		
@@ -464,8 +464,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		
 
 		final Map<UserName, DisplayName> expected = new HashMap<>();
-		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
-		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"));
 		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
 		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
@@ -482,8 +482,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		
 
 		final Map<UserName, DisplayName> expected = new HashMap<>();
-		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
-		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"));
 		expected.put(new UserName("u4"), new DisplayName("Albert HevensyDouglas"));
 		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
@@ -593,9 +593,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		expected.put(new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"));
 		expected.put(new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "));
 		
-		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("wh").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("wh+").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -611,9 +610,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"));
 		
-		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("whe").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("wh+e").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -629,9 +627,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "));
 		
-		// TODO NAMESEARCHBUGFIX put punctuation back in
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
-				.withSearchPrefix("who").withSearchOnDisplayName(true).build(), -1),
+				.withSearchPrefix("wh+o").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
 	
@@ -654,8 +651,8 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		createUsersForCanonicalSearch();
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
-		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
-		expected.put(new UserName("u2"), new DisplayName("Herbert Dougie Howser"));
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"));
 		expected.put(new UserName("u3"), new DisplayName("al douglas"));
 		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
@@ -668,7 +665,7 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		createUsersForCanonicalSearch();
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
-		expected.put(new UserName("u1"), new DisplayName("Douglas J Adams"));
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
 		expected.put(new UserName("u3"), new DisplayName("al douglas"));
 		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
@@ -700,12 +697,77 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 				.withSearchPrefix("Alb").withSearchOnDisplayName(true).build(), -1),
 				is(expected));
 	}
+	
+	@Test
+	public void canonicalSearchMultitokenAndPunctuation() throws Exception {
+		createUsersForCanonicalSearch();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("u3"), new DisplayName("al douglas"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("D'oug A*").withSearchOnDisplayName(true).build(), -1),
+				is(expected));
+	}
+	
+	@Test
+	public void canonicalAndUserMultitokenSearch1() throws Exception {
+		createUsersForCanonicalAndUserSearch();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("adamsly"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("adamsly2"), new DisplayName("Herbert Doug~ie Howser"));
+		expected.put(new UserName("ada"), new DisplayName("al douglas"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("ada*").build(), -1),
+				is(expected));
+	}
+	
+	@Test
+	public void canonicalAndUserMultitokenSearch2() throws Exception {
+		createUsersForCanonicalAndUserSearch();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("adamsly"), new DisplayName("Dou*glas J Ad()ams"));
+		expected.put(new UserName("adamsly2"), new DisplayName("Herbert Doug~ie Howser"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("a'dams").build(), -1),
+				is(expected));
+	}
+	
+	@Test
+	public void canonicalAndUserMultitokenSearch3() throws Exception {
+		createUsersForCanonicalAndUserSearch();
+		
+		final Map<UserName, DisplayName> expected = new HashMap<>();
+		expected.put(new UserName("adamsly"), new DisplayName("Dou*glas J Ad()ams"));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("ada* Dougl").build(), -1),
+				is(expected));
+	}
+	
+	private void createUsersForCanonicalAndUserSearch() throws Exception {
+		storage.createUser(NewUser.getBuilder(
+				new UserName("adamsly"), new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1).build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("adamsly2"), new DisplayName("Herbert Doug~ie Howser"), NOW, REMOTE2)
+				.build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("ada"), new DisplayName("al douglas"), NOW, REMOTE3).build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("adlbert"), new DisplayName("Albert HevensyDouglas"), NOW, REMOTE4)
+				.build());
+	}
 
 	private void createUsersForCanonicalSearch() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("u1"), new DisplayName("Douglas J Adams"), NOW, REMOTE1).build());
+				new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("u2"), new DisplayName("Herbert Dougie Howser"), NOW, REMOTE2)
+				new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"), NOW, REMOTE2)
 				.build());
 		storage.createUser(NewUser.getBuilder(
 				new UserName("u3"), new DisplayName("al douglas"), NOW, REMOTE3).build());

--- a/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -94,6 +94,7 @@ public class UserEndpointTest {
 			Thread.sleep(1000);
 		}
 		port = server.getPort();
+		System.out.println("Server started on port " + port);
 		host = "http://localhost:" + port;
 	}
 	
@@ -595,7 +596,7 @@ public class UserEndpointTest {
 				"foobarbazbing".getBytes(), "aa".getBytes());
 
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foo"),
-				new DisplayName("bar"), Instant.ofEpochMilli(20000))
+				new DisplayName("bar *thing*"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("baz"),
@@ -670,12 +671,12 @@ public class UserEndpointTest {
 	
 	@Test
 	public void searchUsersBlankFields() throws Exception {
-		searchUsers("f", "   \t ,   ", ImmutableMap.of("foo", "bar", "baz", "fuz"));
+		searchUsers("f", "   \t ,   ", ImmutableMap.of("foo", "bar *thing*", "baz", "fuz"));
 	}
 	
 	@Test
 	public void searchUsersUserName() throws Exception {
-		searchUsers("f", " username  ,  \t  ", ImmutableMap.of("foo", "bar"));
+		searchUsers("f", " username  ,  \t  ", ImmutableMap.of("foo", "bar *thing*"));
 	}
 	
 	@Test
@@ -686,7 +687,24 @@ public class UserEndpointTest {
 	@Test
 	public void searchUsersBothFields() throws Exception {
 		searchUsers("f", " displayname   \t ,   \t username   ",
-				ImmutableMap.of("foo", "bar", "baz", "fuz"));
+				ImmutableMap.of("foo", "bar *thing*", "baz", "fuz"));
+	}
+	
+	@Test
+	public void searchUsersBothFields2() throws Exception {
+		searchUsers("b", " displayname   \t ,   \t username   ",
+				ImmutableMap.of("foo", "bar *thing*", "baz", "fuz", "toobar", "bleah2"));
+	}
+	
+	@Test
+	public void searchUsersMultitoken() throws Exception {
+		searchUsers("b th", " displayname   \t ,   \t username   ",
+				ImmutableMap.of("foo", "bar *thing*"));
+	}
+	
+	@Test
+	public void searchUsersMultitoken2() throws Exception {
+		searchUsers("b%20th", "", ImmutableMap.of("foo", "bar *thing*"));
 	}
 	
 	private void searchUsers(


### PR DESCRIPTION
Follow on from #385 

Objective here is to allow searches like "Dave Smi" to match "Dave Smith", etc. Currently it matches nothing as the entire string is treated as a single token. These changes make multiple tokens possible while not yet changing behavior (mostly).

Next steps:
 * Add a CLI option to run through all the users in the DB and recanonicalize the display names
 * Release notes & bump version.

Step towards fixing https://github.com/kbase/auth2/issues/351