### PR TITLE
DEVOPS-1665: Remove global token revocation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,27 @@ local account and assign it the create administrator role. That account can
 then be used to create further administrators (including itself) without
 needing to login as root. The root account can then be disabled.
 
+### Revoking tokens in an emergency
+
+The simple HTML only test UI included with the server supports most administration functions,
+but revoking all tokens in the service is not included as it has a major impact on systems the
+auth server supports, essentially shutting them down. If all tokens are revoked, the tokens for
+every single token type (agent, service, etc.) for every single user in the auth system are
+removed - the equivalent of clearing the tokens collection in MongoDB. 
+
+This feature is intended to be used in an emergency such as many tokens becoming compromised or
+the system needs to come to a near immediate halt (near immediate since services outside the auth
+server may cache and accept tokens for some period of time after they're invalidated in auth).
+
+To revoke all tokens, issue the following request to the server (curl used as an example):
+
+```
+curl -X POST --cookie "kbase_session=<admin token>" http://<host>/admin/revokeall
+```
+
+If the `token-cookie-name` deployment configuration value is not `kbase_session` change
+the request to match.
+
 ## Start & stop server w/o a pid
 
 `./jettybase$ java -DSTOP.PORT=8079 -DSTOP.KEY=foo -jar ~/jetty/jetty-distribution-9.3.11.v20160721/start.jar`  

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ def TEMPLATE_LIST_FILE_NAME = "templates.manifest"
 task buildGitCommitFile {
 	doLast {
 		def commitId = grgit.head().id
-		// is there a variable for builddir/classe/java/main?
+		// is there a variable for builddir/classes/java/main?
 		file("$buildDir/classes/java/main/us/kbase/auth2/gitcommit").text = commitId
 	}
 }

--- a/templates/adminconfig.mustache
+++ b/templates/adminconfig.mustache
@@ -28,24 +28,24 @@ The stack trace is always logged.
 </p>
 
 <p>Allowed post-login redirect URL prefix:
-<input type="text" name="allowedloginredirect"
+<input type="text" name="allowedloginredirect" size=50
 	{{#allowedloginredirect}}value="{{.}}"{{/allowedloginredirect}}/>
 </p>
 
 <p>Redirect URL when a user cannot be logged in immediately after return from 3rd party provider,
  e.g. a choice of accounts is required or an account must be created.
-<input type="text" name="completeloginredirect"
+<input type="text" name="completeloginredirect" size=50
 	{{#completeloginredirect}}value="{{.}}"{{/completeloginredirect}}/>
 </p>
 
 <p>Redirect URL after an account link (usually to a user page showing their identities).
-<input type="text" name="postlinkredirect"
+<input type="text" name="postlinkredirect" size=50
 	{{#postlinkredirect}}value="{{.}}"{{/postlinkredirect}}/>
 </p>
 
 <p>Redirect URL when a user account cannot be linked immediately after return from 3rd party
 provider, e.g. a choice of accounts is required.
-<input type="text" name="completelinkredirect"
+<input type="text" name="completelinkredirect" size=50
 	{{#completelinkredirect}}value="{{.}}"{{/completelinkredirect}}/>
 </p>
 
@@ -87,24 +87,24 @@ provider, e.g. a choice of accounts is required.
 <form action="{{environmenturl}}" method="post">
 <input type="hidden" name="environment" value="{{environment}}"/>
 <p>Allowed post-login redirect URL prefix:
-<input type="text" name="allowedloginredirect"
+<input type="text" name="allowedloginredirect" size=50
 	{{#allowedloginredirect}}value="{{.}}"{{/allowedloginredirect}}/>
 </p>
 
 <p>Redirect URL when a user cannot be logged in immediately after return from 3rd party provider,
  e.g. a choice of accounts is required or an account must be created.
-<input type="text" name="completeloginredirect"
+<input type="text" name="completeloginredirect" size=50
 	{{#completeloginredirect}}value="{{.}}"{{/completeloginredirect}}/>
 </p>
 
 <p>Redirect URL after an account link (usually to a user page showing their identities).
-<input type="text" name="postlinkredirect"
+<input type="text" name="postlinkredirect" size=50
 	{{#postlinkredirect}}value="{{.}}"{{/postlinkredirect}}/>
 </p>
 
 <p>Redirect URL when a user account cannot be linked immediately after return from 3rd party
 provider, e.g. a choice of accounts is required.
-<input type="text" name="completelinkredirect"
+<input type="text" name="completelinkredirect" size=50
 	{{#completelinkredirect}}value="{{.}}"{{/completelinkredirect}}/>
 </p>
 <input type="reset" value="Reset"/>

--- a/templates/admingeneral.mustache
+++ b/templates/admingeneral.mustache
@@ -3,9 +3,6 @@
 <form action="{{reseturl}}" method="post">
 	<input type="submit" value="Force password reset for all local users"/>
 </form>
-<form action="{{revokeallurl}}" method="post">
-	<input type="submit" value="Revoke ALL tokens for ALL users and log out"/>
-</form>
 
 <form action="{{tokenurl}}" method="post">
 	View token: <input type="text" name="token" /><br/>
@@ -34,5 +31,7 @@
 	<input type="checkbox" name="crole_{{id}}" /> {{id}}<br/>
 	{{/customroles}}
 	<input type="submit" value="Search"/>
+</form>
+
 </body>
 </html>


### PR DESCRIPTION
Too dangerous as a simple button.

Also make the URLs in the config page easier to read.