### PR TITLE
Log to stdout and fix fat / shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 	id 'war'
 	id 'jacoco'
 	id 'org.ajoberstar.grgit' version '4.1.1'
+	id 'com.github.johnrengelman.shadow' version '8.1.1'
 }
 
 repositories {
@@ -94,28 +95,24 @@ task generateTemplateFileList {
 	}
 }
 
-
-task fatTestJar(type: Jar) {
+shadowJar {
 	// Be careful when updating jars - you may want to set the duplicates strategy to WARN
 	// to see if any of the jars are shadowing the others when building the fat jar, which
 	// has been the case in the past 
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	dependsOn generateTemplateFileList
-	archiveAppendix = 'test-fat'
-	
-	// include source files
+	archiveAppendix = 'test-shadow'
 	from sourceSets.test.output
+	configurations = [project.configurations.testRuntimeClasspath]
 
-	// include all jars
-	from {
-		configurations.testimpl.collect { it.isDirectory() ? it : zipTree(it) }
-	}
-
+	enableRelocation true
+	relocationPrefix 'us.kbase.auth2.shadow'
+	
+	mergeServiceFiles()
+	
 	// Include text files from the "templates" directory
 	from('templates') { into JAR_TEMPLATE_DIR }
 	from("$buildDir/" + TEMPLATE_LIST_FILE_NAME) { into JAR_TEMPLATE_DIR }
-	
-	with jar
 }
 
 task generateManageAuthScript {
@@ -217,7 +214,6 @@ dependencies {
 		'syslog4j-0.9.46'
 	)
 	// needed for syslog4j
-	implementation 'net.java.dev.jna:jna:3.4.0'
 	implementation 'joda-time:joda-time:2.3'
 	
 	// ### Test ###

--- a/src/test/java/us/kbase/test/auth2/TestConfigurator.java
+++ b/src/test/java/us/kbase/test/auth2/TestConfigurator.java
@@ -67,11 +67,13 @@ public class TestConfigurator implements AuthStartupConfig {
 		private final JsonServerSyslog logger;
 		
 		public TestLogger() {
+			JsonServerSyslog.setStaticUseSyslog(false);
 			logger = new JsonServerSyslog(
 					"AuthTestLogger",
-					//TODO CODE update kbase-common and pass null instead
-					"thisisafakekeythatshouldntexistihope",
-					JsonServerSyslog.LOG_LEVEL_INFO, true);
+					null,
+					JsonServerSyslog.LOG_LEVEL_INFO,
+					true
+			);
 			logger.changeOutput(new SyslogOutput() {
 				
 				@Override


### PR DESCRIPTION
Logging to standard out means we no longer need the JNA jar, which doesn't work when shadowed.

Making a shadow jar vs. a fat jar means the dependencies in the jar won't collide with the dependencies in projects that use the shadow jar for testing.