### PR TITLE
Add mongo-retrywrites to config.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@
   are now located in the `build` directory, including the `manage_auth` script.
 * The MongoDB clients have been updated to the most recent version and the service tested
   against Mongo 7.
+* Added the ``mongo-retrywrites`` configuration setting in ``deploy.cfg``, defaulting to
+  ``false``.
 * The docker-compose file has been updated to start an auth server in test mode.
 
 ## 0.6.0

--- a/deploy.cfg.example
+++ b/deploy.cfg.example
@@ -9,6 +9,9 @@
 mongo-host =
 # The name of the mongo database to be used as auth storage.
 mongo-db =
+# Whether to enable ('true') the MongoDB retryWrites parameter or not (anything other than 'true').
+# See https://www.mongodb.com/docs/manual/core/retryable-writes/
+mongo-retrywrites = false
 # If the mongo database is authenticated, the user name of a read/write account.
 mongo-user =
 # If the mongo data base is authenticated, the password for the given username.

--- a/deployment/conf/.templates/deployment.cfg.templ
+++ b/deployment/conf/.templates/deployment.cfg.templ
@@ -1,6 +1,7 @@
 [authserv2]
 mongo-host={{ default .Env.mongo_host "ci-mongo" }}
 mongo-db={{ default .Env.mongo_db "auth2" }}
+mongo-retrywrites={{ default .Env.mongo_retrywrites "false" }}
 mongo-user={{ default .Env.mongo_user "" }}
 mongo-pwd={{ default .Env.mongo_pwd "" }}
 # The name of the cookie in which tokens should be stored in the browser.

--- a/src/main/java/us/kbase/auth2/kbase/KBaseAuthConfig.java
+++ b/src/main/java/us/kbase/auth2/kbase/KBaseAuthConfig.java
@@ -41,6 +41,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private static final String KEY_LOG_NAME = "log-name";
 	private static final String KEY_MONGO_HOST = "mongo-host";
 	private static final String KEY_MONGO_DB = "mongo-db";
+	private static final String KEY_MONGO_RETRY_WRITES = "mongo-retrywrites";
 	private static final String KEY_MONGO_USER = "mongo-user";
 	private static final String KEY_MONGO_PWD = "mongo-pwd";
 	private static final String KEY_COOKIE_NAME = "token-cookie-name";
@@ -68,6 +69,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 	private final SLF4JAutoLogger logger;
 	private final String mongoHost;
 	private final String mongoDB;
+	private final boolean mongoRetryWrites;
 	private final Optional<String> mongoUser;
 	private final Optional<char[]> mongoPwd;
 	private final String cookieName;
@@ -98,6 +100,7 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 			templateDir = Paths.get(getString(KEY_TEMPLATE_DIR, cfg, true));
 			mongoHost = getString(KEY_MONGO_HOST, cfg, true);
 			mongoDB = getString(KEY_MONGO_DB, cfg, true);
