### PR TITLE
PTV-1890: Add an anonymous ID to users

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -389,6 +389,7 @@
         <classpath refid="test.classpath"/>
         <formatter type="plain" usefile="false" />
         <sysproperty key="AUTH2_TEST_CONFIG" value="${testcfg}"/>
+        <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageAnonymousIDBackfillingTest"/>
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageConfigTest"/>
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageCustomRoleTest"/>
         <test name="us.kbase.test.auth2.lib.storage.mongo.MongoStorageTestRoleTest"/>

--- a/src/us/kbase/auth2/lib/Authentication.java
+++ b/src/us/kbase/auth2/lib/Authentication.java
@@ -394,7 +394,7 @@ public class Authentication {
 				throw new RuntimeException("This is impossible", e);
 			}
 			final LocalUser root = LocalUser.getLocalUserBuilder(
-					UserName.ROOT, dn, clock.instant()).build();
+					UserName.ROOT, randGen.randomUUID(), dn, clock.instant()).build();
 			try {
 				storage.createLocalUser(root, new PasswordHashAndSalt(passwordHash, salt));
 				// only way to avoid a race condition. Checking existence before creating user
@@ -462,7 +462,7 @@ public class Authentication {
 			pwd_copy = pwd.getPassword();
 			passwordHash = pwdcrypt.getEncryptedPassword(pwd_copy, salt);
 			final LocalUser lu = LocalUser.getLocalUserBuilder(
-					userName, displayName, clock.instant())
+					userName, randGen.randomUUID(), displayName, clock.instant())
 					.withEmailAddress(email).withForceReset(true).build();
 			storage.createLocalUser(lu, new PasswordHashAndSalt(passwordHash, salt));
 			logInfo("Local user {} created by admin {}",
@@ -1954,7 +1954,8 @@ public class Authentication {
 					"Not authorized to create user with remote identity %s", identityID));
 		}
 		final Instant now = clock.instant();
-		final NewUser.Builder b = NewUser.getBuilder(userName, displayName, now, match.get())
+		final NewUser.Builder b = NewUser.getBuilder(
+				userName, randGen.randomUUID(), displayName, now, match.get())
 				 // no need to set last login, will be set in the login() call below
 				.withEmailAddress(email);
 		for (final PolicyID pid: policyIDs) {
@@ -2054,7 +2055,11 @@ public class Authentication {
 		}
 		final Instant now = clock.instant();
 		storage.testModeCreateUser(
-				userName, displayName, now, now.plusMillis(TEST_MODE_DATA_LIFETIME_MS));
+				userName,
+				randGen.randomUUID(),
+				displayName,
+				now,
+				now.plusMillis(TEST_MODE_DATA_LIFETIME_MS));
 		logInfo("Created test mode user {}", userName.getName());
 	}
 	
@@ -3146,7 +3151,8 @@ public class Authentication {
 			email = EmailAddress.UNKNOWN;
 		}
 		try {
-			storage.createUser(NewUser.getBuilder(userName, dn, clock.instant(), remoteIdentity)
+			storage.createUser(NewUser.getBuilder(
+					userName, randGen.randomUUID(), dn, clock.instant(), remoteIdentity)
 					.withEmailAddress(email).build());
 			logInfo("Imported user {}", userName.getName());
 		} catch (NoSuchRoleException e) {

--- a/src/us/kbase/auth2/lib/storage/AuthStorage.java
+++ b/src/us/kbase/auth2/lib/storage/AuthStorage.java
@@ -119,6 +119,8 @@ public interface AuthStorage {
 	 * Note that {@link AuthUser#isLocal()} returns true for test users since local users are
 	 * defined as having no remote identities, but test users still have no passwords.
 	 * @param name the user's name.
+	 * @param anonymousID the anonymous ID for the user. The calling code is responsible for
+	 * ensuring these IDs are unique per user.
 	 * @param display the user's display name.
 	 * @param created the date the user was created.
 	 * @param expires the date the user expires from the system.
@@ -126,7 +128,8 @@ public interface AuthStorage {
 	 * @throws AuthStorageException if a problem connecting with the storage
 	 * system occurs. 
 	 */
-	void testModeCreateUser(UserName name, DisplayName display, Instant created, Instant expires)
+	void testModeCreateUser(
+			UserName name, UUID anonymousID, DisplayName display, Instant created, Instant expires)
 			throws UserExistsException, AuthStorageException;
 	
 	/** Disable a user account.

--- a/src/us/kbase/auth2/lib/storage/mongo/Fields.java
+++ b/src/us/kbase/auth2/lib/storage/mongo/Fields.java
@@ -20,6 +20,8 @@ public class Fields {
 	
 	/** The user name. */
 	public static final String USER_NAME = "user";
+	/** The anonymous ID for the user. */
+	public static final String USER_ANONYMOUS_ID = "anonid";
 	/** The display name for the user. */
 	public static final String USER_DISPLAY_NAME = "display";
 	/** The canonical version of the display name. E.g. split into parts, whitespace removed, etc.

--- a/src/us/kbase/auth2/lib/user/LocalUser.java
+++ b/src/us/kbase/auth2/lib/user/LocalUser.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
@@ -27,6 +28,7 @@ public class LocalUser extends AuthUser {
 	
 	private LocalUser(
 			final UserName userName,
+			final UUID anonymousID,
 			final DisplayName displayName,
 			final Instant created,
 			final EmailAddress email,
@@ -37,8 +39,8 @@ public class LocalUser extends AuthUser {
 			final UserDisabledState disabledState,
 			final boolean forceReset,
 			final Optional<Instant> lastReset) {
-		super(userName, displayName, created, Collections.emptySet(), email, roles, customRoles,
-				policyIDs, lastLogin, disabledState);
+		super(userName, anonymousID, displayName, created, Collections.emptySet(), email, roles,
+				customRoles, policyIDs, lastLogin, disabledState);
 		this.forceReset = forceReset;
 		this.lastReset = lastReset;
 	}
@@ -98,15 +100,18 @@ public class LocalUser extends AuthUser {
 	 * array data when no longer needed.
 	 * 
 	 * @param userName the users's user name.
+	 * @param anonymousID the user's anonymized ID. The calling code is responsible for ensuring
+	 * these IDs are unique per user.
 	 * @param displayName the user's display name.
 	 * @param creationDate the user's creation date.
 	 * @return a builder.
 	 */
 	public static Builder getLocalUserBuilder(
 			final UserName userName,
+			final UUID anonymousID,
 			final DisplayName displayName,
 			final Instant creationDate) {
-		return new Builder(userName, displayName, creationDate);
+		return new Builder(userName, anonymousID, displayName, creationDate);
 		
 	}
 	
@@ -121,9 +126,10 @@ public class LocalUser extends AuthUser {
 
 		private Builder(
 				final UserName userName,
+				final UUID anonymousID,
 				final DisplayName displayName,
 				final Instant creationDate) {
-			super(userName, displayName, creationDate);
+			super(userName, anonymousID, displayName, creationDate);
 		}
 
 		@Override
@@ -154,8 +160,8 @@ public class LocalUser extends AuthUser {
 		 * @return the user.
 		 */
 		public LocalUser build() {
-			return new LocalUser(userName, displayName, created, email, roles, customRoles,
-					policyIDs, lastLogin, disabledState, forceReset, lastReset);
+			return new LocalUser(userName, anonymousID, displayName, created, email, roles,
+					customRoles, policyIDs, lastLogin, disabledState, forceReset, lastReset);
 		}
 		
 	}

--- a/src/us/kbase/auth2/lib/user/NewUser.java
+++ b/src/us/kbase/auth2/lib/user/NewUser.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
@@ -26,6 +27,7 @@ public class NewUser extends AuthUser {
 	
 	private NewUser(
 			final UserName userName,
+			final UUID anonymousID,
 			final DisplayName displayName,
 			final Instant created,
 			final RemoteIdentity remoteIdentity,
@@ -35,7 +37,8 @@ public class NewUser extends AuthUser {
 			final Map<PolicyID, Instant> policyIDs,
 			final Optional<Instant> lastLogin,
 			final UserDisabledState disabledState) {
-		super(userName, displayName, created, new HashSet<>(Arrays.asList(remoteIdentity)), email,
+		super(userName, anonymousID, displayName, created,
+				new HashSet<>(Arrays.asList(remoteIdentity)), email,
 				roles, customRoles, policyIDs, lastLogin, disabledState);
 	}
 
@@ -53,6 +56,8 @@ public class NewUser extends AuthUser {
 	
 	/** Get a builder for a new standard user.
 	 * @param userName the user's user name.
+	 * @param anonymousID the user's anonymized ID. The calling code is responsible for ensuring
+	 * these IDs are unique per user.
 	 * @param displayName the user's display name.
 	 * @param created the user's creation date.
 	 * @param remoteIdentity the remote identity associated with the user.
@@ -60,10 +65,11 @@ public class NewUser extends AuthUser {
 	 */
 	public static Builder getBuilder(
 			final UserName userName,
+			final UUID anonymousID,
 			final DisplayName displayName,
 			final Instant created,
 			final RemoteIdentity remoteIdentity) {
-		return new Builder(userName, displayName, created, remoteIdentity);
+		return new Builder(userName, anonymousID, displayName, created, remoteIdentity);
 	}
 	
 	/** A NewUser builder.
@@ -76,10 +82,11 @@ public class NewUser extends AuthUser {
 		
 		private Builder(
 				final UserName userName,
+				final UUID anonymousID,
 				final DisplayName displayName,
 				final Instant created,
 				final RemoteIdentity remoteIdentity) {
-			super(userName, displayName, created);
+			super(userName, anonymousID, displayName, created);
 			if (UserName.ROOT.equals(userName)) {
 				throw new IllegalArgumentException("Standard users cannot be root");
 			}
@@ -95,8 +102,8 @@ public class NewUser extends AuthUser {
 		 * @return the user.
 		 */
 		public NewUser build() {
-			return new NewUser(userName, displayName, created, remoteIdentity, email, roles,
-					customRoles, policyIDs, lastLogin, disabledState);
+			return new NewUser(userName, anonymousID, displayName, created, remoteIdentity, email,
+					roles, customRoles, policyIDs, lastLogin, disabledState);
 		}
 		
 	}

--- a/src/us/kbase/test/auth2/MongoStorageTestManager.java
+++ b/src/us/kbase/test/auth2/MongoStorageTestManager.java
@@ -18,6 +18,7 @@ import com.github.zafarkhaja.semver.Version;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
+import us.kbase.auth2.cryptutils.RandomDataGenerator;
 import us.kbase.auth2.lib.storage.mongo.MongoStorage;
 import us.kbase.common.test.controllers.mongo.MongoController;
 
@@ -27,6 +28,7 @@ public class MongoStorageTestManager {
 	public MongoClient mc;
 	public MongoDatabase db;
 	public MongoStorage storage;
+	public RandomDataGenerator mockRand;
 	public Clock mockClock;
 	public Version mongoDBVer;
 	public int indexVer;
@@ -70,10 +72,11 @@ public class MongoStorageTestManager {
 		// only drop the data, not the indexes, since creating indexes is slow and will be done
 		// anyway when the new storage instance is created
 		// db.drop();
+		mockRand = mock(RandomDataGenerator.class);
 		mockClock = mock(Clock.class);
 		final Constructor<MongoStorage> con = MongoStorage.class.getDeclaredConstructor(
-				MongoDatabase.class, Clock.class);
+				MongoDatabase.class, RandomDataGenerator.class, Clock.class);
 		con.setAccessible(true);
-		storage = con.newInstance(db, mockClock);
+		storage = con.newInstance(db, mockRand, mockClock);
 	}
 }

--- a/src/us/kbase/test/auth2/TestCommon.java
+++ b/src/us/kbase/test/auth2/TestCommon.java
@@ -108,8 +108,8 @@ public class TestCommon {
 	}
 	
 	public static void assertExceptionCorrect(
-			final Exception got,
-			final Exception expected) {
+			final Throwable got,
+			final Throwable expected) {
 		assertThat("incorrect exception. trace:\n" + ExceptionUtils.getStackTrace(got),
 				got.getMessage(), is(expected.getMessage()));
 		assertThat("incorrect exception type", got, instanceOf(expected.getClass()));

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
@@ -70,12 +70,14 @@ public class AuthenticationCreateLocalUserTest {
 		logEvents.clear();
 	}
 	
+	private final static UUID UID = UUID.randomUUID();
+	
 	private final static Instant NOW = Instant.now();
 	
 	@Test
 	public void createWithAdminUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo"), NOW)
+				new UserName("admin"), UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 				
@@ -85,7 +87,7 @@ public class AuthenticationCreateLocalUserTest {
 	@Test
 	public void createWithCreateAdminUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo"), NOW)
+				new UserName("admin"), UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -95,7 +97,7 @@ public class AuthenticationCreateLocalUserTest {
 	@Test
 	public void createWithRootUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("foo"), NOW)
+				UserName.ROOT, UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
 		create(admin);
@@ -125,11 +127,14 @@ public class AuthenticationCreateLocalUserTest {
 		when(rand.getTemporaryPassword(10)).thenReturn(pwdChar);
 		
 		when(rand.generateSalt()).thenReturn(salt);
+
+		final UUID uid = UUID.randomUUID();
+		when(rand.randomUUID()).thenReturn(uid).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(create);
 		
 		final LocalUser expected = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), create)
+				new UserName("foo"), uid, new DisplayName("bar"), create)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withForceReset(true).build();
 		
@@ -146,7 +151,7 @@ public class AuthenticationCreateLocalUserTest {
 		assertClear(matcher.savedHash);
 		/* ensure method was called at least once
 		 * Usually not necessary when mocking the call, but since createLU returns null
-		 * need to ensure the method was actually called and therefore the RootuserAnswerMatcher
+		 * need to ensure the method was actually called and therefore the LocalUserAnswerMatcher
 		 * ran
 		 */
 		verify(storage).createLocalUser(any(), any());
@@ -176,7 +181,7 @@ public class AuthenticationCreateLocalUserTest {
 						.withLifeTime(NOW, NOW).build());
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo"), NOW)
+				new UserName("admin"), UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -185,6 +190,8 @@ public class AuthenticationCreateLocalUserTest {
 		when(rand.getTemporaryPassword(10)).thenReturn(pwdChar);
 		
 		when(rand.generateSalt()).thenReturn(salt);
+		
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(create);
 		
@@ -214,7 +221,7 @@ public class AuthenticationCreateLocalUserTest {
 						.withLifeTime(NOW, NOW).build());
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo"), NOW)
+				new UserName("admin"), UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -223,6 +230,8 @@ public class AuthenticationCreateLocalUserTest {
 		when(rand.getTemporaryPassword(10)).thenReturn(pwdChar);
 		
 		when(rand.generateSalt()).thenReturn(salt);
+		
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(create);
 		
@@ -249,7 +258,7 @@ public class AuthenticationCreateLocalUserTest {
 						.withLifeTime(NOW, NOW).build());
 
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo"), NOW)
+				new UserName("admin"), UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -325,7 +334,7 @@ public class AuthenticationCreateLocalUserTest {
 						.withLifeTime(NOW, NOW).build());
 
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("foo"), NOW)
+				UserName.ROOT, UID, new DisplayName("foo"), NOW)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ROOT).build();
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCreateRootTest.java
@@ -17,6 +17,7 @@ import static us.kbase.test.auth2.TestCommon.assertClear;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -54,6 +55,8 @@ public class AuthenticationCreateRootTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private final static UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -78,13 +81,16 @@ public class AuthenticationCreateRootTest {
 				"0qnwBgrYXUeUg/rDzEIo9//gTYN3c9yxfsCtE9JkviU=");
 		final Instant create = Instant.ofEpochMilli(1000000006);
 		
+		final UUID uid = UUID.randomUUID();
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				UserName.ROOT, new DisplayName("root"), create).build();
+				UserName.ROOT, uid, new DisplayName("root"), create).build();
 		
 		final LocalUserAnswerMatcher matcher = new LocalUserAnswerMatcher(
 				exp, new PasswordHashAndSalt(hash, salt));
 		
 		when(rand.generateSalt()).thenReturn(salt);
+		
+		when(rand.randomUUID()).thenReturn(uid).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(create);
 		
@@ -120,14 +126,17 @@ public class AuthenticationCreateRootTest {
 		final byte[] salt = new byte[] {5, 5, 5, 5, 5, 5, 5, 5};
 		final byte[] hash = fromBase64("0qnwBgrYXUeUg/rDzEIo9//gTYN3c9yxfsCtE9JkviU=");
 		
+		final UUID uid = UUID.randomUUID();
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				UserName.ROOT, new DisplayName("root"), Instant.ofEpochMilli(1000))
+				UserName.ROOT, uid, new DisplayName("root"), Instant.ofEpochMilli(1000))
 				.build();
 		
 		final ChangePasswordAnswerMatcher matcher =
 				new ChangePasswordAnswerMatcher(UserName.ROOT, hash, salt, false);
 		
 		when(rand.generateSalt()).thenReturn(salt);
+		
+		when(rand.randomUUID()).thenReturn(uid).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(1000));
 		
@@ -139,7 +148,7 @@ public class AuthenticationCreateRootTest {
 				.changePassword(eq(UserName.ROOT), any(PasswordHashAndSalt.class), eq(false));
 		
 		when(storage.getUser(UserName.ROOT)).thenReturn(LocalUser.getLocalUserBuilder(
-				UserName.ROOT, new DisplayName("root"), Instant.now())
+				UserName.ROOT, uid, new DisplayName("root"), Instant.now())
 				.build());
 		
 		auth.createRoot(pwd);
@@ -169,6 +178,8 @@ public class AuthenticationCreateRootTest {
 		
 		when(rand.generateSalt()).thenReturn(new byte[8]);
 		
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(Instant.now());
 		
 		doThrow(new UserExistsException(UserName.ROOT.getName()))
@@ -197,6 +208,8 @@ public class AuthenticationCreateRootTest {
 		final Clock clock = testauth.clockMock;
 		
 		when(rand.generateSalt()).thenReturn(new byte[8]);
+		
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(Instant.now());
 		
@@ -231,6 +244,9 @@ public class AuthenticationCreateRootTest {
 		
 		when(rand.generateSalt()).thenReturn(salt);
 		
+		final UUID uid = UUID.randomUUID();
+		when(rand.randomUUID()).thenReturn(uid).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(create);
 		
 		doThrow(new UserExistsException(UserName.ROOT.getName()))
@@ -242,7 +258,7 @@ public class AuthenticationCreateRootTest {
 				.changePassword(eq(UserName.ROOT), any(PasswordHashAndSalt.class), eq(false));
 		
 		final LocalUser disabled = LocalUser.getLocalUserBuilder(
-				UserName.ROOT, new DisplayName("root"), Instant.now())
+				UserName.ROOT, uid, new DisplayName("root"), Instant.now())
 				.withUserDisabledState(new UserDisabledState("foo", UserName.ROOT, Instant.now()))
 				.build();
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationCustomRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationCustomRoleTest.java
@@ -47,6 +47,8 @@ public class AuthenticationCustomRoleTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -71,7 +73,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				adminName, new DisplayName("foobar"), Instant.now())
+				adminName, UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -147,7 +149,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				adminName, new DisplayName("foobar"), Instant.now())
+				adminName, UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -304,7 +306,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				un, new DisplayName("foobar"), Instant.now())
+				un, UID, new DisplayName("foobar"), Instant.now())
 				.withRole(r).build();
 
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -439,7 +441,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foobar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -465,7 +467,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foobar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -493,7 +495,7 @@ public class AuthenticationCustomRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foobar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);

--- a/src/us/kbase/test/auth2/lib/AuthenticationDisableUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationDisableUserTest.java
@@ -43,6 +43,8 @@ public class AuthenticationDisableUserTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -131,7 +133,7 @@ public class AuthenticationDisableUserTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.now())
 				.withRole(Role.ADMIN).build())
 				.thenReturn(null);
 		
