### PR TITLE
PTV-1911: Fix user search bugs re underscores + mongo errors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,13 @@
 # Authentication Service MKII release notes
 
+## 0.7.2
+
+* Fixed a bug where usernames with underscores would not be matched in username searches if an
+  underscore was an interior character of a search prefix.
+* Fixed a bug where a MongoDB error would be thrown if a user search prefix resulted in no search
+  terms if it had no valid characters for the requested search, whether user name or display
+  name. Now a service error is thrown.
+
 ## 0.7.1
 
 * Publishes a shadow jar on jitpack.io for supporting tests in other repos.

--- a/src/main/java/us/kbase/auth2/Version.java
+++ b/src/main/java/us/kbase/auth2/Version.java
@@ -5,6 +5,6 @@ package us.kbase.auth2;
 public class Version {
 	
 	/** The version of the KBase Auth2 service. */
-	public static final String VERSION = "0.7.1";
+	public static final String VERSION = "0.7.2";
 
 }

--- a/src/main/java/us/kbase/auth2/lib/Authentication.java
+++ b/src/main/java/us/kbase/auth2/lib/Authentication.java
@@ -1181,10 +1181,17 @@ public class Authentication {
 		 * problems. Make this smarter if necessary. E.g. could store username and numeric suffix
 		 * db side and search and sort db side.
 		 */
-		final UserSearchSpec spec = UserSearchSpec.getBuilder()
-				// checked that this does indeed use an index for the mongo implementation
-				.withSearchRegex("^" + Pattern.quote(sugStrip) + "\\d*$")
-				.withSearchOnUserName(true).withIncludeDisabled(true).build();
+		final UserSearchSpec spec;
+		try {
+			spec = UserSearchSpec.getBuilder()
+					// checked that this does indeed use an index for the mongo implementation
+					.withSearchRegex("^" + Pattern.quote(sugStrip) + "\\d*$")
+					.withSearchOnUserName(true)
+					.withIncludeDisabled(true)
+					.build();
+		} catch (IllegalParameterException e) {
+			throw new RuntimeException("this is impossible", e);
+		}
 		final Map<UserName, DisplayName> users = storage.getUserDisplayNames(spec, -1);
 		final boolean match = users.containsKey(suggestedUserName);
 		final boolean hasNumSuffix = sugStrip.length() != sugName.length();

--- a/src/test/java/us/kbase/test/auth2/lib/UserNameTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/UserNameTest.java
@@ -3,6 +3,7 @@ package us.kbase.test.auth2.lib;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static us.kbase.test.auth2.TestCommon.list;
 
 import org.junit.Test;
 
@@ -104,8 +105,8 @@ public class UserNameTest {
 	
 	@Test
 	public void sanitize() throws Exception {
-		assertThat("incorrect santize", UserName.sanitizeName("  999aFA8 ea6t  \t   ѱ ** J(())"),
-				is(Optional.of(new UserName("afa8ea6tj"))));
+		assertThat("incorrect santize", UserName.sanitizeName("  999aF_A8 ea6t  \t   ѱ ** J(())"),
+				is(Optional.of(new UserName("af_a8ea6tj"))));
 		assertThat("incorrect santize", UserName.sanitizeName("999  8 6  \t   ѱ ** (())"),
 				is(Optional.empty()));
 	}
@@ -117,6 +118,34 @@ public class UserNameTest {
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, new NullPointerException("suggestedUserName"));
+		}
+	}
+	
+	@Test
+	public void getCanonicalNames() throws Exception {
+		assertThat("incorrect canonicalize",
+				UserName.getCanonicalNames(
+						"   999aF_A8 ea6t  \t  foo  _ѱaatѱ(*)  891**ѱ \n  fo-o  x\n"),
+				is(list("af_a8", "ea6t", "foo", "aat", "x")));
+		assertThat("incorrect canonicalize",
+				UserName.getCanonicalNames(
+						"   999_8 6  \t    _ѱѱ(*)  891**ѱ \n    \n"),
+				is(list()));
+	}
+	
+	@Test
+	public void getCanonicalNamesFail() throws Exception {
+		failGetCanonicalNames(null);
+		failGetCanonicalNames("   \t  ");
+	}
+	
+	private void failGetCanonicalNames(final String names) {
+		try {
+			UserName.getCanonicalNames(names);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, new IllegalArgumentException(
+					"names cannot be null or whitespace only"));
 		}
 	}
 	