+			mongoRetryWrites = TRUE.equals(getString(KEY_MONGO_RETRY_WRITES, cfg));
 			mongoUser = Optional.ofNullable(getString(KEY_MONGO_USER, cfg));
 			Optional<String> mongop = Optional.ofNullable(getString(KEY_MONGO_PWD, cfg));
 			if (mongoUser.isPresent() ^ mongop.isPresent()) {
@@ -342,6 +345,11 @@ public class KBaseAuthConfig implements AuthStartupConfig {
 		return mongoDB;
 	}
 
+	@Override
+	public boolean getMongoRetryWrites() {
+		return mongoRetryWrites;
+	}
+	
 	@Override
 	public Optional<String> getMongoUser() {
 		return mongoUser;

--- a/src/main/java/us/kbase/auth2/service/AuthBuilder.java
+++ b/src/main/java/us/kbase/auth2/service/AuthBuilder.java
@@ -64,9 +64,10 @@ public class AuthBuilder {
 	
 	private MongoClient buildMongo(final AuthStartupConfig c) throws StorageInitException {
 		//TODO ZLATER MONGO handle shards & replica sets
-		final MongoClientSettings.Builder mongoBuilder = MongoClientSettings.builder().applyToClusterSettings(
-				builder -> builder.hosts(Arrays.asList(new ServerAddress(c.getMongoHost()))));
-
+		final MongoClientSettings.Builder mongoBuilder = MongoClientSettings.builder()
+				.retryWrites(c.getMongoRetryWrites())
+				.applyToClusterSettings(builder -> builder.hosts(
+						Arrays.asList(new ServerAddress(c.getMongoHost()))));
 		try {
 			if (c.getMongoUser().isPresent()) {
 				final MongoCredential creds = MongoCredential.createCredential(

--- a/src/main/java/us/kbase/auth2/service/AuthStartupConfig.java
+++ b/src/main/java/us/kbase/auth2/service/AuthStartupConfig.java
@@ -14,6 +14,7 @@ public interface AuthStartupConfig {
 	Set<IdentityProviderConfig> getIdentityProviderConfigs();
 	String getMongoHost();
 	String getMongoDatabase();
+	boolean getMongoRetryWrites();
 	// note both or neither for user & pwd
 	Optional<String> getMongoUser();
 	Optional<char[]> getMongoPwd();

--- a/src/test/java/us/kbase/test/auth2/TestConfigurator.java
+++ b/src/test/java/us/kbase/test/auth2/TestConfigurator.java
@@ -133,6 +133,11 @@ public class TestConfigurator implements AuthStartupConfig {
 	public String getMongoDatabase() {
 		return mongoDatabase == null ? System.getProperty(MONGO_DB_KEY) : mongoDatabase;
 	}
+	
+	@Override
+	public boolean getMongoRetryWrites() {
+		return false;
+	}
 
 	@Override
 	public Optional<String> getMongoUser() {

--- a/src/test/java/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
+++ b/src/test/java/us/kbase/test/auth2/kbase/KBaseAuthConfigTest.java
@@ -78,6 +78,7 @@ public class KBaseAuthConfigTest {
 		
 		assertThat("incorrect mongo host", cfg.getMongoHost(), is("localhost:50000"));
 		assertThat("incorrect mongo db", cfg.getMongoDatabase(), is("mydb"));
+		assertThat("incorrect retry writes", cfg.getMongoRetryWrites(), is(false));
 		assertThat("incorrect mongo user", cfg.getMongoUser(), is(Optional.empty()));
 		assertThat("incorrect mongo pwd", cfg.getMongoPwd(), is(Optional.empty()));
 		assertThat("incorrect test mode", cfg.isTestModeEnabled(), is(false));
@@ -96,6 +97,7 @@ public class KBaseAuthConfigTest {
 				"[authserv2]",
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     mydb   ",
+				"mongo-retrywrites   =   \t  true  \t ",
 				"mongo-user= muser",
 				"mongo-pwd =  mpwd",
 				"test-mode-enabled= true",
@@ -141,6 +143,7 @@ public class KBaseAuthConfigTest {
 		
 		assertThat("incorrect mongo host", cfg.getMongoHost(), is("localhost:50000"));
 		assertThat("incorrect mongo db", cfg.getMongoDatabase(), is("mydb"));
+		assertThat("incorrect retry writes", cfg.getMongoRetryWrites(), is(true));
 		assertThat("incorrect mongo user", cfg.getMongoUser(), is(Optional.of("muser")));
 		assertThat("incorrect mongo pwd",
 				Arrays.equals(cfg.getMongoPwd().get(), "mpwd".toCharArray()), is(true));
@@ -224,6 +227,7 @@ public class KBaseAuthConfigTest {
 		
 		assertThat("incorrect mongo host", cfg.getMongoHost(), is("localhost:50000"));
 		assertThat("incorrect mongo db", cfg.getMongoDatabase(), is("mydb"));
+		assertThat("incorrect retry writes", cfg.getMongoRetryWrites(), is(false));
 		assertThat("incorrect mongo user", cfg.getMongoUser(), is(Optional.empty()));
 		assertThat("incorrect mongo pwd", cfg.getMongoPwd(), is(Optional.empty()));
 		assertThat("incorrect test mode", cfg.isTestModeEnabled(), is(false));
@@ -242,6 +246,7 @@ public class KBaseAuthConfigTest {
 				"[authserv2]",
 				"mongo-host=  localhost:50000    ",
 				"mongo-db   =     mydb   ",
+				"mongo-retrywrites=true",
 				"mongo-user= muser",
 				"mongo-pwd =  mpwd",
 				"test-mode-enabled= true",
@@ -273,6 +278,7 @@ public class KBaseAuthConfigTest {
 		
 		assertThat("incorrect mongo host", cfg.getMongoHost(), is("localhost:50000"));
 		assertThat("incorrect mongo db", cfg.getMongoDatabase(), is("mydb"));
+		assertThat("incorrect retry writes", cfg.getMongoRetryWrites(), is(true));
 		assertThat("incorrect mongo user", cfg.getMongoUser(), is(Optional.of("muser")));
 		assertThat("incorrect mongo pwd",
 				Arrays.equals(cfg.getMongoPwd().get(), "mpwd".toCharArray()), is(true));

--- a/src/test/java/us/kbase/test/auth2/service/LoggingFilterTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/LoggingFilterTest.java
@@ -87,6 +87,11 @@ public class LoggingFilterTest {
 		public String getMongoDatabase() {
 			return DB_NAME;
 		}
+		
+		@Override
+		public boolean getMongoRetryWrites() {
+			return false;
+		}
 
 		@Override
 		public Optional<String> getMongoUser() {


### PR DESCRIPTION
The new client by default sets retry writes to true, which doesn't work for single servers.

This is painful to test locally so we'll need to test in CI.