@@ -159,7 +161,7 @@ public class AuthenticationDisableUserTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(adminName)).thenReturn(AuthUser.getBuilder(
-				adminName, new DisplayName("foo"), Instant.now())
+				adminName, UID, new DisplayName("foo"), Instant.now())
 				.withRole(role).build())
 				.thenReturn(null);
 		
@@ -263,7 +265,7 @@ public class AuthenticationDisableUserTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.now())
 				.withRole(Role.ADMIN).build())
 				.thenReturn(null);
 		
@@ -289,7 +291,7 @@ public class AuthenticationDisableUserTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(adminName)).thenReturn(AuthUser.getBuilder(
-				adminName, new DisplayName("foo"), Instant.now())
+				adminName, UID, new DisplayName("foo"), Instant.now())
 				.withRole(role).build())
 				.thenReturn(null);
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserDisplayNamesTest.java
@@ -50,6 +50,8 @@ public class AuthenticationGetUserDisplayNamesTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -168,7 +170,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpec() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -184,7 +186,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecWithRootAsAdmin() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -202,7 +204,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecWithRootAsCreate() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -220,7 +222,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecWithRootAsRoot() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("foo"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
@@ -248,7 +250,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 		for (final UserSearchSpec spec: Arrays.asList(noprefix, custom, role, disabled)) {
 			for (final Role r: Arrays.asList(Role.ROOT, Role.CREATE_ADMIN, Role.ADMIN)) {
 				final AuthUser user = AuthUser.getBuilder(
-						r == Role.ROOT ? UserName.ROOT : new UserName("foo"),
+						r == Role.ROOT ? UserName.ROOT : new UserName("foo"), UID,
 						new DisplayName("foo"), Instant.now())
 						.withEmailAddress(new EmailAddress("f@h.com"))
 						.withRole(r).build();
@@ -277,7 +279,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailRegex() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("foo"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
@@ -320,7 +322,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailStdUserCustomRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -334,7 +336,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailStdUserRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -348,7 +350,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailStdUserNoPrefix() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -361,7 +363,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailStdUserIncludeRoot() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -375,7 +377,7 @@ public class AuthenticationGetUserDisplayNamesTest {
 	@Test
 	public void getDisplayNamesSpecFailStdUserIncludeDisabled() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationGetUserTest.java
@@ -42,6 +42,8 @@ public class AuthenticationGetUserTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -55,7 +57,7 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getUser() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("whee"), new DisplayName("foo"), Instant.now())
+				new UserName("whee"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
@@ -142,7 +144,7 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getOtherUserSameUser() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("whee"), new DisplayName("foo"), Instant.now())
+				new UserName("whee"), UID, new DisplayName("foo"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
@@ -152,12 +154,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getOtherUserDiffUser() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("whee"), new DisplayName("foo1"), Instant.now())
+				new UserName("whee"), UID, new DisplayName("foo1"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser target = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo1"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("foo1"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
@@ -194,12 +196,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getOtherUserFailDisabledDiffUser() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("foo1"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("foo1"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser target = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo1"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("foo1"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withUserDisabledState(
 						new UserDisabledState("foo", new UserName("baz"), Instant.now())).build();
@@ -230,7 +232,7 @@ public class AuthenticationGetUserTest {
 						.withLifeTime(Instant.now(), Instant.now()).build());
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("foo1"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("foo1"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build());
 		
@@ -303,12 +305,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getUserAsAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -318,12 +320,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getUserAsAdminSelf() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -334,12 +336,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getUserAsAdminCreate() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -349,12 +351,12 @@ public class AuthenticationGetUserTest {
 	@Test
 	public void getUserAsAdminRoot() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -409,7 +411,7 @@ public class AuthenticationGetUserTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationImportUserTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationImportUserTest.java
@@ -11,6 +11,7 @@ import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -42,6 +43,8 @@ public class AuthenticationImportUserTest {
 	
 	private static List<ILoggingEvent> logEvents;
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@BeforeClass
 	public static void beforeClass() {
 		logEvents = AuthenticationTester.setUpSLF4JTestLoggerAppender();
@@ -59,17 +62,20 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
 		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 				new RemoteIdentityDetails("user", "full", "f@h.com")));
 		
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), new DisplayName("full"),
-				Instant.ofEpochMilli(10000),
-				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
-						new RemoteIdentityDetails("user", "full", "f@h.com")))
-				.withEmailAddress(new EmailAddress("f@h.com"))
-				.build());
+		verify(storage).createUser(
+				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
+						Instant.ofEpochMilli(10000),
+						new RemoteIdentity(new RemoteIdentityID("prov", "id"),
+								new RemoteIdentityDetails("user", "full", "f@h.com")))
+						.withEmailAddress(new EmailAddress("f@h.com"))
+						.build());
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO,
 				"Imported user foo", Authentication.class));
@@ -87,12 +93,14 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
 		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 				new RemoteIdentityDetails("user", fullname, "f@h.com")));
 		
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"),
+		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), UID,
 				new DisplayName("unknown"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user", fullname, "f@h.com")))
@@ -112,12 +120,14 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
 		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 				new RemoteIdentityDetails("user", "full", email)));
 		
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"),
+		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), UID,
 				new DisplayName("full"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user", "full", email)))
@@ -144,12 +154,14 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
 		auth.importUser(new UserName("foo"), REMOTE_ID);
 		
 		doThrow(new UserExistsException("foo")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), new DisplayName("full"),
+				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());
@@ -164,17 +176,19 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UUID.randomUUID(), UID, null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
 		auth.importUser(new UserName("foo"), REMOTE_ID);
 		
 		doThrow(new IdentityLinkedException("linked")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), new DisplayName("full"),
+				NewUser.getBuilder(new UserName("foo2"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());
 		
-		failImportUser(auth, new UserName("foo"), REMOTE_ID,
+		failImportUser(auth, new UserName("foo2"), REMOTE_ID,
 				new IdentityLinkedException("linked"));
 	}
 	
@@ -185,12 +199,14 @@ public class AuthenticationImportUserTest {
 		final Clock clock = testauth.clockMock;
 		final Authentication auth = testauth.auth;
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UUID.randomUUID(), UID, null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), REMOTE_ID);
+		auth.importUser(new UserName("foo2"), REMOTE_ID);
 		
 		doThrow(new NoSuchRoleException("foo")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), new DisplayName("full"),
+				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());

--- a/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLinkTest.java
@@ -84,6 +84,9 @@ public class AuthenticationLinkTest {
 	
 	private final Instant NOW = Instant.now();
 	
+	private final UUID UID = UUID.randomUUID();
+	private final UUID UID2 = UUID.randomUUID();
+	
 	private final RemoteIdentity REMOTE = new RemoteIdentity(new RemoteIdentityID("Prov", "id1"),
 			new RemoteIdentityDetails("user1", "full1", "f1@g.com"));
 	
@@ -131,7 +134,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(rand.getToken())
@@ -267,7 +270,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.build()).thenReturn(null);
 		
 		failLinkStart(auth, userToken, 120, "ip1", "env", new LinkFailedException(
@@ -316,7 +319,7 @@ public class AuthenticationLinkTest {
 						.link("mystate", "pkceverifiedforyourcomfort", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.now())
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkceverifiedforyourcomfort", true, null))
@@ -376,7 +379,7 @@ public class AuthenticationLinkTest {
 						.link("somestate", "pkcecuresacne", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.now())
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkcecuresacne", true, null))
@@ -434,7 +437,7 @@ public class AuthenticationLinkTest {
 						.link("stateish", "pkceambrosiaofthegods", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkceambrosiaofthegods", true, null))
@@ -459,7 +462,7 @@ public class AuthenticationLinkTest {
 		
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.empty()).thenReturn(null);
 		when(storage.getUser(storageRemoteID3)).thenReturn(Optional.of(AuthUser.getBuilder(
-				new UserName("whee"), new DisplayName("arg"), Instant.now())
+				new UserName("whee"), UID2, new DisplayName("arg"), Instant.now())
 				.withIdentity(storageRemoteID3).build())).thenReturn(null);
 		
 		when(storage.link(new UserName("baz"), storageRemoteID2))
@@ -517,7 +520,7 @@ public class AuthenticationLinkTest {
 						.link("stately", "pkcehasgreatretirementbenefits", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkcehasgreatretirementbenefits", true, "myenv"))
@@ -584,7 +587,7 @@ public class AuthenticationLinkTest {
 						.link("stateinheah", "pkceisnotsnakeoilatall", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkceisnotsnakeoilatall", true, null))
@@ -598,7 +601,7 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"));
 		
 		when(storage.getUser(storageRemoteID)).thenReturn(Optional.of(AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now()).build()))
+				new UserName("someuser"), UID2, new DisplayName("a"), Instant.now()).build()))
 				.thenReturn(null);
 		
 		final UUID tokenID = UUID.randomUUID();
@@ -655,7 +658,7 @@ public class AuthenticationLinkTest {
 								new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities(
@@ -680,7 +683,7 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityDetails("user4", "full4", "f4@g.com"));
 		
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now()).build()))
+				new UserName("someuser"), UID2, new DisplayName("a"), Instant.now()).build()))
 				.thenReturn(null);
 		when(storage.getUser(storageRemoteID3)).thenReturn(Optional.empty())
 				.thenReturn(null);
@@ -739,7 +742,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceverifier", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build());
 		
 		failLinkWithToken(auth, null, "prov", "foo", null, "state",
@@ -1005,7 +1008,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceverifier", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("f"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("f"), Instant.now())
 				.withUserDisabledState(
 						new UserDisabledState("f", new UserName("b"), Instant.now())).build());
 		
@@ -1042,7 +1045,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceverifier", new UserName("foo")));
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now()).build());
 		
 		failLinkWithToken(auth, token, "prov", "foo", null, "state",
 				new LinkFailedException("Cannot link identities to local account foo"));
@@ -1075,7 +1078,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceprovidesdivineinfluence", new UserName("foo")));
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now())
 				.withIdentity(REMOTE).build());
 		
 		when(idp.getIdentities("foo", "pkceprovidesdivineinfluence", true, "env")).thenThrow(
@@ -1112,7 +1115,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkcewasinventedbyaristotle", new UserName("foo")));
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now())
 				.withIdentity(REMOTE).build());
 		
 		when(idp.getIdentities("foo", "pkcewasinventedbyaristotle", true, null)).thenThrow(
@@ -1150,7 +1153,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceimkindofgettingboredwiththis", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkceimkindofgettingboredwiththis", true, null))
@@ -1200,7 +1203,7 @@ public class AuthenticationLinkTest {
 						.link("state", "pkceohwhocares", new UserName("baz")));
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(20000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(20000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(idp.getIdentities("authcode", "pkceohwhocares", true, null))
@@ -1307,7 +1310,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID temptokenid = UUID.randomUUID();
@@ -1334,7 +1337,7 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityDetails("user4", "full4", "f4@g.com"));
 		
 		final AuthUser user2 = AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now())
+				new UserName("someuser"), UID2, new DisplayName("a"), Instant.now())
 				.withIdentity(storageRemoteID2).build();
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(user2))
 				.thenReturn(null);
@@ -1372,7 +1375,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID tempTokenID = UUID.randomUUID();
@@ -1388,7 +1391,7 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com"));
 
 		final AuthUser user2 = AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now())
+				new UserName("someuser"), UID2, new DisplayName("a"), Instant.now())
 				.withIdentity(storageRemoteID2).build();
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(user2)).thenReturn(null);
 		
@@ -1419,7 +1422,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		failGetLinkState(auth, null, tempToken, new NullPointerException("token"));
@@ -1461,7 +1464,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now()).build());
 
 		failGetLinkState(auth, token, new IncomingToken("bar"),
 				new LinkFailedException("Cannot link identities to local account foo"));
@@ -1482,7 +1485,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken()))
@@ -1506,7 +1509,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1533,7 +1536,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1561,7 +1564,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID tempTokenID = UUID.randomUUID();
@@ -1595,7 +1598,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID tempTokenID = UUID.randomUUID();
@@ -1642,7 +1645,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1688,7 +1691,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1732,7 +1735,7 @@ public class AuthenticationLinkTest {
 						.withLifeTime(Instant.now(), Instant.now()).build());
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build());
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1783,7 +1786,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now()).build());
 
 		failLinkIdentity(auth, token, new IncomingToken("bar"), "foo",
 				new LinkFailedException("Cannot link identities to local account foo"));