--- a/src/test/java/us/kbase/test/auth2/lib/UserSearchSpecTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/UserSearchSpecTest.java
@@ -20,6 +20,7 @@ import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserSearchSpec;
 import us.kbase.auth2.lib.UserSearchSpec.Builder;
 import us.kbase.auth2.lib.UserSearchSpec.SearchField;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.test.auth2.TestCommon;
 
 public class UserSearchSpecTest {
@@ -32,9 +33,9 @@ public class UserSearchSpecTest {
 	}
 
 	@Test
-	public void buildWithEverything() {
+	public void buildWithEverything() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
-				.withSearchPrefix("F*oo bar  *()")
+				.withSearchPrefix("F*oo bar  *() baz_bat")
 				.withSearchOnUserName(true)
 				.withSearchOnDisplayName(true)
 				.withSearchOnRole(Role.ADMIN)
@@ -45,7 +46,10 @@ public class UserSearchSpecTest {
 				.withIncludeDisabled(true)
 				.build();
 		
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo", "bar")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(),
+				is(list("foo", "bar", "baz_bat")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(),
+				is(list("foo", "bar", "bazbat")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -60,13 +64,13 @@ public class UserSearchSpecTest {
 		assertThat("incorrect orderby", uss.orderBy(), is(SearchField.USERNAME));
 		assertThat("incorrect include root", uss.isRootIncluded(), is(true));
 		assertThat("incorrect include disabled", uss.isDisabledIncluded(), is(true));
-		
 	}
 	
 	@Test
-	public void buildWithNothing() {
+	public void buildWithNothing() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder().build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list()));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -83,10 +87,11 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void buildWithPrefixOnly() {
+	public void buildWithPrefixOnly() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchPrefix("foO").build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list("foo")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("foo")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -103,11 +108,12 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void buildUserSearch() {
+	public void buildUserSearch() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchPrefix("foo")
 				.withSearchOnUserName(true).build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list("foo")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("foo")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -124,13 +130,14 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void buildDisplaySearch() {
+	public void buildDisplaySearch() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchPrefix("foo")
 				.withSearchOnDisplayName(true)
 				.withSearchOnCustomRole("bar")
 				.withSearchOnRole(Role.SERV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list("foo")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("foo")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -146,11 +153,12 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void buildCustomRoleSearch() {
+	public void buildCustomRoleSearch() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnCustomRole("foo")
 				.withSearchOnRole(Role.DEV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list()));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -166,10 +174,11 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void buildRoleSearch() {
+	public void buildRoleSearch() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnRole(Role.DEV_TOKEN).build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list()));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -186,10 +195,11 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void resetSearch() {
+	public void resetSearch() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder().withSearchPrefix("foo")
 				.withSearchOnUserName(false).withSearchOnDisplayName(false).build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list("foo")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("foo")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -210,7 +220,8 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder();
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list()));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(opt("\\Qfoo.bar\\E")));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(true));
@@ -238,7 +249,8 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder().withSearchPrefix("foo");
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list()));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list()));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(opt("\\Qfoo.bar\\E")));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(false));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(true));
@@ -259,7 +271,8 @@ public class UserSearchSpecTest {
 		final Builder b = UserSearchSpec.getBuilder();
 		setRegex(b, "\\Qfoo.bar\\E");
 		final UserSearchSpec uss = b.withSearchPrefix("foo").build();
-		assertThat("incorrect prefix", uss.getSearchPrefixes(), is(list("foo")));
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list("foo")));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("foo")));
 		assertThat("incorrect regex", uss.getSearchRegex(), is(MT));
 		assertThat("incorrect has prefixes", uss.hasSearchPrefixes(), is(true));
 		assertThat("incorrect has regex", uss.hasSearchRegex(), is(false));