@@ -1804,7 +1807,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken()))
@@ -1829,7 +1832,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1856,7 +1859,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID id = UUID.randomUUID();
@@ -1888,7 +1891,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID id = UUID.randomUUID();
@@ -1920,7 +1923,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1947,7 +1950,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -1977,7 +1980,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2012,7 +2015,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2047,7 +2050,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2098,7 +2101,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2128,7 +2131,7 @@ public class AuthenticationLinkTest {
 				new RemoteIdentityDetails("user5", "full5", "f5@g.com"));
 		
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(AuthUser.getBuilder(
-				new UserName("someuser"), new DisplayName("a"), Instant.now()).build()))
+				new UserName("someuser"), UID2, new DisplayName("a"), Instant.now()).build()))
 				.thenReturn(null);
 		when(storage.getUser(storageRemoteID3)).thenReturn(Optional.empty())
 				.thenReturn(null);
@@ -2174,7 +2177,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2219,7 +2222,7 @@ public class AuthenticationLinkTest {
 						.withLifeTime(Instant.now(), Instant.now()).build());
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build());
 		
 		failLinkAll(auth, null, tempToken, new NullPointerException("token"));
@@ -2261,7 +2264,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now()).build());
 
 		failLinkAll(auth, token, new IncomingToken("bar"),
 				new LinkFailedException("Cannot link identities to local account foo"));
@@ -2282,7 +2285,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken()))
@@ -2307,7 +2310,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2346,7 +2349,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2373,7 +2376,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID id = UUID.randomUUID();
@@ -2406,7 +2409,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		final UUID id = UUID.randomUUID();
@@ -2439,7 +2442,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2467,7 +2470,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		when(storage.getTemporarySessionData(tempToken.getHashedToken())).thenReturn(
@@ -2517,7 +2520,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		auth.unlink(userToken, "foobar");
@@ -2574,7 +2577,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("f"), Instant.now()).build());
 
 		failUnlink(auth, token, "foo",
 				new UnLinkFailedException("Local user foo doesn't have remote identities"));
@@ -2594,7 +2597,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		doThrow(new NoSuchUserException("baz")).when(storage)
@@ -2618,7 +2621,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		doThrow(new UnLinkFailedException("unlink")).when(storage)
@@ -2641,7 +2644,7 @@ public class AuthenticationLinkTest {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("baz"))).thenReturn(AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foo"), Instant.ofEpochMilli(10000))
+				new UserName("baz"), UID, new DisplayName("foo"), Instant.ofEpochMilli(10000))
 				.withIdentity(REMOTE).build()).thenReturn(null);
 		
 		doThrow(new NoSuchIdentityException("noid")).when(storage)

--- a/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
@@ -11,8 +11,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import static us.kbase.test.auth2.TestCommon.set;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.now;
+import static us.kbase.test.auth2.TestCommon.set;
 import static us.kbase.test.auth2.TestCommon.tempToken;
 import static us.kbase.test.auth2.lib.AuthenticationTester.assertLogEventsCorrect;
 import static us.kbase.test.auth2.lib.AuthenticationTester.initTestMocks;
@@ -90,6 +91,9 @@ import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 public class AuthenticationLoginTest {
 	
 	private static final Instant SMALL = Instant.ofEpochMilli(1);
+	
+	private static final UUID UID = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
 	
 	private static final TokenCreationContext CTX = TokenCreationContext.getBuilder().build();
 	
@@ -274,7 +278,7 @@ public class AuthenticationLoginTest {
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"));
 		
-		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(10000L))
 				.withRole(userRole)
 				.withIdentity(storageRemoteID).build();
@@ -376,7 +380,7 @@ public class AuthenticationLoginTest {
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"));
 		
-		final AuthUser.Builder user = AuthUser.getBuilder(new UserName("foo"),
+		final AuthUser.Builder user = AuthUser.getBuilder(new UserName("foo"), UID,
 				new DisplayName("bar"), Instant.ofEpochMilli(10000L))
 				.withRole(userRole)
 				.withIdentity(storageRemoteID);
@@ -528,7 +532,7 @@ public class AuthenticationLoginTest {
 		when(storage.getUser(storageRemoteID1)).thenReturn(Optional.empty())
 				.thenReturn(null);
 		
-		final AuthUser user = AuthUser.getBuilder(new UserName("foo"),
+		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), UID,
 				new DisplayName("bar"), Instant.ofEpochMilli(10000L))
 				.withIdentity(storageRemoteID2).build();
 		when(storage.getUser(storageRemoteID2)).thenReturn(Optional.of(user))
@@ -610,7 +614,7 @@ public class AuthenticationLoginTest {
 				new RemoteIdentityDetails("user3", "full3", "d@g.com"));
 		
 		
-		final AuthUser user = AuthUser.getBuilder(new UserName("foo"),
+		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), UID,
 				new DisplayName("bar"), Instant.ofEpochMilli(10000L))
 				.withIdentity(storageRemoteID1)
 				.withIdentity(storageRemoteID2).build();
@@ -621,7 +625,7 @@ public class AuthenticationLoginTest {
 				.withIdentity(storageRemoteID1).withIdentity(storageRemoteID2).build()))
 				.thenReturn(null);
 		
-		final AuthUser user2 = AuthUser.getBuilder(new UserName("foo2"),
+		final AuthUser user2 = AuthUser.getBuilder(new UserName("foo2"), UID2,
 				new DisplayName("bar2"), Instant.ofEpochMilli(50000L))
 				.withIdentity(storageRemoteID3).build();
 		
@@ -1123,7 +1127,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, null, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(10000L))
 				.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build();
@@ -1135,7 +1139,7 @@ public class AuthenticationLoginTest {
 		final LoginState got = auth.getLoginState(token);
 		
 		final LoginState expected = LoginState.getBuilder("prov", true,Instant.ofEpochMilli(10001))
-				.withUser(AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+				.withUser(AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 						Instant.ofEpochMilli(10000L))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build(),
@@ -1173,13 +1177,13 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, null, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		final AuthUser user1 = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
-				Instant.ofEpochMilli(10000L))
+		final AuthUser user1 = AuthUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000L))
 				.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build();
 		
-		final AuthUser user2 = AuthUser.getBuilder(new UserName("foo2"), new DisplayName("bar2"),
-				Instant.ofEpochMilli(20000L))
+		final AuthUser user2 = AuthUser.getBuilder(
+				new UserName("foo2"), UID2, new DisplayName("bar2"), Instant.ofEpochMilli(20000L))
 				.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 						new RemoteIdentityDetails("user2", "full2", "e@g.com"))).build();
 		
@@ -1197,14 +1201,14 @@ public class AuthenticationLoginTest {
 		
 		final Instant exp = Instant.ofEpochMilli(10001);
 		final LoginState expected = LoginState.getBuilder("prov", true, exp).withUser(
-				AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+				AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 						Instant.ofEpochMilli(10000L))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build(),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 		
-				.withUser(AuthUser.getBuilder(new UserName("foo2"), new DisplayName("bar2"),
+				.withUser(AuthUser.getBuilder(new UserName("foo2"), UID2, new DisplayName("bar2"),
 						Instant.ofEpochMilli(20000L))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 								new RemoteIdentityDetails("user2", "full2", "e@g.com"))).build(),
@@ -1243,7 +1247,7 @@ public class AuthenticationLoginTest {
 						new AuthConfig(true, null, null),
 						new CollectingExternalConfig(Collections.emptyMap())));
 		
-		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+		final AuthUser user = AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(10000L))
 				.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build();
@@ -1261,7 +1265,7 @@ public class AuthenticationLoginTest {
 		
 		final Instant exp = Instant.ofEpochMilli(10001);
 		final LoginState expected = LoginState.getBuilder("prov", true, exp).withUser(
-				AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+				AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 						Instant.ofEpochMilli(10000L))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build(),
@@ -1400,7 +1404,7 @@ public class AuthenticationLoginTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L),
 				Instant.ofEpochMilli(20000L), Instant.ofEpochMilli(30000L), null);
-		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(tokenID).thenReturn(null);
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
@@ -1408,8 +1412,8 @@ public class AuthenticationLoginTest {
 				set(new PolicyID("pid1"), new PolicyID("pid2")),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), false);
 
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
-				Instant.ofEpochMilli(10000),
+		verify(storage).createUser(NewUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com"))
@@ -1470,7 +1474,7 @@ public class AuthenticationLoginTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L),
 				Instant.ofEpochMilli(20000L), Instant.ofEpochMilli(30000L), null);
-		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(tokenID).thenReturn(null);
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
@@ -1478,8 +1482,8 @@ public class AuthenticationLoginTest {
 				set(new PolicyID("pid1"), new PolicyID("pid2")),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), true);
 
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
-				Instant.ofEpochMilli(10000),
+		verify(storage).createUser(NewUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com"))
@@ -1565,7 +1569,7 @@ public class AuthenticationLoginTest {
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id5"),
 				new RemoteIdentityDetails("user5", "full5", "b@g.com"))))
 				.thenReturn(Optional.of(NewUser.getBuilder(
-						new UserName("baz"), new DisplayName("bar"), Instant.ofEpochMilli(700000),
+						new UserName("baz"), UID, new DisplayName("bar"), inst(700000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id5"),
 						new RemoteIdentityDetails("user5", "full5", "b@g.com"))).build()));
 		
@@ -1587,7 +1591,7 @@ public class AuthenticationLoginTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L),
 				Instant.ofEpochMilli(20000L), Instant.ofEpochMilli(30000L), null);
-		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
+		when(rand.randomUUID()).thenReturn(UID2).thenReturn(tokenID).thenReturn(null);
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
@@ -1595,8 +1599,8 @@ public class AuthenticationLoginTest {
 				Collections.emptySet(),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), true);
 
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
-				Instant.ofEpochMilli(10000),
+		verify(storage).createUser(NewUser.getBuilder(
+				new UserName("foo"), UID2, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com")).build());
@@ -1901,10 +1905,11 @@ public class AuthenticationLoginTest {
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))))
 				.thenReturn(null);
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new UserExistsException("baz")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("baz"), new DisplayName("bat"),
+				NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -1942,10 +1947,12 @@ public class AuthenticationLoginTest {
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))))
 				.thenReturn(null);
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
+		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new IdentityLinkedException("ef0518c79af70ed979907969c6d0a0f7")).when(storage)
-				.createUser(NewUser.getBuilder(new UserName("baz"), new DisplayName("bat"),
+				.createUser(NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -1984,10 +1991,11 @@ public class AuthenticationLoginTest {
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))))
 				.thenReturn(null);
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new NoSuchRoleException("foobar")).when(storage)
-				.createUser(NewUser.getBuilder(new UserName("baz"), new DisplayName("bat"),
+				.createUser(NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -2028,6 +2036,7 @@ public class AuthenticationLoginTest {
 								new RemoteIdentityDetails("user2", "full2", "e@g.com")))))
 				.thenReturn(null);
 		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
@@ -2076,6 +2085,8 @@ public class AuthenticationLoginTest {
 						new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 								new RemoteIdentityDetails("user2", "full2", "e@g.com")))))
 				.thenReturn(null);
+		
+		when(testauth.randGenMock.randomUUID()).thenReturn(UID).thenReturn(null);
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
@@ -2130,7 +2141,7 @@ public class AuthenticationLoginTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L),
 				Instant.ofEpochMilli(20000L), Instant.ofEpochMilli(30000L), null);
-		when(rand.randomUUID()).thenReturn(tokenID).thenReturn(null);
+		when(rand.randomUUID()).thenReturn(UID).thenReturn(tokenID).thenReturn(null);
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		doThrow(new NoSuchUserException("foo")).when(storage).setLastLogin(
@@ -2194,7 +2205,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com")))).thenReturn(Optional.of(
-						AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+						AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 								Instant.ofEpochMilli(70000))
 						.withRole(userRole)
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
@@ -2263,7 +2274,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com")))).thenReturn(Optional.of(
-						AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+						AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 								Instant.ofEpochMilli(70000))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -2345,7 +2356,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com")))).thenReturn(Optional.of(
-						AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+						AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 								Instant.ofEpochMilli(70000))
 						.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -2366,7 +2377,7 @@ public class AuthenticationLoginTest {
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id5"),
 				new RemoteIdentityDetails("user5", "full5", "b@g.com"))))
 				.thenReturn(Optional.of(NewUser.getBuilder(
-						new UserName("baz"), new DisplayName("bar"), Instant.ofEpochMilli(700000),
+						new UserName("baz"), UID2, new DisplayName("bar"), inst(700000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id5"),
 						new RemoteIdentityDetails("user5", "full5", "b@g.com"))).build()));
 		
@@ -2612,7 +2623,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build()));
@@ -2648,7 +2659,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -2686,7 +2697,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build()));
@@ -2728,7 +2739,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build()));
@@ -2774,7 +2785,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build()));
@@ -2820,7 +2831,7 @@ public class AuthenticationLoginTest {
 		
 		when(storage.getUser(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com"))))
-					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"),
+					.thenReturn(Optional.of(AuthUser.getBuilder(new UserName("foo"), UID,
 							new DisplayName("bar"), Instant.ofEpochMilli(70000))
 					.withIdentity(new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 							new RemoteIdentityDetails("user1", "full1", "f@h.com"))).build()));

--- a/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationPasswordLoginTest.java
@@ -75,6 +75,9 @@ public class AuthenticationPasswordLoginTest {
 	
 	/* tests anything to do with passwords, including login. */
 	
+	private static final UUID UID = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
+	
 	private static final TokenCreationContext CTX = TokenCreationContext.getBuilder().build();
 	
 	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
@@ -126,7 +129,7 @@ public class AuthenticationPasswordLoginTest {
 				"this is a token");
 		
 		final LocalUser.Builder b = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"));
 		for (final Role r: roles) {
 			b.withRole(r);
@@ -186,7 +189,7 @@ public class AuthenticationPasswordLoginTest {
 				"M0D2KmSM5CoOHojYgbbKQy1UrkLskxrQnWxcaRf3/hs=");
 		
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withForceReset(true).build();
 		
@@ -303,7 +306,7 @@ public class AuthenticationPasswordLoginTest {
 				"M0D2KmSM5CoOHojYgbbKQy1UrkLskxrQnWxcaRf3/hs=");
 		
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
 		when(storage.getPasswordHashAndSalt(new UserName("foo"))).thenReturn(
@@ -337,7 +340,7 @@ public class AuthenticationPasswordLoginTest {
 				"M0D2KmSM5CoOHojYgbbKQy1UrkLskxrQnWxcaRf3/hs=");
 		
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withUserDisabledState(
 						new UserDisabledState("foo", new UserName("foo"), Instant.now())).build();
@@ -375,7 +378,7 @@ public class AuthenticationPasswordLoginTest {
 		final UUID id = UUID.randomUUID();
 		
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
 		when(storage.getPasswordHashAndSalt(new UserName("foo"))).thenReturn(
@@ -453,7 +456,7 @@ public class AuthenticationPasswordLoginTest {
 				"SL1L2qIybfSLoXzIxUyIpCGR63C3NiROQVZE26GcZo0=");
 		
 		final LocalUser.Builder b = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"));
 		for (final Role r: roles) {
 			b.withRole(r);
@@ -631,7 +634,7 @@ public class AuthenticationPasswordLoginTest {
 				"M0D2KmSM5CoOHojYgbbKQy1UrkLskxrQnWxcaRf3/hs=");
 
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
 		when(storage.getPasswordHashAndSalt(new UserName("foo"))).thenReturn(
@@ -667,7 +670,7 @@ public class AuthenticationPasswordLoginTest {
 				"M0D2KmSM5CoOHojYgbbKQy1UrkLskxrQnWxcaRf3/hs=");
 
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withUserDisabledState(
 						new UserDisabledState("foo", new UserName("foo"), Instant.now())).build();
@@ -710,7 +713,7 @@ public class AuthenticationPasswordLoginTest {
 				new PasswordHashAndSalt(hashold, saltold));
 		
 		final LocalUser exp = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
 		when(storage.getLocalUser(new UserName("foo"))).thenReturn(exp);
@@ -749,12 +752,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordAdminOnStd() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -768,12 +771,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordSelf() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -787,12 +790,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordRootOnCreate() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -806,12 +809,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordRootOnSelf() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("baz"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -825,12 +828,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordCreateOnAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -844,12 +847,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordFailLocalUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withIdentity(REMOTE1)
 				.build();
@@ -865,12 +868,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordFailCreateOnRoot() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("baz"), Instant.now())
+				UserName.ROOT, UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -885,12 +888,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordFailCreateOnCreate() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("baz"), Instant.now())
+				new UserName("bar"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -905,12 +908,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void resetPasswordFailAdminOnAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("baz"), Instant.now())
+				new UserName("bar"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -971,7 +974,7 @@ public class AuthenticationPasswordLoginTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -992,12 +995,12 @@ public class AuthenticationPasswordLoginTest {
 		// mostly to exercise the password clearing code, although there's no way to check the
 		// clearing occurred
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -1026,12 +1029,12 @@ public class AuthenticationPasswordLoginTest {
 		// mostly to exercise the password clearing code, although there's no way to check the
 		// clearing occurred
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -1154,12 +1157,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordAdminOnStd() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -1173,12 +1176,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordSelf() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -1192,12 +1195,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordRootOnCreate() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -1211,12 +1214,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordRootOnSelf() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("baz"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -1230,12 +1233,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordCreateOnAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -1249,12 +1252,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordFailLocalUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), Instant.now())
+				new UserName("foo"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withIdentity(REMOTE1).build();
 		
@@ -1269,12 +1272,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordFailCreateOnRoot() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("baz"), Instant.now())
+				UserName.ROOT, UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.build();
 		
@@ -1289,12 +1292,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordFailCreateOnCreate() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("baz"), Instant.now())
+				new UserName("bar"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -1309,12 +1312,12 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetPasswordFailAdminOnAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("baz"), Instant.now())
+				new UserName("bar"), UID2, new DisplayName("baz"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@hoo.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -1375,7 +1378,7 @@ public class AuthenticationPasswordLoginTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -1449,7 +1452,7 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetAllPasswordsCreateAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -1459,7 +1462,7 @@ public class AuthenticationPasswordLoginTest {
 	@Test
 	public void forceResetAllPasswordsRoot() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("bar"), Instant.now())
+				UserName.ROOT, UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.build();
 		

--- a/src/us/kbase/test/auth2/lib/AuthenticationPolicyIDTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationPolicyIDTest.java
@@ -64,7 +64,7 @@ public class AuthenticationPolicyIDTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				adminName, new DisplayName("foobar"), Instant.now())
+				adminName, UUID.randomUUID(), new DisplayName("foobar"), Instant.now())
 				.withRole(Role.ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);

--- a/src/us/kbase/test/auth2/lib/AuthenticationRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationRoleTest.java
@@ -44,6 +44,8 @@ import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 
 public class AuthenticationRoleTest {
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	private static List<ILoggingEvent> logEvents;
 	
 	@BeforeClass
@@ -68,7 +70,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foobar"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.SERV_TOKEN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, htoken, null);
@@ -167,7 +169,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foobar"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.SERV_TOKEN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, htoken, null);
@@ -193,7 +195,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foobar"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.SERV_TOKEN)
 				.withUserDisabledState(
 						new UserDisabledState("foo", new UserName("bar"), Instant.now()))
@@ -220,7 +222,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				UserName.ROOT, new DisplayName("foobar"), Instant.now()).build();
+				UserName.ROOT, UID, new DisplayName("foobar"), Instant.now()).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, htoken, null);
 		
@@ -395,7 +397,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("baz"), new DisplayName("foobar"), Instant.now())
+				new UserName("baz"), UID, new DisplayName("foobar"), Instant.now())
 				.withRole(Role.CREATE_ADMIN).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);
@@ -471,7 +473,7 @@ public class AuthenticationRoleTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser u = AuthUser.getBuilder(
-				adminUser, new DisplayName("foobar"), Instant.now())
+				adminUser, UID, new DisplayName("foobar"), Instant.now())
 				.withRole(withRole).build();
 		
 		when(storage.getToken(token.getHashedToken())).thenReturn(htoken, (StoredToken) null);

--- a/src/us/kbase/test/auth2/lib/AuthenticationTestModeTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTestModeTokenTest.java
@@ -41,6 +41,8 @@ import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 
 public class AuthenticationTestModeTokenTest {
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	private static List<ILoggingEvent> logEvents;
 	
 	@BeforeClass
@@ -64,7 +66,7 @@ public class AuthenticationTestModeTokenTest {
 		final UUID id = UUID.randomUUID();
 		
 		when(storage.testModeGetUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("d"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("d"), Instant.now()).build());
 		when(rand.randomUUID()).thenReturn(id);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		when(rand.getToken()).thenReturn("whee");
@@ -99,7 +101,7 @@ public class AuthenticationTestModeTokenTest {
 		final UUID id = UUID.randomUUID();
 		
 		when(storage.testModeGetUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("d"), Instant.now()).build());
+				new UserName("foo"), UID, new DisplayName("d"), Instant.now()).build());
 		when(rand.randomUUID()).thenReturn(id);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		when(rand.getToken()).thenReturn("whee");

--- a/src/us/kbase/test/auth2/lib/AuthenticationTester.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTester.java
@@ -467,7 +467,7 @@ public class AuthenticationTester {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("f"), Instant.now())
 				.withUserDisabledState(
 						new UserDisabledState("f", new UserName("b"), Instant.now())).build());
 		
@@ -500,7 +500,7 @@ public class AuthenticationTester {
 				.thenReturn(null);
 		
 		when(storage.getUser(un)).thenReturn(AuthUser.getBuilder(
-				un, new DisplayName("f"), Instant.now())
+				un, UUID.randomUUID(), new DisplayName("f"), Instant.now())
 				.withRole(r).build());
 		
 		failExecute(ao, auth, "unauthorized user test for role " + r,
@@ -526,7 +526,8 @@ public class AuthenticationTester {
 				.thenReturn(null);
 		
 		when(storage.getUser(new UserName("foo"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("f"), Instant.now()).build());
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("f"), Instant.now())
+				.build());
 		
 		failExecute(ao, auth, "unauthorized user test",
 				new UnauthorizedException(ErrorType.UNAUTHORIZED));
@@ -550,7 +551,7 @@ public class AuthenticationTester {
 				.thenReturn(null);
 		
 		final Builder builder = AuthUser.getBuilder(
-				userName, new DisplayName("f"), Instant.now());
+				userName, UUID.randomUUID(), new DisplayName("f"), Instant.now());
 		
 		if (role != null) {
 			builder.withRole(role);

--- a/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
+++ b/src/us/kbase/test/auth2/lib/AuthenticationTokenTest.java
@@ -59,7 +59,9 @@ import us.kbase.test.auth2.lib.AuthenticationTester.TestMocks;
 
 public class AuthenticationTokenTest {
 	
-	/* tests token get, create, revoke, and getBare. */
+	/* tests token get, create, and revoke. */
+	
+	private static final UUID UID = UUID.randomUUID();
 	
 	private static final TokenCreationContext CTX = TokenCreationContext.getBuilder().build();
 	
@@ -232,7 +234,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void getTokensUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -526,7 +528,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void revokeTokenAdmin() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 
@@ -586,7 +588,7 @@ public class AuthenticationTokenTest {
 				.withLifeTime(Instant.now(), Instant.now()).build();
 		
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -715,7 +717,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void revokeAllTokensAdminAll() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -800,7 +802,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void revokeAllTokensAdminUser() throws Exception {
 		final AuthUser admin = AuthUser.getBuilder(
-				new UserName("admin"), new DisplayName("bar"), Instant.now())
+				new UserName("admin"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -890,7 +892,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createAgentToken() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.build();
 		
 		createToken(user, new HashMap<>(), 7 * 24 * 3600 * 1000L, TokenType.AGENT);
@@ -899,7 +901,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createAgentTokenWithAltLifeTime() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.build();
 		
 		final HashMap<TokenLifetimeType, Long> lifetimes = new HashMap<>();
@@ -910,7 +912,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createDevToken() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -920,7 +922,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createDevTokenAltLifetime() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN).build();
 		
@@ -932,7 +934,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createDevTokenWithServRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.SERV_TOKEN).build();
 		
@@ -942,7 +944,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createServToken() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.SERV_TOKEN).build();
 		
@@ -952,7 +954,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createServTokenWithAdminRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.ADMIN).build();
 		
@@ -962,7 +964,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createServTokenWithAltLifetime() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.SERV_TOKEN).build();
 		
@@ -1002,7 +1004,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createTokenFailNoDevRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN).build();
 		
@@ -1013,7 +1015,7 @@ public class AuthenticationTokenTest {
 	@Test
 	public void createTokenFailNoServRole() throws Exception {
 		final AuthUser user = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.DEV_TOKEN)
 				.withRole(Role.CREATE_ADMIN).build();

--- a/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
+++ b/src/us/kbase/test/auth2/lib/LinkIdentitiesTest.java
@@ -8,6 +8,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -23,6 +24,8 @@ import us.kbase.auth2.lib.user.AuthUser;
 import us.kbase.test.auth2.TestCommon;
 
 public class LinkIdentitiesTest {
+	
+	private static final UUID UID = UUID.randomUUID();
 	
 	private final static RemoteIdentity REMOTE1 = new RemoteIdentity(
 			new RemoteIdentityID("prov", "bar"),
@@ -40,7 +43,7 @@ public class LinkIdentitiesTest {
 	static {
 		try {
 			AUTH_USER = AuthUser.getBuilder(
-					new UserName("foo"), new DisplayName("bar"), Instant.now())
+					new UserName("foo"), UID, new DisplayName("bar"), Instant.now())
 					.withEmailAddress(new EmailAddress("f@h.com"))
 					.withIdentity(REMOTE1).build();
 		} catch (Exception e) {
@@ -135,7 +138,7 @@ public class LinkIdentitiesTest {
 				new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("u2", "f2", "f2@g.com"));
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("d"), Instant.now())
+				new UserName("bar"), UUID.randomUUID(), new DisplayName("d"), Instant.now())
 				.withIdentity(ri1)
 				.withIdentity(ri2)
 				.build();
@@ -197,7 +200,7 @@ public class LinkIdentitiesTest {
 				new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("u2", "f2", "f2@g.com"));
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("bar"), new DisplayName("d"), Instant.now())
+				new UserName("bar"), UUID.randomUUID(), new DisplayName("d"), Instant.now())
 				.withIdentity(ri1)
 				.withIdentity(ri2)
 				.build();
@@ -227,11 +230,11 @@ public class LinkIdentitiesTest {
 		final Instant now = Instant.now();
 		final LinkIdentities ls = LinkIdentities.getBuilder(
 				new UserName("fake"), "prov", Instant.now())
-				.withUser(AuthUser.getBuilder(new UserName("foo"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("foo"), UID, dn, now)
 						.withIdentity(REMOTE1).build(), REMOTE1)
-				.withUser(AuthUser.getBuilder(new UserName("bar"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("bar"), UUID.randomUUID(), dn, now)
 						.withIdentity(REMOTE2).build(), REMOTE2)
-				.withUser(AuthUser.getBuilder(new UserName("baz"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("baz"), UUID.randomUUID(), dn, now)
 						.withIdentity(REMOTE3).build(), REMOTE3)
 				.build();
 		
@@ -254,7 +257,7 @@ public class LinkIdentitiesTest {
 	@Test
 	public void sortedLinkedIdentities() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("dn"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("dn"), Instant.now())
 				.withIdentity(REMOTE3)
 				.withIdentity(REMOTE1)
 				.withIdentity(REMOTE2)

--- a/src/us/kbase/test/auth2/lib/LoginStateTest.java
+++ b/src/us/kbase/test/auth2/lib/LoginStateTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -27,6 +28,9 @@ import us.kbase.test.auth2.TestCommon;
 
 public class LoginStateTest {
 	
+	private static final UUID UID = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
+	
 	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
 			new RemoteIdentityID("prov", "bar"),
 			new RemoteIdentityDetails("user", "full", "email"));
@@ -44,10 +48,10 @@ public class LoginStateTest {
 	static {
 		try {
 			AUTH_USER1 = NewUser.getBuilder(
-					new UserName("foo4"), new DisplayName("bar4"), Instant.now(), REMOTE1)
+					new UserName("foo4"), UID, new DisplayName("bar4"), Instant.now(), REMOTE1)
 					.withEmailAddress(new EmailAddress("f@h.com")).build();
 			AUTH_USER2 = AuthUser.getBuilder(
-					new UserName("foo5"), new DisplayName("bar5"), Instant.now())
+					new UserName("foo5"), UID2, new DisplayName("bar5"), Instant.now())
 					.withEmailAddress(new EmailAddress("f@h5.com"))
 					.withIdentity(REMOTE2).withIdentity(REMOTE3)
 					.withRole(Role.ADMIN)
@@ -164,11 +168,11 @@ public class LoginStateTest {
 		final DisplayName dn = new DisplayName("d");
 		final Instant now = Instant.now();
 		final LoginState ls = LoginState.getBuilder("prov", false, Instant.now())
-				.withUser(AuthUser.getBuilder(new UserName("foo"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("foo"), UID, dn, now)
 						.withIdentity(REMOTE1).build(), REMOTE1)
-				.withUser(AuthUser.getBuilder(new UserName("bar"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("bar"), UID2, dn, now)
 						.withIdentity(REMOTE2).build(), REMOTE2)
-				.withUser(AuthUser.getBuilder(new UserName("baz"), dn, now)
+				.withUser(AuthUser.getBuilder(new UserName("baz"), UUID.randomUUID(), dn, now)
 						.withIdentity(REMOTE3).build(), REMOTE3)
 				.build();
 		
@@ -190,7 +194,7 @@ public class LoginStateTest {
 	@Test
 	public void sortedLinkedIdentities() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("dn"), Instant.now())
+				new UserName("foo"), UID, new DisplayName("dn"), Instant.now())
 				.withIdentity(REMOTE3)
 				.withIdentity(REMOTE1)
 				.withIdentity(REMOTE2)

--- a/src/us/kbase/test/auth2/lib/ViewableUserTest.java
+++ b/src/us/kbase/test/auth2/lib/ViewableUserTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.fail;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -26,7 +27,7 @@ public class ViewableUserTest {
 	@Test
 	public void constructWithoutEmail() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("e@f.com")).build();
 		
 		final ViewableUser vu = new ViewableUser(u, false);
@@ -38,7 +39,7 @@ public class ViewableUserTest {
 	@Test
 	public void constructWithEmail() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.now())
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("bar"), Instant.now())
 				.withEmailAddress(new EmailAddress("e@f.com")).build();
 
 		final ViewableUser vu = new ViewableUser(u, true);

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageAnonymousIDBackfillingTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageAnonymousIDBackfillingTest.java
@@ -1,0 +1,160 @@
+package us.kbase.test.auth2.lib.storage.mongo;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+import static us.kbase.test.auth2.TestCommon.assertExceptionCorrect;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+import org.bson.Document;
+import org.junit.Test;
+
+import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.PasswordHashAndSalt;
+import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.identity.RemoteIdentity;
+import us.kbase.auth2.lib.identity.RemoteIdentityDetails;
+import us.kbase.auth2.lib.identity.RemoteIdentityID;
+import us.kbase.auth2.lib.storage.mongo.MongoStorage;
+import us.kbase.auth2.lib.user.AuthUser;
+import us.kbase.auth2.lib.user.LocalUser;
+import us.kbase.auth2.lib.user.NewUser;
+
+public class MongoStorageAnonymousIDBackfillingTest extends MongoStorageTester {
+	
+	/*
+	 * These tests check the lazy backfilling mechanism for anonymous user IDs added in
+	 * 0.6.0. Since test users are ephemeral and only last one hour, they are not tested as
+	 * all newly created users will have anonymous IDs.
+	 */
+	
+	private static final UUID UID = UUID.randomUUID();
+	
+	private static final Instant NOW = Instant.now()
+			.truncatedTo(ChronoUnit.MILLIS); // mongo truncates
+	
+	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
+			new RemoteIdentityID("prov", "bar1"),
+			new RemoteIdentityDetails("user1", "full1", "email1"));
+	
+	@Test
+	public void backfillMissingAnonIDNoFieldLocalUser() throws Exception {
+		backfillMissingAnonIDLocalUser(new Document("$unset", new Document("anonid", "")));
+	}
+		
+	@Test
+	public void backfillMissingAnonIDWithFieldLocalUser() throws Exception {
+		backfillMissingAnonIDLocalUser(new Document("$set", new Document("anonid", null)));
+	}
+
+	public void backfillMissingAnonIDLocalUser(final Document update) throws Exception {
+		final byte[] pwd = "foobarbaz2".getBytes(StandardCharsets.UTF_8);
+		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
+		final LocalUser nlu = LocalUser.getLocalUserBuilder(
+				new UserName("local"), UID, new DisplayName("bar"), NOW)
+				.build();
+				
+		storage.createLocalUser(nlu, new PasswordHashAndSalt(pwd, salt));
+		db.getCollection("users").updateOne(new Document("user", "local"), update);
+		
+		final UUID uid2 = UUID.randomUUID();
+		when(manager.mockRand.randomUUID()).thenReturn(uid2, (UUID) null);
+		
+		assertThat("incorrect user", storage.getLocalUser(new UserName("local")),
+				is(LocalUser.getLocalUserBuilder(
+						new UserName("local"), uid2, new DisplayName("bar"), NOW).build()));
+	}
+	
+	@Test
+	public void backfillMissingAnonIDNoFieldStdUser() throws Exception {
+		backfillMissingAnonIDStdUser(new Document("$unset", new Document("anonid", "")));
+	}
+	
+	@Test
+	public void backFillMissingAnonIDWithFieldStdUser() throws Exception {
+		backfillMissingAnonIDStdUser(new Document("$set", new Document("anonid", null)));
+	}
+
+	public void backfillMissingAnonIDStdUser(final Document update) throws Exception {
+		storage.createUser(NewUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("d"), NOW, REMOTE1).build());
+		db.getCollection("users").updateOne(new Document("user", "foo"), update);
+		
+		final UUID uid2 = UUID.randomUUID();
+		when(manager.mockRand.randomUUID()).thenReturn(uid2, (UUID) null);
+		
+		final AuthUser got = storage.getUser(new UserName("foo"));
+		final AuthUser expected = AuthUser.getBuilder(
+				new UserName("foo"), uid2, new DisplayName("d"), NOW)
+				.withIdentity(REMOTE1)
+				.build();
+		assertThat("incorrect user", got, is(expected));
+	}
+	
+	/*
+	 * The following tests test race conditions by accessing the internal update method
+	 * directly. At this point the userdoc has already been pulled from the database and
+	 * checked for the absence of an anonymous ID, and so race conditions are possible if
+	 * the document is then updated by another thread.
+	 */
+	
+	private Method getAnonIDUpdateMethod() throws Exception {
+		final Method m = MongoStorage.class
+				.getDeclaredMethod("updateUserAnonID", String.class, UserName.class);
+		m.setAccessible(true);
+		return m;
+	}
+	
+	@Test
+	public void updateUserAnonIDWithRaceOnUpdate() throws Exception {
+		/* Tests the case where the user doc is pulled from the DB and then another process
+		 * adds the anonID. The next update (e.g. this one) should then be ignored.
+		 */
+		storage.createUser(NewUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("d"), NOW, REMOTE1).build());
+		/* We create the user with an anonymous ID to simulate the case where the userdoc was
+		 * pulled from the DB and then another process added the anonymous ID.
+		 */
+		when(manager.mockRand.randomUUID()).thenReturn(UUID.randomUUID(), (UUID) null);
+		
+		final Document userdoc = (Document) getAnonIDUpdateMethod()
+				.invoke(storage, "users", new UserName("foo"));
+		
+		// only check a few properties, the methods above test exhaustively
+		assertThat("incorrect user", userdoc.getString("user"), is("foo"));
+		assertThat("incorrect anonid", userdoc.getString("anonid"), is(UID.toString()));
+		assertThat("incorrect dispname", userdoc.getString("display"), is("d"));
+		@SuppressWarnings("unchecked")
+		final List<Document> idents = (List<Document>) userdoc.get("idents");
+		assertThat("incorrect prov user id", idents.get(0).get("prov_id"), is("bar1"));
+	}
+	
+	@Test
+	public void updateUserAnonWithMissingDocument() throws Exception {
+		/* Tests the case where the user doc is removed after being pulled from the db.
+		 * This should never happen under normal operating conditions since user cannot be
+		 * removed, only disabled.
+		 */
+		
+		storage.createUser(NewUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("d"), NOW, REMOTE1).build());
+		// We create a user with a different name to simulate removal of the target userdoc.
+		when(manager.mockRand.randomUUID()).thenReturn(UUID.randomUUID(), (UUID) null);
+		
+		try {
+			getAnonIDUpdateMethod().invoke(storage, "users", new UserName("bar"));
+			fail("expected exception");
+		} catch (InvocationTargetException e) {
+			assertExceptionCorrect(e.getCause(), new RuntimeException(
+					"User unexpectedly not found in database: bar"));
+		}
+	}
+}

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageCustomRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageCustomRoleTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 import org.bson.Document;
 import org.junit.Test;
@@ -28,6 +29,8 @@ import us.kbase.auth2.lib.user.NewUser;
 import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageCustomRoleTest extends MongoStorageTester {
+	
+	private static final UUID UID = UUID.randomUUID();
 
 	private static final Instant NOW = Instant.now();
 	
@@ -128,7 +131,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -147,7 +150,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -160,7 +163,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void removeRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -174,7 +177,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void removeNonExistentRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -188,7 +191,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveSameRole() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -201,7 +204,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void noop() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		
@@ -223,7 +226,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 		 * deleted.
 		 */
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		storage.setCustomRole(new CustomRole("bar", "bleah"));
@@ -264,7 +267,7 @@ public class MongoStorageCustomRoleTest extends MongoStorageTester {
 	@Test
 	public void updateFailNoSuchRole() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		storage.setCustomRole(new CustomRole("foo", "bleah"));
 		failUpdateRoles(new UserName("foo"), set("foo"), set("bar"),
 				new NoSuchRoleException("bar"));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageDisableAccountTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageDisableAccountTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -22,6 +23,7 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
@@ -31,7 +33,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void disableAccountTwice() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),
@@ -102,7 +104,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void enableAccountTwice() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),
@@ -160,7 +162,7 @@ public class MongoStorageDisableAccountTest extends MongoStorageTester {
 	@Test
 	public void disableEnableDisable() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		assertThat("account already disabled",
 				storage.getUser(new UserName("foo")).getDisabledState(),

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -30,6 +31,10 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	
+	private static final UUID UID1 = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
+	private static final UUID UID3 = UUID.randomUUID();
+	private static final UUID UID4 = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 	
 	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
@@ -51,11 +56,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromList() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("whoo"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("whoo"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("bar"));
@@ -68,11 +73,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromEmptyList() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("whoo"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("whoo"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		assertThat("incorrect users found", storage.getUserDisplayNames(
@@ -82,11 +87,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void getNamesFromListWithDisabledUsers() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("whoo"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("whoo"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		when(mockClock.instant()).thenReturn(Instant.now());
 		
@@ -123,11 +128,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foow"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foow"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("whee"), new DisplayName("bar"));
@@ -141,11 +146,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchDisplayName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("barw"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("barw"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("whoo"));
@@ -159,13 +164,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchBothNames() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -181,13 +186,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchBothNamesEmpty() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -202,13 +207,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchNoResults() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -220,13 +225,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllResults() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -242,11 +247,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserRegex() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("baz"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whoo"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		expected.put(new UserName("foo"), new DisplayName("baz"));
@@ -265,11 +270,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchWithRegexInPrefix() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("baz"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("baz"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whoo"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
 		
@@ -281,13 +286,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchUserLimit() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wfoo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("wfoo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -301,13 +306,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchDisplayLimit() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -322,13 +327,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.updateRoles(new UserName("whee"), set(Role.ADMIN, Role.DEV_TOKEN),
@@ -352,13 +357,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchMultipleRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.updateRoles(new UserName("whee"), set(Role.ADMIN, Role.DEV_TOKEN),
@@ -377,13 +382,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchCustomRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3,new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
@@ -410,13 +415,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchMultipleCustomRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("thewrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("thewrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
@@ -504,13 +509,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllFields() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("whoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("whoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("wrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
@@ -543,13 +548,13 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void searchAllFieldsWithLimit() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("fwhoo"), NOW, REMOTE1).build());
+				new UserName("foo"), UID1, new DisplayName("fwhoo"), NOW, REMOTE1).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("wbar"), NOW, REMOTE2).build());
+				new UserName("whee"), UID2, new DisplayName("wbar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wugga"), new DisplayName("wonk"), NOW, REMOTE3).build());
+				new UserName("wugga"), UID3, new DisplayName("wonk"), NOW, REMOTE3).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("wrock"), new DisplayName("smellywcooking"), NOW, REMOTE4)
+				new UserName("wrock"), UID4, new DisplayName("smellywcooking"), NOW, REMOTE4)
 				.build());
 		
 		storage.setCustomRole(new CustomRole("baz", "bleah"));
@@ -583,10 +588,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void canonicalSearchPunctuation1() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"), NOW, REMOTE1)
+				new UserName("foo"), UID1, new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"),
+				NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
+				new UserName("whee"), UID2, new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -601,10 +607,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void canonicalSearchPunctuation2() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"), NOW, REMOTE1)
+				new UserName("foo"), UID1, new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"),
+				NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
+				new UserName("whee"), UID2, new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -618,10 +625,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void canonicalSearchPunctuation3() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"), NOW, REMOTE1)
+				new UserName("foo"), UID1, new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"),
+				NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
+				new UserName("whee"), UID2, new DisplayName("*&wbar#@  *&wh+oo;; "), NOW, REMOTE2)
 				.build());
 		
 		final Map<UserName, DisplayName> expected = new HashMap<>();
@@ -635,10 +643,11 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	@Test
 	public void canonicalSearchPunctuation4() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"), NOW, REMOTE1)
+				new UserName("foo"), UID1, new DisplayName("(wh+ee) ++bun+k]՞ fwhoo"),
+				NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("*&wbar#@  wh+oo;; "), NOW, REMOTE2)
+				new UserName("whee"), UID2, new DisplayName("*&wbar#@  wh+oo;; "), NOW, REMOTE2)
 				.build());
 		
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
@@ -752,27 +761,31 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 	
 	private void createUsersForCanonicalAndUserSearch() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("adamsly"), new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1).build());
-		storage.createUser(NewUser.getBuilder(
-				new UserName("adamsly2"), new DisplayName("Herbert Doug~ie Howser"), NOW, REMOTE2)
+				new UserName("adamsly"), UID1, new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("ada"), new DisplayName("al douglas"), NOW, REMOTE3).build());
+				new UserName("adamsly2"), UID2, new DisplayName("Herbert Doug~ie Howser"),
+				NOW, REMOTE2)
+				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("adlbert"), new DisplayName("Albert HevensyDouglas"), NOW, REMOTE4)
+				new UserName("ada"), UID3, new DisplayName("al douglas"), NOW, REMOTE3).build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("adlbert"), UID4, new DisplayName("Albert HevensyDouglas"),
+				NOW, REMOTE4)
 				.build());
 	}
 
 	private void createUsersForCanonicalSearch() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("u1"), new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1).build());