@@ -276,10 +289,16 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void immutablePrefixes() {
+	public void immutablePrefixes() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder().withSearchPrefix("foo bar").build();
 		try {
-			uss.getSearchPrefixes().add("baz");
+			uss.getSearchUserNamePrefixes().add("baz");
+			fail("expected exception");
+		} catch (UnsupportedOperationException e) {
+			//test passed
+		}
+		try {
+			uss.getSearchDisplayPrefixes().add("baz");
 			fail("expected exception");
 		} catch (UnsupportedOperationException e) {
 			//test passed
@@ -287,7 +306,7 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void immutableRoles() {
+	public void immutableRoles() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnRole(Role.DEV_TOKEN).build();
 		try {
@@ -299,7 +318,7 @@ public class UserSearchSpecTest {
 	}
 	
 	@Test
-	public void immutableCustomRoles() {
+	public void immutableCustomRoles() throws Exception {
 		final UserSearchSpec uss = UserSearchSpec.getBuilder()
 				.withSearchOnCustomRole("foo").build();
 		try {
@@ -307,6 +326,66 @@ public class UserSearchSpecTest {
 			fail("expected exception");
 		} catch (UnsupportedOperationException e) {
 			//test passed
+		}
+	}
+	
+	private static final String ERR_USER_SEARCH = "The search prefix %s contains no valid "
+			+ "username prefix and a user name search was requested";
+	
+	@Test
+	public void buildUserSearchWithInvalidAndValidPrefixes() throws Exception {
+		// if the user search spec is good, the display spec must be good. The reverse is not true.
+		final Exception e = new IllegalParameterException(String.format(ERR_USER_SEARCH, "98_7"));
+		final Builder b = UserSearchSpec.getBuilder()
+				.withSearchPrefix("98_7"); // valid display spec, not user spec
+		
+		// test that no exception is thrown
+		UserSearchSpec uss = b.build();
+		buildUserSearchWithInvalidAndValidPrefixesAssertOnPass(uss);
+		
+		buildFail(b.withSearchOnUserName(true), e);
+		
+		// test that no exception is thrown
+		uss = b.withSearchOnDisplayName(true).build();
+		buildUserSearchWithInvalidAndValidPrefixesAssertOnPass(uss);
+		
+		// test that no exception is thrown
+		uss = b.withSearchOnUserName(false).build();
+		buildUserSearchWithInvalidAndValidPrefixesAssertOnPass(uss);
+	}
+
+	private void buildUserSearchWithInvalidAndValidPrefixesAssertOnPass(final UserSearchSpec uss) {
+		assertThat("incorrect user prefix", uss.getSearchUserNamePrefixes(), is(list()));
+		assertThat("incorrect display prefix", uss.getSearchDisplayPrefixes(), is(list("987")));
+		assertThat("incorrect user search", uss.isUserNameSearch(), is(false));
+		assertThat("incorrect display name search", uss.isDisplayNameSearch(), is(true));
+	}
+
+	private static final String ERR_DISPLAY_SEARCH = "The search prefix &*^(%(^*&) contains only "
+			+ "punctuation and a display name search was requested";
+	
+	@Test
+	public void buildDisplaySearchFail() throws Exception {
+		// if the user search spec is good, the display spec must be good. The reverse is not true.
+		final Exception e = new IllegalParameterException(ERR_DISPLAY_SEARCH);
+		final Exception euser = new IllegalParameterException(
+				String.format(ERR_USER_SEARCH, ("&*^(%(^*&)")));
+		final Builder b = UserSearchSpec.getBuilder()
+				.withSearchPrefix("&*^(%(^*&)");
+		buildFail(b, e);
+		
+		buildFail(b.withSearchOnDisplayName(true), e);
+		buildFail(b.withSearchOnUserName(true), e);
+		buildFail(b.withSearchOnDisplayName(false), euser);
+	}
+
+	
+	private void buildFail(final Builder b, final Exception expected) {
+		try {
+			b.build();
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
 		}
 	}
 	

--- a/src/test/java/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/storage/mongo/MongoStorageGetDisplayNamesTest.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableMap;
+
 import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.Role;
@@ -653,6 +655,25 @@ public class MongoStorageGetDisplayNamesTest extends MongoStorageTester{
 		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
 				.withSearchPrefix("fwhe").withSearchOnDisplayName(true).build(), -1),
 				is(Collections.emptyMap()));
+	}
+	
+	@Test
+	public void userSearchUnderscore() throws Exception {
+		storage.createUser(NewUser.getBuilder(
+				new UserName("foo_bar"), UID1, new DisplayName("1"),
+				NOW, REMOTE1)
+				.build());
+		storage.createUser(NewUser.getBuilder(
+				new UserName("fo_obar"), UID2, new DisplayName("2"), NOW, REMOTE2)
+				.build());
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("fo_").build(), -1),
+				is(ImmutableMap.of(new UserName("fo_obar"), new DisplayName("2"))));
+		
+		assertThat("incorrect users found", storage.getUserDisplayNames(UserSearchSpec.getBuilder()
+				.withSearchPrefix("foo_b").build(), -1),
+				is(ImmutableMap.of(new UserName("foo_bar"), new DisplayName("1"))));
 	}
 	
 	@Test

--- a/src/test/java/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -3,12 +3,12 @@ package us.kbase.test.auth2.service.api;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static us.kbase.test.auth2.service.ServiceTestUtils.failRequestJSON;
+import static us.kbase.test.auth2.TestCommon.inst;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -154,12 +154,12 @@ public class UserEndpointTest {
 	public void getMeMinimalInput() throws Exception {
 		final UUID uid = UUID.randomUUID();
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				uid, new DisplayName("bleah"), Instant.ofEpochMilli(20000)).build(),
+				uid, new DisplayName("bleah"), inst(20000)).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
@@ -197,25 +197,25 @@ public class UserEndpointTest {
 		manager.storage.setCustomRole(new CustomRole("whoo", "a"));
 		manager.storage.setCustomRole(new CustomRole("whee", "b"));
 		manager.storage.createUser(NewUser.getBuilder(new UserName("foobar"), UID,
-				new DisplayName("bleah"), Instant.ofEpochMilli(20000),
+				new DisplayName("bleah"), inst(20000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withCustomRole("whoo")
 				.withCustomRole("whee")
 				.withEmailAddress(new EmailAddress("a@g.com"))
-				.withLastLogin(Instant.ofEpochMilli(30000))
+				.withLastLogin(inst(30000))
 				.withRole(Role.ADMIN)
 				.withRole(Role.DEV_TOKEN)
-				.withPolicyID(new PolicyID("wugga"), Instant.ofEpochMilli(40000))
-				.withPolicyID(new PolicyID("wubba"), Instant.ofEpochMilli(50000))
+				.withPolicyID(new PolicyID("wugga"), inst(40000))
+				.withPolicyID(new PolicyID("wubba"), inst(50000))
 				.build());
 		manager.storage.link(new UserName("foobar"), new RemoteIdentity(
 				new RemoteIdentityID("prov2", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "f2@g.com")));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
@@ -295,13 +295,13 @@ public class UserEndpointTest {
 	@Test
 	public void putMeNoUpdate() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
@@ -316,7 +316,7 @@ public class UserEndpointTest {
 		
 		assertThat("user modified unexpectedly", manager.storage.getUser(new UserName("foobar")),
 				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("bleah"),
-						Instant.ofEpochMilli(20000))
+						inst(20000))
 						.withEmailAddress(new EmailAddress("f@h.com"))
 						.build()));
 	}
@@ -324,13 +324,13 @@ public class UserEndpointTest {
 	@Test
 	public void putMeFullUpdate() throws Exception {
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				new PasswordHashAndSalt("foobarbazbing".getBytes(), "aa".getBytes()));
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/V2/me").build();
@@ -346,7 +346,7 @@ public class UserEndpointTest {
 		
 		assertThat("user not modified", manager.storage.getUser(new UserName("foobar")),
 				is(AuthUser.getBuilder(new UserName("foobar"), UID, new DisplayName("whee"),
-						Instant.ofEpochMilli(20000))
+						inst(20000))
 						.withEmailAddress(new EmailAddress("x@g.com"))
 						.build()));
 	}
@@ -421,13 +421,13 @@ public class UserEndpointTest {
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
 				"foobarbazbing".getBytes(), "aa".getBytes());
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/legacy/globus/users/foobar")
@@ -465,17 +465,17 @@ public class UserEndpointTest {
 		final PasswordHashAndSalt creds = new PasswordHashAndSalt(
 				"foobarbazbing".getBytes(), "aa".getBytes());
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobar"),
-				UID, new DisplayName("bleah"), Instant.ofEpochMilli(20000))
+				UID, new DisplayName("bleah"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foobaz"),
-				UUID.randomUUID(),new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
+				UUID.randomUUID(),new DisplayName("bleah2"), inst(20000))
 				.withEmailAddress(new EmailAddress("f2@g.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("foobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("foobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		
 		final URI target = UriBuilder.fromUri(host).path("/api/legacy/globus/users/foobaz")
@@ -604,31 +604,35 @@ public class UserEndpointTest {
 				"foobarbazbing".getBytes(), "aa".getBytes());
 
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("foo"),
-				uuid(), new DisplayName("bar *thing*"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("bar *thing*"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("baz"),
-				uuid(), new DisplayName("fuz"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("fuz"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("puz"),
-				uuid(), new DisplayName("mup"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("mup"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("mua"),
-				uuid(), new DisplayName("paz"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("paz"), inst(20000))
+				.withEmailAddress(new EmailAddress("f@h.com")).build(),
+				creds);
+		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("under_score"),
+				uuid(), new DisplayName("zzznevermind"), inst(20000))
 				.withEmailAddress(new EmailAddress("f@h.com")).build(),
 				creds);
 		
 		
 		manager.storage.createLocalUser(LocalUser.getLocalUserBuilder(new UserName("toobar"),
-				uuid(), new DisplayName("bleah2"), Instant.ofEpochMilli(20000))
+				uuid(), new DisplayName("bleah2"), inst(20000))
 				.withEmailAddress(new EmailAddress("f2@g.com")).build(),
 				creds);
 		final IncomingToken token = new IncomingToken("whee");
 		manager.storage.storeToken(StoredToken.getBuilder(TokenType.LOGIN, UUID.randomUUID(),
-				new UserName("toobar")).withLifeTime(Instant.ofEpochMilli(10000),
-						Instant.ofEpochMilli(1000000000000000L)).build(),
+				new UserName("toobar")).withLifeTime(inst(10000),
+						inst(1000000000000000L)).build(),
 				token.getHashedToken().getTokenHash());
 		return token;
 	}
@@ -680,6 +684,15 @@ public class UserEndpointTest {
 	@Test
 	public void searchUsersBlankFields() throws Exception {
 		searchUsers("f", "   \t ,   ", ImmutableMap.of("foo", "bar *thing*", "baz", "fuz"));
+	}
+	
+	@Test
+	public void searchUsersUnderscore() throws Exception {
+		// The display name canonicalization previously applied to the user name as well, which
+		// caused a bug since the username in the database is not canonicalized. This would cause
+		// searches to fail when the one allowed punctuation symbol `_`, was included in 
+		// the search term.
+		searchUsers("9un$der_s", "", ImmutableMap.of("under_score", "zzznevermind"));
 	}
 	
 	@Test
@@ -742,17 +755,27 @@ public class UserEndpointTest {
 	
 	@Test
 	public void searchUsersFailBadToken() throws Exception {
-		failSearchUsers(null, 400, "Bad Request",
+		failSearchUsers("f", null, 400, "Bad Request",
 				new NoTokenProvidedException("No user token provided"));
-		failSearchUsers("foobar", 401, "Unauthorized", new InvalidTokenException());
+		failSearchUsers("f", "foobar", 401, "Unauthorized", new InvalidTokenException());
+	}
+	
+	@Test
+	public void searchUsersFailBadInput() throws Exception {
+		final IncomingToken token = setUpUsersForTesting();
+		failSearchUsers("*^&)*^)", token.getToken(), 400, "Bad Request",
+				new IllegalParameterException(
+						"The search prefix *^&)*^) contains only "
+						+ "punctuation and a display name search was requested"));
 	}
 	
 	private void failSearchUsers(
+			final String prefix,
 			final String token,
 			final int code,
 			final String error,
 			final AuthException e) throws Exception {
-		final URI target = UriBuilder.fromUri(host).path("/api/V2/users/search/f").build();
+		final URI target = UriBuilder.fromUri(host).path("/api/V2/users/search/" + prefix).build();
 		
 		final WebTarget wt = CLI.target(target);
 		final Builder req = wt.request()

--- a/src/test/java/us/kbase/test/auth2/service/common/ServiceCommonTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/common/ServiceCommonTest.java
@@ -47,7 +47,7 @@ import us.kbase.test.auth2.TestCommon;
 public class ServiceCommonTest {
 	
 	public static final String SERVICE_NAME = "Authentication Service";
-	public static final String SERVER_VER = "0.7.1";
+	public static final String SERVER_VER = "0.7.2";
 	public static final String GIT_ERR = 
 			"Missing git commit file gitcommit, should be in us.kbase.auth2";
 	


### PR DESCRIPTION
* Fixed a bug where if a user name contained an underscore and the search term included the underscore followed by at least one letter the search wouldn't match
* Fixed a bug where if the search terms were all illegal characters such that the search list was empty for a requested search a mongo error would be thrown

Fixes #435 