-		storage.createUser(NewUser.getBuilder(
-				new UserName("u2"), new DisplayName("Herbert Doug~ie Howser"), NOW, REMOTE2)
+				new UserName("u1"), UID1, new DisplayName("Dou*glas J Ad()ams"), NOW, REMOTE1)
 				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("u3"), new DisplayName("al douglas"), NOW, REMOTE3).build());
+				new UserName("u2"), UID2, new DisplayName("Herbert Doug~ie Howser"), NOW, REMOTE2)
+				.build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("u4"), new DisplayName("Albert HevensyDouglas"), NOW, REMOTE4)
+				new UserName("u3"), UID3, new DisplayName("al douglas"), NOW, REMOTE3).build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("u4"), UID4, new DisplayName("Albert HevensyDouglas"), NOW, REMOTE4)
 				.build());
 	}
 }

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageInvalidDBDataTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageInvalidDBDataTest.java
@@ -37,6 +37,7 @@ import us.kbase.test.auth2.TestCommon;
  */
 public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 	
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
@@ -46,7 +47,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void missingUserName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("user", null)));
 		
@@ -57,7 +58,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void illegalUserName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("user", "*foo")));
 		
@@ -69,7 +70,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void missingDisplayName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("display", "    \t \n")));
 		
@@ -80,7 +81,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void illegalDisplayName() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("display", TestCommon.LONG101)));
 		
@@ -91,7 +92,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void missingEmail() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("email", "    \t \n")));
 		
@@ -102,7 +103,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void illegalEmail() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$set", new Document("email", "noemailhere")));
 		
@@ -113,7 +114,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void missingPolicyID() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE)
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE)
 				.withPolicyID(new PolicyID("foo"), Instant.now()).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$addToSet", new Document("policyids", new Document("id", "       ")
@@ -126,7 +127,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void illegalPolicyID() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE)
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE)
 				.withPolicyID(new PolicyID("foo"), Instant.now()).build());
 		db.getCollection("users").updateOne(new Document("user", "foo"),
 				new Document("$addToSet", new Document("policyids", new Document("id", "foo\nbar")
@@ -244,7 +245,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void disabledStateMissingReason() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		when(mockClock.instant()).thenReturn(Instant.now());
 		storage.disableAccount(new UserName("foo"), new UserName("bar"), "baz");
@@ -259,7 +260,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void invalidDisabledState() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		when(mockClock.instant()).thenReturn(Instant.now());
 		storage.disableAccount(new UserName("foo"), new UserName("bar"), "baz");
@@ -275,7 +276,7 @@ public class MongoStorageInvalidDBDataTest extends MongoStorageTester {
 	@Test
 	public void disabledStateLongReason() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		when(mockClock.instant()).thenReturn(Instant.now());
 		storage.disableAccount(new UserName("foo"), new UserName("bar"), "baz");

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageLinkTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -31,6 +32,8 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageLinkTest extends MongoStorageTester {
 
+	private static final UUID UID = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 	
 	private static final RemoteIdentity REMOTE1 = new RemoteIdentity(
@@ -52,7 +55,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void link() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		final boolean linked = storage.link(new UserName("foo"), REMOTE2);
 		assertThat("incorrect linked state", linked, is(true));
 		assertThat("incorrect identities", storage.getUser(new UserName("foo")).getIdentities(),
@@ -62,7 +65,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void unlink() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		storage.unlink(new UserName("foo"), REMOTE1.getRemoteID().getID());
 		assertThat("incorrect identities", storage.getUser(new UserName("foo")).getIdentities(),
@@ -72,7 +75,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void linkNoop() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		final RemoteIdentity ri = new RemoteIdentity(
 				new RemoteIdentityID("prov", "bar2"),
@@ -87,7 +90,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void linkAndUpdateIdentity() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		final RemoteIdentity ri = new RemoteIdentity(
 				new RemoteIdentityID("prov", "bar2"),
@@ -110,9 +113,9 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 		m.setAccessible(true);
 		
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo1"), new DisplayName("bar"), NOW, REMOTE4).build());
+				new UserName("foo1"), UID, new DisplayName("bar"), NOW, REMOTE4).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID2, new DisplayName("bar"), NOW, REMOTE1).build());
 		final AuthUser au = storage.getUser(new UserName("foo"));
 		final int p = (int) m.invoke(storage, au, REMOTE2);
 		assertThat("expected successful link", p, is(1));
@@ -129,9 +132,9 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 				"addIdentity", AuthUser.class, RemoteIdentity.class);
 		m.setAccessible(true);
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo1"), new DisplayName("bar"), NOW, REMOTE4).build());
+				new UserName("foo1"), UID, new DisplayName("bar"), NOW, REMOTE4).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID2, new DisplayName("bar"), NOW, REMOTE1).build());
 		final AuthUser au = storage.getUser(new UserName("foo"));
 		storage.link(new UserName("foo"), REMOTE2);
 		
@@ -153,9 +156,9 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 				"addIdentity", AuthUser.class, RemoteIdentity.class);
 		m.setAccessible(true);
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo1"), new DisplayName("bar"), NOW, REMOTE4).build());
+				new UserName("foo1"), UID, new DisplayName("bar"), NOW, REMOTE4).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID2, new DisplayName("bar"), NOW, REMOTE1).build());
 		final AuthUser au = storage.getUser(new UserName("foo"));
 		storage.link(new UserName("foo"), REMOTE2);
 		
@@ -174,9 +177,9 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 				"addIdentity", AuthUser.class, RemoteIdentity.class);
 		m.setAccessible(true);
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo1"), new DisplayName("bar"), NOW, REMOTE4).build());
+				new UserName("foo1"), UID, new DisplayName("bar"), NOW, REMOTE4).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID2, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		final AuthUser au = storage.getUser(new UserName("foo"));
 		storage.unlink(new UserName("foo"), REMOTE1.getRemoteID().getID());
@@ -189,7 +192,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void linkFailNulls() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		failLink(null, REMOTE1, new NullPointerException("userName"));
 		failLink(new UserName("foo"), null, new NullPointerException("remoteID"));
 	}
@@ -197,7 +200,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void linkFailNoUser() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		failLink(new UserName("foo1"), REMOTE2, new NoSuchUserException("foo1"));
 	}
 	
@@ -206,7 +209,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 		final byte[] pwd = "foobarbaz2".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
 		final LocalUser nlu = LocalUser.getLocalUserBuilder(
-				new UserName("local"), new DisplayName("bar"), NOW).build();
+				new UserName("local"), UID, new DisplayName("bar"), NOW).build();
 				
 		storage.createLocalUser(nlu, new PasswordHashAndSalt(pwd, salt));
 		failLink(new UserName("local"), REMOTE2,
@@ -216,9 +219,9 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void linkFailAlreadyLinked() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE2).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE2).build());
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo2"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo2"), UID2, new DisplayName("bar"), NOW, REMOTE1).build());
 		
 		final RemoteIdentity ri = new RemoteIdentity(
 				new RemoteIdentityID("prov", "bar2"),
@@ -250,7 +253,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void unlinkFailNoUser() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		failUnlink(new UserName("foo1"), REMOTE1.getRemoteID().getID(),
 				new NoSuchUserException("foo1"));
@@ -261,7 +264,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 		final byte[] pwd = "foobarbaz2".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "whee".getBytes(StandardCharsets.UTF_8);
 		final LocalUser nlu = LocalUser.getLocalUserBuilder(
-				new UserName("local"), new DisplayName("bar"), NOW).build();
+				new UserName("local"), UID, new DisplayName("bar"), NOW).build();
 				
 		storage.createLocalUser(nlu, new PasswordHashAndSalt(pwd, salt));
 		failUnlink(new UserName("local"), "foobar",
@@ -271,7 +274,7 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void unlinkFailOneIdentity() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		failUnlink(new UserName("foo"), REMOTE1.getRemoteID().getID(),
 				new UnLinkFailedException("The user has only one associated identity"));
 	}
@@ -279,10 +282,10 @@ public class MongoStorageLinkTest extends MongoStorageTester {
 	@Test
 	public void unlinkFailNoSuchIdentity() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE1).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE1).build());
 		storage.link(new UserName("foo"), REMOTE2);
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo1"), new DisplayName("bar"), NOW, REMOTE3).build());
+				new UserName("foo1"), UID2, new DisplayName("bar"), NOW, REMOTE3).build());
 		failUnlink(new UserName("foo"), REMOTE3.getRemoteID().getID(),
 				new NoSuchIdentityException("The user is not linked to identity " +
 						REMOTE3.getRemoteID().getID()));

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStoragePasswordTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStoragePasswordTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.UUID;
 import java.time.Instant;
 
 import org.bson.Document;
@@ -27,6 +28,7 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStoragePasswordTest extends MongoStorageTester {
 	
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
@@ -38,7 +40,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW).build(),
+				new UserName("foo"), UID, new DisplayName("bar"), NOW).build(),
 				new PasswordHashAndSalt(passwordHash, salt));
 
 		storage.forcePasswordReset(new UserName("foo"));
@@ -50,7 +52,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 	@Test
 	public void resetFailNoLocalUser() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		failReset(new UserName("foo"), new NoSuchLocalUserException("foo"));
 	}
 	
@@ -74,13 +76,14 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW).build(),
+				new UserName("foo"), UID, new DisplayName("bar"), NOW).build(),
 				new PasswordHashAndSalt(passwordHash, salt));
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo2"), new DisplayName("bar"), NOW).build(),
+				new UserName("foo2"), UUID.randomUUID(), new DisplayName("bar"), NOW).build(),
 				new PasswordHashAndSalt(passwordHash, salt));
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo3"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo3"), UUID.randomUUID(), new DisplayName("bar"), NOW, REMOTE)
+				.build());
 		
 		storage.forcePasswordReset();
 		final Document stduser = db.getCollection("users")
@@ -97,7 +100,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW).build(),
+				new UserName("foo"), UID, new DisplayName("bar"), NOW).build(),
 				new PasswordHashAndSalt(passwordHash, salt));
 		final LocalUser user = storage.getLocalUser(new UserName("foo"));
 		assertThat("incorrect last reset date", user.getLastPwdReset(), is(Optional.empty()));
@@ -126,7 +129,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 		final byte[] passwordHash = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW).build(),
+				new UserName("foo"), UID, new DisplayName("bar"), NOW).build(),
 				new PasswordHashAndSalt(passwordHash, salt));
 		final LocalUser user = storage.getLocalUser(new UserName("foo"));
 		assertThat("incorrect last reset date", user.getLastPwdReset(), is(Optional.empty()));
@@ -171,7 +174,7 @@ public class MongoStoragePasswordTest extends MongoStorageTester {
 	@Test
 	public void changePasswordFailNoLocalUser() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		final byte[] pwd = "foobarbaz1".getBytes(StandardCharsets.UTF_8);
 		final byte[] salt = "wo".getBytes(StandardCharsets.UTF_8);
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(pwd, salt);

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageRolesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageRolesTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -24,6 +25,7 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageRolesTest extends MongoStorageTester {
 
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 	
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
@@ -33,7 +35,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN, Role.ADMIN), set(Role.SERV_TOKEN));
@@ -49,7 +51,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		storage.updateRoles(new UserName("foo"), set(Role.DEV_TOKEN, Role.ADMIN),
 				Collections.emptySet());
 		assertThat("incorrect roles", storage.getUser(new UserName("foo")).getRoles(),
@@ -59,7 +61,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void removeRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN), Collections.emptySet());
@@ -72,7 +74,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void removeNonExistentRoles() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.updateRoles(new UserName("foo"), Collections.emptySet(),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN));
@@ -83,7 +85,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveSameRole() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		
 		storage.updateRoles(new UserName("foo"),
 				set(Role.DEV_TOKEN, Role.CREATE_ADMIN), set(Role.DEV_TOKEN));
@@ -94,7 +96,7 @@ public class MongoStorageRolesTest extends MongoStorageTester {
 	@Test
 	public void noop() throws Exception {
 		storage.createUser(NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), NOW, REMOTE).build());
+				new UserName("foo"), UID, new DisplayName("bar"), NOW, REMOTE).build());
 		storage.updateRoles(new UserName("foo"), set(Role.DEV_TOKEN), Collections.emptySet());
 		
 		storage.updateRoles(new UserName("foo"), Collections.emptySet(), Collections.emptySet());

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestCommon.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestCommon.java
@@ -10,6 +10,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
@@ -46,6 +47,7 @@ public class MongoStorageTestCommon {
 			throws Exception {
 		storage.createUser(NewUser.getBuilder(
 				new UserName(username),
+				UUID.randomUUID(),
 				new DisplayName(displayName),
 				NOW,
 				createRemoteIdentity(remoteID)

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestGetDisplayNamesTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestGetDisplayNamesTest.java
@@ -3,12 +3,14 @@ package us.kbase.test.auth2.lib.storage.mongo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -22,10 +24,12 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageTestGetDisplayNamesTest extends MongoStorageTester {
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@Test
 	public void emptyList() throws Exception {
 		final Instant now = Instant.now();
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"), now,
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"), now,
 				now.plusSeconds(10));
 		
 		final Map<UserName, DisplayName> res = storage.testModeGetUserDisplayNames(set());
@@ -36,12 +40,12 @@ public class MongoStorageTestGetDisplayNamesTest extends MongoStorageTester {
 	@Test
 	public void getDisplayNames() throws Exception {
 		final Instant now = Instant.now();
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"), now,
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"), now,
 				now.plusSeconds(10));
-		storage.testModeCreateUser(new UserName("baz"), new DisplayName("bat"), now,
-				now.plusSeconds(10));
-		storage.testModeCreateUser(new UserName("wugga"), new DisplayName("whoo"), now,
-				now.plusSeconds(10));
+		storage.testModeCreateUser(new UserName("baz"), UUID.randomUUID(), new DisplayName("bat"),
+				now, now.plusSeconds(10));
+		storage.testModeCreateUser(new UserName("wugga"), UUID.randomUUID(),
+				new DisplayName("whoo"), now, now.plusSeconds(10));
 		
 		final Map<UserName, DisplayName> res = storage.testModeGetUserDisplayNames(
 				set(new UserName("foo"), new UserName("wugga")));
@@ -70,7 +74,7 @@ public class MongoStorageTestGetDisplayNamesTest extends MongoStorageTester {
 	@Test
 	public void getStdNameFromTestStorage() throws Exception {
 		storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(10000L)).build(),
+				new UserName("foo"), UID, new DisplayName("bar"), inst(10000L)).build(),
 				new PasswordHashAndSalt("foobarbazbat".getBytes(), "bar".getBytes()));
 		
 		final Map<UserName, DisplayName> res = storage.testModeGetUserDisplayNames(
@@ -82,7 +86,7 @@ public class MongoStorageTestGetDisplayNamesTest extends MongoStorageTester {
 	@Test
 	public void getTestNameFromStdStorage() throws Exception {
 		final Instant now = Instant.now();
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"), now,
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"), now,
 				now.plusSeconds(10));
 		
 		final Map<UserName, DisplayName> res = storage.getUserDisplayNames(

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestRoleTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTestRoleTest.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Set;
+import java.util.UUID;
 
 import org.bson.Document;
 import org.junit.Test;
@@ -31,6 +32,8 @@ import us.kbase.auth2.lib.user.NewUser;
 import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageTestRoleTest extends MongoStorageTester {
+	
+	private static final UUID UID = UUID.randomUUID();
 	
 	private final static Instant DAY1 = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 			.plus(1, ChronoUnit.DAYS); // mongo truncates
@@ -159,7 +162,7 @@ public class MongoStorageTestRoleTest extends MongoStorageTester {
 	@Test
 	public void addAndRemoveRoles() throws Exception {
 		final Instant expires = Instant.now().plus(1, ChronoUnit.DAYS);
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"),
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(100000), expires);
 		
 		storage.testModeSetCustomRole(new CustomRole("foo", "bleah"), DAY1);
@@ -197,7 +200,7 @@ public class MongoStorageTestRoleTest extends MongoStorageTester {
 		 * case for future proofing purposes.
 		 */
 		final Instant expires = Instant.now().plus(1, ChronoUnit.DAYS);
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"),
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(100000), expires);
 		
 		storage.testModeSetCustomRole(new CustomRole("foo", "bleah"), DAY1);
@@ -217,7 +220,7 @@ public class MongoStorageTestRoleTest extends MongoStorageTester {
 		storage.setCustomRole(new CustomRole("baz", "bat"));
 		storage.testModeSetCustomRole(new CustomRole("bar", "bat"), DAY1);
 		storage.testModeSetCustomRole(new CustomRole("baz", "bat"), DAY1);
-		storage.createUser(NewUser.getBuilder(new UserName("foo"), new DisplayName("bar"),
+		storage.createUser(NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(10000), REMOTE).build());
 		failUpdateRoles(new UserName("foo"), set(Role.ADMIN), set("bar", "baz"),
 				new NoSuchUserException("foo"));
@@ -230,7 +233,7 @@ public class MongoStorageTestRoleTest extends MongoStorageTester {
 		storage.testModeSetCustomRole(new CustomRole("bar", "bat"), DAY1);
 		storage.testModeSetCustomRole(new CustomRole("baz", "bat"), DAY1);
 		final Instant expires = Instant.now().plus(1, ChronoUnit.DAYS);
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"),
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(100000), expires);
 		try {
 			storage.updateCustomRoles(new UserName("foo"), set("bar"), set("baz"));
@@ -280,7 +283,7 @@ public class MongoStorageTestRoleTest extends MongoStorageTester {
 	@Test
 	public void updateFailNoSuchRole() throws Exception {
 		final Instant expires = Instant.now().plus(1, ChronoUnit.DAYS);
-		storage.testModeCreateUser(new UserName("foo"), new DisplayName("bar"),
+		storage.testModeCreateUser(new UserName("foo"), UID, new DisplayName("bar"),
 				Instant.ofEpochMilli(100000), expires);
 		storage.testModeSetCustomRole(new CustomRole("foo", "bleah"), DAY1);
 		failUpdateRoles(new UserName("foo"), set(), set("bar"),

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageTester.java
@@ -10,6 +10,7 @@ import com.github.zafarkhaja.semver.Version;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
+import us.kbase.auth2.cryptutils.RandomDataGenerator;
 import us.kbase.auth2.lib.storage.mongo.MongoStorage;
 import us.kbase.common.test.controllers.mongo.MongoController;
 import us.kbase.test.auth2.MongoStorageTestManager;
@@ -23,6 +24,7 @@ public class MongoStorageTester {
 	static MongoClient mc;
 	static MongoDatabase db;
 	static MongoStorage storage;
+	static RandomDataGenerator mockRand;
 	static Clock mockClock;
 	static Version mongoDBVer;
 	static int indexVer;
@@ -35,6 +37,7 @@ public class MongoStorageTester {
 		mc = manager.mc;
 		db = manager.db;
 		storage = manager.storage;
+		mockRand = manager.mockRand;
 		mockClock = manager.mockClock;
 		mongoDBVer = manager.mongoDBVer;
 		indexVer = manager.indexVer;
@@ -54,6 +57,7 @@ public class MongoStorageTester {
 	public void clearDB() throws Exception {
 		manager.reset();
 		storage = manager.storage;
+		mockRand = manager.mockRand;
 		mockClock = manager.mockClock;
 	}
 }

--- a/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
+++ b/src/us/kbase/test/auth2/lib/storage/mongo/MongoStorageUpdateUserFieldsTest.java
@@ -13,6 +13,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -33,6 +34,7 @@ import us.kbase.test.auth2.TestCommon;
 
 public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now()
 			.truncatedTo(ChronoUnit.MILLIS); // mongo truncates
 	
@@ -47,7 +49,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateNoop() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"), UserUpdate.getBuilder().build());
@@ -60,7 +62,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateDisplay() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
@@ -74,7 +76,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateEmail() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
@@ -88,7 +90,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void updateBoth() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		storage.updateUser(new UserName("user1"),
@@ -126,7 +128,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void lastLogin() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		final Instant d = NOW.plus(Duration.ofHours(2));
@@ -158,7 +160,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsEmpty() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		storage.addPolicyIDs(new UserName("user1"), Collections.emptySet());
@@ -169,7 +171,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDs() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		when(mockClock.instant()).thenReturn(Instant.ofEpochMilli(10000));
@@ -182,7 +184,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsOverwrite() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		when(mockClock.instant()).thenReturn(Instant.ofEpochMilli(10000),
@@ -200,7 +202,7 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void addPolicyIDsOverwriteEmpty() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com")).build();
 		storage.createUser(nu);
 		when(mockClock.instant()).thenReturn(Instant.ofEpochMilli(10000));
@@ -241,14 +243,14 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void removePolicyID() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withEmailAddress(new EmailAddress("e@g1.com"))
 				.withPolicyID(new PolicyID("foo"), Instant.now())
 				.withPolicyID(new PolicyID("bar"), Instant.ofEpochMilli(30000))
 				.build();
 		storage.createUser(nu);
 		final NewUser nu2 = NewUser.getBuilder(
-				new UserName("user2"), new DisplayName("bar1"), NOW, REMOTE2)
+				new UserName("user2"), UID, new DisplayName("bar1"), NOW, REMOTE2)
 				.withEmailAddress(new EmailAddress("e@g1.com"))
 				.withPolicyID(new PolicyID("foo"), Instant.now())
 				.withPolicyID(new PolicyID("baz"), Instant.ofEpochMilli(40000))
@@ -266,13 +268,13 @@ public class MongoStorageUpdateUserFieldsTest extends MongoStorageTester {
 	@Test
 	public void removeUnusedPolicyID() throws Exception {
 		final NewUser nu = NewUser.getBuilder(
-				new UserName("user1"), new DisplayName("bar1"), NOW, REMOTE1)
+				new UserName("user1"), UID, new DisplayName("bar1"), NOW, REMOTE1)
 				.withPolicyID(new PolicyID("foo"), Instant.ofEpochMilli(20000))
 				.withPolicyID(new PolicyID("bar"), Instant.ofEpochMilli(30000))
 				.build();
 		storage.createUser(nu);
 		final NewUser nu2 = NewUser.getBuilder(
-				new UserName("user2"), new DisplayName("bar1"), NOW, REMOTE2)
+				new UserName("user2"), UID, new DisplayName("bar1"), NOW, REMOTE2)
 				.withEmailAddress(new EmailAddress("e@g1.com"))
 				.withPolicyID(new PolicyID("foo"), Instant.ofEpochMilli(35000))
 				.withPolicyID(new PolicyID("baz"), Instant.ofEpochMilli(40000))

--- a/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
+++ b/src/us/kbase/test/auth2/lib/user/AuthUserTest.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -31,6 +32,7 @@ import us.kbase.test.auth2.TestCommon;
 
 public class AuthUserTest {
 	
+	private static final UUID UID = UUID.randomUUID();
 	private static final Instant NOW = Instant.now();
 	
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
@@ -45,9 +47,12 @@ public class AuthUserTest {
 	
 	@Test
 	public void constructMinimal() throws Exception {
-		final AuthUser u = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"), NOW)
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("foo"), UID, new DisplayName("bar"), NOW)
 				.build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.empty()));
 		assertThat("incorrect created date", u.getCreated(), is(NOW));
@@ -74,7 +79,7 @@ public class AuthUserTest {
 		final Optional<Instant> ll = Optional.of(Instant.now());
 		final Instant d = ll.get().plusMillis(2);
 		
-		final AuthUser u = AuthUser.getBuilder(UserName.ROOT, new DisplayName("bar1"), NOW)
+		final AuthUser u = AuthUser.getBuilder(UserName.ROOT, UID, new DisplayName("bar1"), NOW)
 				.withEmailAddress(new EmailAddress("f@h1.com"))
 				.withCustomRole("foo")
 				.withCustomRole("bar")
@@ -82,6 +87,8 @@ public class AuthUserTest {
 				.withUserDisabledState(
 						new UserDisabledState("reason", new UserName("whee"), d)).build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.of(new UserName("whee"))));
 		assertThat("incorrect created date", u.getCreated(), is(NOW));
@@ -109,7 +116,8 @@ public class AuthUserTest {
 		final Optional<Instant> ll = Optional.of(Instant.now());
 		final Instant d = ll.get().plusMillis(2);
 		
-		final AuthUser u = AuthUser.getBuilder(new UserName("whoo"), new DisplayName("bar3"), NOW)
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withEmailAddress(new EmailAddress("f@h2.com"))
 				.withIdentity(REMOTE)
 				.withRole(Role.DEV_TOKEN)
@@ -122,6 +130,8 @@ public class AuthUserTest {
 				.withUserDisabledState(new UserDisabledState(new UserName("whee1"), d))
 				.build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.of(new UserName("whee1"))));
 		assertThat("incorrect created date", u.getCreated(), is(NOW));
@@ -148,7 +158,7 @@ public class AuthUserTest {
 	@Test
 	public void newIdentitiesMinimal() throws Exception {
 		final AuthUser pre = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withIdentity(REMOTE).build();
 		
 		final RemoteIdentity ri2 = new RemoteIdentity(
@@ -158,6 +168,8 @@ public class AuthUserTest {
 		final AuthUser u = AuthUser.getBuilderWithoutIdentities(pre)
 				.withIdentity(ri2).build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.empty()));
 		assertThat("incorrect created date", u.getCreated(), is(NOW));
@@ -183,7 +195,8 @@ public class AuthUserTest {
 		final Optional<Instant> ll = Optional.of(Instant.now());
 		final Instant d = ll.get().plusMillis(2);
 		
-		final AuthUser pre = AuthUser.getBuilder(new UserName("whoo"), new DisplayName("bar3"), NOW)
+		final AuthUser pre = AuthUser.getBuilder(
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withEmailAddress(new EmailAddress("f@h2.com"))
 				.withIdentity(REMOTE)
 				.withRole(Role.DEV_TOKEN)
@@ -203,6 +216,8 @@ public class AuthUserTest {
 		final AuthUser u = AuthUser.getBuilderWithoutIdentities(pre)
 				.withIdentity(ri2).build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.of(new UserName("whee1"))));
 		assertThat("incorrect created date", u.getCreated(), is(NOW));
@@ -228,7 +243,8 @@ public class AuthUserTest {
 	
 	@Test
 	public void roleMethods() throws Exception {
-		final AuthUser u = AuthUser.getBuilder(new UserName("whoo"), new DisplayName("bar3"), NOW)
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withRole(Role.ADMIN)
 				.withRole(Role.DEV_TOKEN)
 				.build();
@@ -249,7 +265,8 @@ public class AuthUserTest {
 				new RemoteIdentityID("prov2", "bar2"),
 				new RemoteIdentityDetails("user2", "full2", "email2"));
 		
-		final AuthUser u = AuthUser.getBuilder(new UserName("whoo"), new DisplayName("bar3"), NOW)
+		final AuthUser u = AuthUser.getBuilder(
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withIdentity(REMOTE)
 				.withIdentity(ri2)
 				.build();
@@ -279,7 +296,7 @@ public class AuthUserTest {
 		final Instant ll = Instant.now();
 		final Instant c = ll.plusMillis(1000);
 		
-		final AuthUser u = AuthUser.getBuilder(new UserName("foo"), new DisplayName("bar"), c)
+		final AuthUser u = AuthUser.getBuilder(new UserName("foo"), UID, new DisplayName("bar"), c)
 				.withLastLogin(ll)
 				.build();
 		
@@ -288,7 +305,7 @@ public class AuthUserTest {
 	
 	@Test
 	public void rootAddRoot() throws Exception {
-		AuthUser.getBuilder(UserName.ROOT, new DisplayName("foo"), NOW)
+		AuthUser.getBuilder(UserName.ROOT, UID, new DisplayName("foo"), NOW)
 				.withRole(Role.ROOT).build();
 		// should work
 	}
@@ -296,6 +313,7 @@ public class AuthUserTest {
 	@Test
 	public void constructFail() throws Exception {
 		final UserName un = new UserName("foo");
+		final UUID ui = UUID.randomUUID();
 		final EmailAddress email = new EmailAddress("f@h.com");
 		final DisplayName dn = new DisplayName("bar");
 		final RemoteIdentity id = REMOTE;
@@ -306,37 +324,40 @@ public class AuthUserTest {
 		final Instant created = Instant.now();
 		final Instant ll = Instant.now();
 		final UserDisabledState ds = new UserDisabledState();
-		failBuild(null, dn, created, email, id, role, crole, pid, pidt, ll, ds,
+		failBuild(null, ui, dn, created, email, id, role, crole, pid, pidt, ll, ds,
 				new NullPointerException("userName"));
-		failBuild(un, null, created, email, id, role, crole, pid, pidt, ll, ds,
+		failBuild(un, null, dn, created, email, id, role, crole, pid, pidt, ll, ds,
+				new NullPointerException("anonymousID"));
+		failBuild(un, ui, null, created, email, id, role, crole, pid, pidt, ll, ds,
 				new NullPointerException("displayName"));
-		failBuild(un, dn, null, email, id, role, crole, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, null, email, id, role, crole, pid, pidt, ll, ds,
 				new NullPointerException("created"));
-		failBuild(un, dn, created, null, id, role, crole, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, created, null, id, role, crole, pid, pidt, ll, ds,
 				new NullPointerException("email"));
-		failBuild(un, dn, created, email, null, role, crole, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, created, email, null, role, crole, pid, pidt, ll, ds,
 				new NullPointerException("remoteIdentity"));
-		failBuild(un, dn, created, email, id, null, crole, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, created, email, id, null, crole, pid, pidt, ll, ds,
 				new NullPointerException("role"));
-		failBuild(un, dn, created, email, id, role, null, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, created, email, id, role, null, pid, pidt, ll, ds,
 				new NullPointerException("customRole"));
-		failBuild(un, dn, created, email, id, role, crole, null, pidt, ll, ds,
+		failBuild(un, ui, dn, created, email, id, role, crole, null, pidt, ll, ds,
 				new NullPointerException("policyID"));
-		failBuild(un, dn, created, email, id, role, crole, pid, null, ll, ds,
+		failBuild(un, ui, dn, created, email, id, role, crole, pid, null, ll, ds,
 				new NullPointerException("agreedOn"));
-		failBuild(un, dn, created, email, id, role, crole, pid, pidt, null, ds,
+		failBuild(un, ui, dn, created, email, id, role, crole, pid, pidt, null, ds,
 				new NullPointerException("lastLogin"));
-		failBuild(un, dn, ll, email, id, role, crole, pid, pidt, created, null,
+		failBuild(un, ui, dn, ll, email, id, role, crole, pid, pidt, created, null,
 				new NullPointerException("disabledState"));
-		failBuild(UserName.ROOT, dn, created, email, id, Role.ROOT, crole, pid, pidt, ll, ds,
+		failBuild(UserName.ROOT, ui, dn, created, email, id, Role.ROOT, crole, pid, pidt, ll, ds,
 				new IllegalStateException("Root user cannot have identities"));
-		failBuild(un, dn, created, email, id, Role.ROOT, crole, pid, pidt, ll, ds,
+		failBuild(un, ui, dn, created, email, id, Role.ROOT, crole, pid, pidt, ll, ds,
 				new IllegalStateException("Non-root username with root role"));
 	}
 	
 	@Test
 	public void failRootBuildRoles() throws Exception {
-		final AuthUser.Builder b = AuthUser.getBuilder(UserName.ROOT, new DisplayName("foo"), NOW);
+		final AuthUser.Builder b = AuthUser.getBuilder(
+				UserName.ROOT, UID, new DisplayName("foo"), NOW);
 		for (final Role r: Arrays.asList(
 				Role.DEV_TOKEN, Role.SERV_TOKEN, Role.ADMIN, Role.CREATE_ADMIN)) {
 			try {
@@ -351,6 +372,7 @@ public class AuthUserTest {
 	
 	private void failBuild(
 			final UserName userName,
+			final UUID anonymousID,
 			final DisplayName displayName,
 			final Instant created,
 			final EmailAddress email,
@@ -363,7 +385,7 @@ public class AuthUserTest {
 			final UserDisabledState disabledState,
 			final Exception e) {
 		try {
-			AuthUser.getBuilder(userName, displayName, created)
+			AuthUser.getBuilder(userName, anonymousID, displayName, created)
 					.withEmailAddress(email)
 					.withIdentity(identity)
 					.withRole(role)
@@ -380,7 +402,7 @@ public class AuthUserTest {
 	@Test
 	public void immutableIdentities() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withIdentity(REMOTE).build();
 		
 		final RemoteIdentity ri = new RemoteIdentity(
@@ -398,7 +420,7 @@ public class AuthUserTest {
 	@Test
 	public void immutableRoles() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withRole(Role.DEV_TOKEN).build();
 		
 		try {
@@ -412,7 +434,7 @@ public class AuthUserTest {
 	@Test
 	public void immutableCustomRoles() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withCustomRole("foo").build();
 		
 		try {
@@ -426,7 +448,7 @@ public class AuthUserTest {
 	@Test
 	public void immutableGrantableRoles() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withRole(Role.ADMIN).build();
 		
 		try {
@@ -440,7 +462,7 @@ public class AuthUserTest {
 	@Test
 	public void immutablePolicyIDs() throws Exception {
 		final AuthUser u = AuthUser.getBuilder(
-				new UserName("whoo"), new DisplayName("bar3"), NOW)
+				new UserName("whoo"), UID, new DisplayName("bar3"), NOW)
 				.withPolicyID(new PolicyID("foo"), Instant.now()).build();
 		
 		try {
@@ -453,7 +475,7 @@ public class AuthUserTest {
 	
 	@Test
 	public void sortedCustomRoles() throws Exception {
-		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), UID, new DisplayName("u"),
 				Instant.ofEpochMilli(10000))
 				.withCustomRole("zoo")
 				.withCustomRole("foo")
@@ -467,7 +489,7 @@ public class AuthUserTest {
 	
 	@Test
 	public void sortedRoles() throws Exception {
-		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), UID, new DisplayName("u"),
 				Instant.ofEpochMilli(10000))
 				.withRole(Role.SERV_TOKEN)
 				.withRole(Role.ADMIN)
@@ -481,7 +503,7 @@ public class AuthUserTest {
 	
 	@Test
 	public void sortedPolicyIDs() throws Exception {
-		final AuthUser u = AuthUser.getBuilder(new UserName("f"), new DisplayName("u"),
+		final AuthUser u = AuthUser.getBuilder(new UserName("f"), UID, new DisplayName("u"),
 				Instant.ofEpochMilli(10000))
 				.withPolicyID(new PolicyID("zoo"), Instant.ofEpochMilli(10000))
 				.withPolicyID(new PolicyID("mid2"), Instant.ofEpochMilli(15000))

--- a/src/us/kbase/test/auth2/lib/user/LocalUserTest.java
+++ b/src/us/kbase/test/auth2/lib/user/LocalUserTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -28,6 +29,8 @@ public class LocalUserTest {
 	
 	/* note that this does not replicate the tests from authuser to test the general builder */
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	@Test
 	public void equals() {
 		EqualsVerifier.forClass(LocalUser.class).usingGetClass()
@@ -37,9 +40,11 @@ public class LocalUserTest {
 	@Test
 	public void constructMinimal() throws Exception {
 		final LocalUser lu = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(5))
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(5))
 				.build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", lu.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect pwd reset", lu.isPwdResetRequired(), is(false));
 		assertThat("incorrect reset date", lu.getLastPwdReset(), is(Optional.empty()));
 		
@@ -68,7 +73,7 @@ public class LocalUserTest {
 	@Test
 	public void constructMaximal() throws Exception {
 		final LocalUser lu = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(5))
+				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(5))
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withRole(Role.CREATE_ADMIN)
 				.withCustomRole("foobar")
@@ -80,6 +85,8 @@ public class LocalUserTest {
 				.withLastReset(Instant.ofEpochMilli(40000))
 				.build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", lu.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect pwd reset", lu.isPwdResetRequired(), is(true));
 		assertThat("incorrect reset date", lu.getLastPwdReset(),
 				is(Optional.of(Instant.ofEpochMilli(40000))));
@@ -112,7 +119,7 @@ public class LocalUserTest {
 	public void buildFail() throws Exception {
 		try {
 			LocalUser.getLocalUserBuilder(
-					new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(5))
+					new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(5))
 					.withLastReset(null)
 					.build();
 			fail("expected exception");

--- a/src/us/kbase/test/auth2/lib/user/NewUserTest.java
+++ b/src/us/kbase/test/auth2/lib/user/NewUserTest.java
@@ -9,6 +9,7 @@ import static us.kbase.test.auth2.TestCommon.set;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.Test;
 
@@ -26,6 +27,8 @@ public class NewUserTest {
 	
 	/* note that this does not replicate the tests from authuser to test the general builder */
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	private static final RemoteIdentity REMOTE = new RemoteIdentity(
 			new RemoteIdentityID("prov42", "bar42"),
 			new RemoteIdentityDetails("user42", "full42", "email42"));
@@ -34,9 +37,11 @@ public class NewUserTest {
 	public void build() throws Exception {
 		final Instant now = Instant.now();
 		final NewUser u = NewUser.getBuilder(
-				new UserName("foo"), new DisplayName("bar"), now, REMOTE)
+				new UserName("foo"), UID, new DisplayName("bar"), now, REMOTE)
 				.withEmailAddress(new EmailAddress("f@h.com")).build();
 		
+		// test based on equality vs identity
+		assertThat("incorrect anonID", u.getAnonymousID(), is(UUID.fromString(UID.toString())));
 		assertThat("incorrect disable admin", u.getAdminThatToggledEnabledState(),
 				is(Optional.empty()));
 		assertThat("incorrect created", u.getCreated(), is(now));
@@ -72,7 +77,8 @@ public class NewUserTest {
 			final Exception e)
 			throws Exception {
 		try {
-			NewUser.getBuilder(userName, new DisplayName("bar"), Instant.now(), remoteIdentity);
+			NewUser.getBuilder(
+					userName, UID, new DisplayName("bar"), Instant.now(), remoteIdentity);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, e);

--- a/src/us/kbase/test/auth2/service/api/TestModeTest.java
+++ b/src/us/kbase/test/auth2/service/api/TestModeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.set;
 import static us.kbase.test.auth2.service.common.ServiceCommonTest.assertRootJSONCorrect;
 
@@ -65,6 +66,7 @@ public class TestModeTest {
 	 * we do not test for null constructor inputs.
 	 */
 	
+	private static final UUID UID = UUID.randomUUID();
 	
 	/* the value of the git commit from the root endpoint could either be
 	 * an error message or a git commit hash depending on the test environment, so both are
@@ -84,7 +86,7 @@ public class TestModeTest {
 		final TestMode tm = new TestMode(auth);
 		
 		when(auth.testModeGetUser(new UserName("foobar"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foobar"), new DisplayName("foo bar"), Instant.ofEpochMilli(10000))
+				new UserName("foobar"), UID, new DisplayName("foo bar"), inst(10000))
 				.build());
 		
 		final Map<String, Object> au = tm.createTestUser(new CreateTestUser("foobar", "foo bar"));
@@ -169,7 +171,7 @@ public class TestModeTest {
 		final TestMode tm = new TestMode(auth);
 		
 		when(auth.testModeGetUser(new UserName("foobar"))).thenReturn(AuthUser.getBuilder(
-				new UserName("foobar"), new DisplayName("foo bar"), Instant.ofEpochMilli(10000))
+				new UserName("foobar"), UID, new DisplayName("foo bar"), inst(10000))
 				.build());
 		
 		final Map<String, Object> au = tm.getTestUser("foobar");
@@ -448,7 +450,7 @@ public class TestModeTest {
 		final TestMode tm = new TestMode(auth);
 		
 		when(auth.testModeGetUser(new IncomingToken("some token"))).thenReturn(
-				AuthUser.getBuilder(new UserName("un"), new DisplayName("dn"),
+				AuthUser.getBuilder(new UserName("un"), UID, new DisplayName("dn"),
 						Instant.ofEpochMilli(10000))
 						.build());
 		
@@ -762,7 +764,7 @@ public class TestModeTest {
 		
 		when(auth.testModeGetUser(new IncomingToken("yay!"), new UserName("foo"))).thenReturn(
 				new ViewableUser(AuthUser.getBuilder(
-						new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(10000))
+						new UserName("foo"), UID, new DisplayName("bar"), inst(10000))
 							.build(),
 						true));
 		
@@ -897,7 +899,7 @@ public class TestModeTest {
 		
 		when(auth.testModeGetUser(new IncomingToken("this is a token"))).thenReturn(
 				AuthUser.getBuilder(
-						new UserName("foo"), new DisplayName("dn"), Instant.ofEpochMilli(10000L))
+						new UserName("foo"), UID, new DisplayName("dn"), inst(10000L))
 						.build());
 		
 		final MultivaluedMap<String, String> form = new MultivaluedHashMap<>();

--- a/src/us/kbase/test/auth2/service/api/TokenEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/TokenEndpointTest.java
@@ -2,6 +2,7 @@ package us.kbase.test.auth2.service.api;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
 
 import java.net.URI;
@@ -328,7 +329,7 @@ public class TokenEndpointTest {
 	
 	private NewToken setUpUser() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("foo"), new DisplayName("bar"), Instant.ofEpochMilli(10000))
+				new UserName("foo"), UUID.randomUUID(), new DisplayName("bar"), inst(10000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "zz".getBytes()));
 		final NewToken nt = new NewToken(StoredToken.getBuilder(

--- a/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -71,6 +71,7 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
  */
 public class UserEndpointTest {
 
+	private static final UUID UID = UUID.randomUUID();
 	private static final String DB_NAME = "test_user_api";
 	private static final String COOKIE_NAME = "login-cookie";
 	
@@ -152,7 +153,7 @@ public class UserEndpointTest {
 	@Test
 	public void getMeMinimalInput() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
@@ -193,7 +194,7 @@ public class UserEndpointTest {
 	public void getMeMaximalInput() throws Exception {
 		manager.storage.setCustomRole(new CustomRole("whoo", "a"));
 		manager.storage.setCustomRole(new CustomRole("whee", "b"));
-		manager.storage.createUser(NewUser.getBuilder(new UserName("foobar"),
+		manager.storage.createUser(NewUser.getBuilder(new UserName("foobar"), UID,
 				new DisplayName("bleah"), Instant.ofEpochMilli(20000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
@@ -291,7 +292,7 @@ public class UserEndpointTest {
 	@Test
 	public void putMeNoUpdate() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
@@ -311,7 +312,7 @@ public class UserEndpointTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user modified unexpectedly", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("bleah"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("bleah"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("f@h.com"))
 						.build()));
@@ -320,7 +321,7 @@ public class UserEndpointTest {
 	@Test
 	public void putMeFullUpdate() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
@@ -341,7 +342,7 @@ public class UserEndpointTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user not modified", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("whee"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("whee"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("x@g.com"))
 						.build()));
@@ -417,7 +418,7 @@ public class UserEndpointTest {
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
 				"foobarbazbing".getBytes(), "aa".getBytes());
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");
@@ -461,11 +462,11 @@ public class UserEndpointTest {
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
 				"foobarbazbing".getBytes(), "aa".getBytes());
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobaz"),
-				new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
+				UUID.randomUUID(),new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f2@g.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");
@@ -591,30 +592,34 @@ public class UserEndpointTest {
 		assertThat("incorrect users", response, is(expected));
 	}
 	
+	private UUID uuid() {
+		return UUID.randomUUID();
+	}
+	
 	private IncomingToken setUpUsersForTesting() throws Exception {
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
 				"foobarbazbing".getBytes(), "aa".getBytes());
 
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foo"),
-				new DisplayName("bar *thing*"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("bar *thing*"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("baz"),
-				new DisplayName("fuz"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("fuz"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("puz"),
-				new DisplayName("mup"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("mup"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("mua"),
-				new DisplayName("paz"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("paz"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		
 		
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("toobar"),
-				new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f2@g.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");

--- a/src/us/kbase/test/auth2/service/ui/LinkTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LinkTest.java
@@ -192,7 +192,8 @@ public class LinkTest {
 		enableProvider(host, COOKIE_NAME, admintoken, "prov2");
 		
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("u1"), new DisplayName("d"), Instant.now()).build(),
+				new UserName("u1"), UUID.randomUUID(), new DisplayName("d"), Instant.now())
+				.build(),
 				new PasswordHashAndSalt("foofoofoofoo".getBytes(), "arp".getBytes()));
 		
 		final NewToken nt = new NewToken(StoredToken.getBuilder(
@@ -242,7 +243,9 @@ public class LinkTest {
 
 	private NewToken setUpLinkUserAndToken() throws Exception {
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("u1"), new DisplayName("d"), Instant.now(), REMOTE1).build());
+				new UserName("u1"), UUID.randomUUID(), new DisplayName("d"), Instant.now(),
+				REMOTE1)
+				.build());
 		final NewToken nt = new NewToken(StoredToken.getBuilder(
 				TokenType.LOGIN, UUID.randomUUID(), new UserName("u1"))
 				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(100000000000000L))

--- a/src/us/kbase/test/auth2/service/ui/LoginTest.java
+++ b/src/us/kbase/test/auth2/service/ui/LoginTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
 import static us.kbase.test.auth2.TestCommon.calculatePKCEChallenge;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.set;
 import static us.kbase.test.auth2.service.ServiceTestUtils.enableLogin;
 import static us.kbase.test.auth2.service.ServiceTestUtils.enableProvider;
@@ -90,6 +91,10 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 public class LoginTest {
 	
 	//TODO TEST convert most of these to unit tests, but keep enough for integration tests
+	
+	private static final UUID UID = UUID.randomUUID();
+	private static final UUID UID2 = UUID.randomUUID();
+	private static final UUID UID3 = UUID.randomUUID();
 	
 	private static final String DB_NAME = "test_login_ui";
 	private static final String COOKIE_NAME = "login-cookie";
@@ -587,7 +592,7 @@ public class LoginTest {
 				authcode, pkce, environment);
 		
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("whee"), new DisplayName("dn"), Instant.ofEpochMilli(20000),
+				new UserName("whee"), UID, new DisplayName("dn"), Instant.ofEpochMilli(20000),
 					remoteIdentity)
 				.build());
 	}
@@ -1155,11 +1160,11 @@ public class LoginTest {
 		manager.storage.storeTemporarySessionData(data, IncomingToken.hash("this is a token"));
 		
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("userat"),
-				new DisplayName("f"), Instant.ofEpochMilli(30000)).build(),
+				UID, new DisplayName("f"), Instant.ofEpochMilli(30000)).build(),
 				new PasswordHashAndSalt("foobarbazbat".getBytes(), "aaa".getBytes()));
 		
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("ruser1"), new DisplayName("disp1"), Instant.ofEpochMilli(10000),
+				new UserName("ruser1"), UID2, new DisplayName("disp1"), inst(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1a", "full1a", "e1a@g.com")))
 				.withPolicyID(new PolicyID("foo"), Instant.ofEpochMilli(60000))
@@ -1169,7 +1174,7 @@ public class LoginTest {
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("user2a", "full2a", "e2a@g.com")));
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("ruser2"), new DisplayName("disp2"), Instant.ofEpochMilli(10000),
+				new UserName("ruser2"), UID3, new DisplayName("disp2"), inst(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id3"),
 						new RemoteIdentityDetails("user3a", "full3a", "e3a@g.com"))).build());
 		when(manager.mockClock.instant()).thenReturn(Instant.ofEpochMilli(40000));
@@ -1281,12 +1286,12 @@ public class LoginTest {
 		manager.storage.storeTemporarySessionData(data, IncomingToken.hash("this is a token"));
 		
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("ruser1"), new DisplayName("disp1"), Instant.ofEpochMilli(10000),
+				new UserName("ruser1"), UID, new DisplayName("disp1"), inst(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1a", "full1a", "e1a@g.com")))
 				.build());
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("ruser2"), new DisplayName("disp2"), Instant.ofEpochMilli(10000),
+				new UserName("ruser2"), UID2, new DisplayName("disp2"), inst(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 						new RemoteIdentityDetails("user2a", "full2a", "e2a@g.com")))
 				.build());
@@ -2355,9 +2360,9 @@ public class LoginTest {
 		manager.storage.storeTemporarySessionData(data, IncomingToken.hash("this is a token"));
 		
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("u1"), new DisplayName("d"), Instant.now(), REMOTE1).build());
+				new UserName("u1"), UID, new DisplayName("d"), Instant.now(), REMOTE1).build());
 		manager.storage.createUser(NewUser.getBuilder(
-				new UserName("u2"), new DisplayName("d"), Instant.now(), REMOTE2).build());
+				new UserName("u2"), UID2, new DisplayName("d"), Instant.now(), REMOTE2).build());
 
 		return tt;
 	}

--- a/src/us/kbase/test/auth2/service/ui/MeTest.java
+++ b/src/us/kbase/test/auth2/service/ui/MeTest.java
@@ -67,6 +67,7 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 
 public class MeTest {
 
+	private static final UUID UID = UUID.randomUUID();
 	private static final String DB_NAME = "test_me_ui";
 	private static final String COOKIE_NAME = "login-cookie";
 	
@@ -111,7 +112,7 @@ public class MeTest {
 	@Test
 	public void getMeMinimalInput() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
@@ -233,7 +234,7 @@ public class MeTest {
 		manager.storage.setCustomRole(new CustomRole("whoo", "a"));
 		manager.storage.setCustomRole(new CustomRole("whee", "b"));
 		manager.storage.createUser(NewUser.getBuilder(new UserName("foobar"),
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000),
+				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withCustomRole("whoo")
@@ -304,7 +305,7 @@ public class MeTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user modified unexpectedly", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("bleah"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("bleah"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("f@h.com"))
 						.build()));
@@ -325,7 +326,7 @@ public class MeTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user modified unexpectedly", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("bleah"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("bleah"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("f@h.com"))
 						.build()));
@@ -347,7 +348,7 @@ public class MeTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user not modified", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("whee"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("whee"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("x@g.com"))
 						.build()));
@@ -372,7 +373,7 @@ public class MeTest {
 		assertThat("incorrect response code", res.getStatus(), is(204));
 		
 		assertThat("user not modified", manager.storage.getUser(new UserName("foobar")),
-				is(AuthUser.getBuilder(new UserName("foobar"), new DisplayName("whee"),
+				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("whee"),
 						Instant.ofEpochMilli(20000))
 						.withEmailAddress(new EmailAddress("x@g.com"))
 						.build()));
@@ -471,7 +472,7 @@ public class MeTest {
 	
 	private IncomingToken createLocalUserForTests(final Set<Role> roles) throws Exception {
 		final us.kbase.auth2.lib.user.LocalUser.Builder builder =
-				LocalUser.getLocalUserBuilder(new UserName("foobar"),
+				LocalUser.getLocalUserBuilder(new UserName("foobar"), UID,
 				new DisplayName("bleah"), Instant.ofEpochMilli(20000))
 				.withEmailAddress(new EmailAddress("f@h.com"));
 		for (final Role r: roles) {

--- a/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
+++ b/src/us/kbase/test/auth2/service/ui/SimpleEndpointsTest.java
@@ -3,6 +3,7 @@ package us.kbase.test.auth2.service.ui;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestHTML;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
 import static us.kbase.test.auth2.service.common.ServiceCommonTest.SERVER_VER;
@@ -239,7 +240,7 @@ public class SimpleEndpointsTest {
 		String pwdhashb64 = "yfzvxxMCbKQgoa0e38AmGNZxPJ+lT8PNXPgiR8QkFM0=";
 		
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000)).build(),
+				new UserName("whoo"), UUID.randomUUID(), new DisplayName("d"), inst(10000)).build(),
 				new PasswordHashAndSalt(Base64.getDecoder().decode(pwdhashb64), salt.getBytes()));
 		
 		final IncomingToken token = new IncomingToken("whoop");

--- a/src/us/kbase/test/auth2/service/ui/TokensTest.java
+++ b/src/us/kbase/test/auth2/service/ui/TokensTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestHTML;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
+import static us.kbase.test.auth2.TestCommon.inst;
 import static us.kbase.test.auth2.TestCommon.set;
 
 import java.net.InetAddress;
@@ -62,6 +63,8 @@ import us.kbase.test.auth2.service.ServiceTestUtils;
 
 public class TokensTest {
 	
+	private static final UUID UID = UUID.randomUUID();
+	
 	private static final String DB_NAME = "test_tokens_ui";
 	private static final String COOKIE_NAME = "login-cookie";
 	
@@ -108,7 +111,7 @@ public class TokensTest {
 		final String id = "edc1dcbb-d370-4660-a639-01a72f0d578a";
 
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000)).build(),
+				new UserName("whoo"), UID, new DisplayName("d"), inst(10000)).build(),
 				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));
 		
 		final IncomingToken token = new IncomingToken("whoop");
@@ -178,7 +181,7 @@ public class TokensTest {
 		final String id3 = "653cc5ce-37e6-4e61-ac25-48831657f257";
 
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000))
+				new UserName("whoo"), UID, new DisplayName("d"), Instant.ofEpochMilli(10000))
 				.withRole(Role.SERV_TOKEN)
 				.build(),
 				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));
@@ -339,7 +342,7 @@ public class TokensTest {
 	@Test
 	public void createTokenMinimalInput() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000))
+				new UserName("whoo"), UID, new DisplayName("d"), Instant.ofEpochMilli(10000))
 				.withRole(Role.SERV_TOKEN)
 				.build(),
 				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));
@@ -405,7 +408,7 @@ public class TokensTest {
 	@Test
 	public void createTokenMaximalInput() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(
-				new UserName("whoo"), new DisplayName("d"), Instant.ofEpochMilli(10000))
+				new UserName("whoo"), UID, new DisplayName("d"), Instant.ofEpochMilli(10000))
 				.withRole(Role.SERV_TOKEN)
 				.build(),
 				new PasswordHashAndSalt("fobarbazbing".getBytes(), "aa".getBytes()));


### PR DESCRIPTION
Any new users will have an ID automatically assigned. Anonymous IDs will be assigned to current users when they're pulled from the DB for the first time after upgrading the service.

Next steps:
* Expose in /me and testmode and admin /user endpoints
* Add admin method to look up users by anonymous ID
* Release notes