### PR TITLE
CDM-367: Disallow repeating and trailing underscores in new user names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+##########################################
+# READ BEFORE ALTERING THIS FILE
+#
+# Only files specific to this repo or that will be generated as part of using this repo should
+# be ignored here. Files that are specific to particular development environments or users
+# should be ignored in the global gitignore to ignore for all repos, or in .git/info/exclude
+# to ignore for just this repo.
+# 
+# Examples of appropriate files for each location:
+# This file:
+#    junit files
+#    gradle build files
+#    test configuration and output, including coverage data
+#
+# Global gitignore
+#    Eclipse .settings, .project, and .pyproject files
+#    Mac .DS_store files
+#    VSCode .vscode directory
+#
+# .git/info/exclude
+#    Temporary code / notes while exploring new repo features
+#    Personal variations of test.cfg files, e.g. my-test.cfg, etc.
+#    Personal data used for manual testing
+#
+##########################################
+
+/bin
+/test.cfg
+/junit*.properties
+
+# Ignore Gradle project-specific cache directory
+.gradle
+
+# Ignore Gradle build output directory
+build

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## 0.7.2
 
+* BACKWARDS INCOMPATIBILITY: Multiple underscores in series or trailing underscores are
+  no longer allowed in usernames. Existing usernames are unaffected.
 * Fixed a bug where usernames with underscores would not be matched in username searches if an
   underscore was an interior character of a search prefix.
 * Fixed a bug where a MongoDB error would be thrown if a user search prefix resulted in no search

--- a/src/main/java/us/kbase/auth2/lib/Authentication.java
+++ b/src/main/java/us/kbase/auth2/lib/Authentication.java
@@ -436,7 +436,7 @@ public class Authentication {
 	 */
 	public Password createLocalUser(
 			final IncomingToken adminToken,
-			final UserName userName,
+			final NewUserName userName,
 			final DisplayName displayName,
 			final EmailAddress email)
 			throws AuthStorageException, UserExistsException, UnauthorizedException,
@@ -1960,7 +1960,7 @@ public class Authentication {
 	public NewToken createUser(
 			final IncomingToken token,
 			final String identityID,
-			final UserName userName,
+			final NewUserName userName,
 			final DisplayName displayName,
 			final EmailAddress email,
 			final Set<PolicyID> policyIDs,
@@ -2082,7 +2082,7 @@ public class Authentication {
 	 * @throws UnauthorizedException the user name is the root user name.
 	 * @throws TestModeException if test mode is not enabled.
 	 */
-	public void testModeCreateUser(final UserName userName, final DisplayName displayName)
+	public void testModeCreateUser(final NewUserName userName, final DisplayName displayName)
 			throws UserExistsException, AuthStorageException, UnauthorizedException,
 			TestModeException {
 		ensureTestMode();
@@ -3172,7 +3172,7 @@ public class Authentication {
 	 * @throws AuthStorageException if an error occurred accessing the storage system.
 	 * @throws IdentityLinkedException if the identity is already linked to a user.
 	 */
-	public void importUser(final UserName userName, final RemoteIdentity remoteIdentity)
+	public void importUser(final NewUserName userName, final RemoteIdentity remoteIdentity)
 			throws UserExistsException, AuthStorageException, IdentityLinkedException {
 		requireNonNull(userName, "userName");
 		requireNonNull(remoteIdentity, "remoteIdentity");

--- a/src/main/java/us/kbase/auth2/lib/NewUserName.java
+++ b/src/main/java/us/kbase/auth2/lib/NewUserName.java
@@ -1,0 +1,55 @@
+package us.kbase.auth2.lib;
+
+import us.kbase.auth2.lib.exceptions.ErrorType;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.lib.exceptions.MissingParameterException;
+
+/** A user name for a new user.
+ * 
+ * Valid user names are strings of up to 100 characters consisting of lowercase ASCII letters,
+ * digits, and the underscore. The first character must be a letter.
+ * 
+ * Unlike existing users, new users may also not have more than 1 underscore in a row and may not
+ * have trailing underscores.
+ * 
+ * The only exception is the user name ***ROOT***, which represents the root user.
+ *
+ */
+public class NewUserName extends UserName {
+	
+	/** The username for the root user. */
+	public final static NewUserName ROOT;
+	static {
+		try {
+			ROOT = new NewUserName(ROOT_NAME);
+		} catch (IllegalParameterException | MissingParameterException e) {
+			throw new RuntimeException("Programming error: " + e.getMessage(), e);
+		}
+	}
+
+	/** Create a user name for a new, to be created, user.
+	 * @param name the user name.
+	 * @throws MissingParameterException if the name supplied is null or empty.
+	 * @throws IllegalParameterException if the name supplied has illegal characters or is too
+	 * long.
+	 */
+	public NewUserName(final String name)
+			throws MissingParameterException, IllegalParameterException {
+		super(name);
+		if (name.contains("__") || name.endsWith("_")) {
+			throw new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME,
+					"New usernames cannot contain repeating underscores or "
+					+ "trailing underscores"
+			);
+		}
+	}
+	
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("NewUserName [getName()=");
+		builder.append(getName());
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/src/main/java/us/kbase/auth2/lib/UserName.java
+++ b/src/main/java/us/kbase/auth2/lib/UserName.java
@@ -20,13 +20,12 @@ import us.kbase.auth2.lib.exceptions.MissingParameterException;
  * digits, and the underscore. The first character must be a letter.
  * 
  * The only exception is the user name ***ROOT***, which represents the root user.
- * @author gaprice@lbl.gov
  *
  */
 public class UserName extends Name {
 
 	// this must never be a valid username 
-	private final static String ROOT_NAME = "***ROOT***";
+	final static String ROOT_NAME = "***ROOT***";
 	
 	/** The username for the root user. */
 	public final static UserName ROOT;

--- a/src/main/java/us/kbase/auth2/service/api/TestMode.java
+++ b/src/main/java/us/kbase/auth2/service/api/TestMode.java
@@ -35,6 +35,7 @@ import com.google.common.collect.ImmutableMap;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.AuthException;
@@ -99,7 +100,7 @@ public class TestMode {
 			throw new MissingParameterException("JSON body missing");
 		}
 		create.exceptOnAdditionalProperties();
-		final UserName user = new UserName(create.userName);
+		final NewUserName user = new NewUserName(create.userName);
 		auth.testModeCreateUser(user, new DisplayName(create.displayName));
 		try {
 			return Me.toUserMap(auth.testModeGetUser(user));

--- a/src/main/java/us/kbase/auth2/service/ui/Admin.java
+++ b/src/main/java/us/kbase/auth2/service/ui/Admin.java
@@ -50,6 +50,7 @@ import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
@@ -255,7 +256,7 @@ public class Admin {
 			NoTokenProvidedException {
 		final Password pwd = auth.createLocalUser(
 				getTokenFromCookie(headers, cfg.getTokenCookieName()),
-				new UserName(userName), new DisplayName(displayName), new EmailAddress(email));
+				new NewUserName(userName), new DisplayName(displayName), new EmailAddress(email));
 		final Map<String, String> ret = ImmutableMap.of(
 				Fields.USER, userName,
 				Fields.DISPLAY, displayName,

--- a/src/main/java/us/kbase/auth2/service/ui/Login.java
+++ b/src/main/java/us/kbase/auth2/service/ui/Login.java
@@ -62,6 +62,7 @@ import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.OAuth2StartData;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.TokenCreationContext;
@@ -106,14 +107,25 @@ public class Login {
 	private static final String TRUE = "true";
 	private static final String FALSE = "false";
 	
-	@Inject
-	private Authentication auth;
+	private final Authentication auth;
+	private final AuthAPIStaticConfig cfg;
+	private final UserAgentParser userAgentParser;
 	
+	/** Construct the login endpoint handler. This is typically done by the Jersey framework.
+	 * @param auth an instance of the core authentication class.
+	 * @param cfg the static configuration for the authentication service.
+	 * @param userAgentParser a user agent parser instance.
+	 */
 	@Inject
-	private AuthAPIStaticConfig cfg;
-	
-	@Inject
-	private UserAgentParser userAgentParser;
+	public Login(
+			final Authentication auth,
+			final AuthAPIStaticConfig cfg,
+			final UserAgentParser userAgentParser
+		) {
+		this.auth = auth;
+		this.cfg = cfg;
+		this.userAgentParser = userAgentParser;
+	}
 	
 	@GET
 	@Template(name = "/loginstart")
@@ -625,7 +637,7 @@ public class Login {
 		final NewToken newtoken = auth.createUser(
 				getLoginInProcessToken(token),
 				CreateChoice.getString(identityID, Fields.ID),
-				new UserName(userName),
+				new NewUserName(userName),
 				new DisplayName(displayName),
 				new EmailAddress(email),
 				CreateChoice.getPolicyIDs(policyIDs),
@@ -634,7 +646,7 @@ public class Login {
 		return createLoginResponse(redirectURI, newtoken, !FALSE.equals(session));
 	}
 	
-	private static class CreateChoice extends PickChoice {
+	public static class CreateChoice extends PickChoice {
 		
 		public final String user;
 		public final String displayName;
@@ -683,7 +695,7 @@ public class Login {
 		final NewToken newtoken = auth.createUser(
 				getLoginInProcessToken(token),
 				create.getIdentityID(),
-				new UserName(create.user),
+				new NewUserName(create.user),
 				new DisplayName(create.displayName),
 				new EmailAddress(create.email),
 				create.getPolicyIDs(),

--- a/src/test/java/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/AuthenticationCreateLocalUserTest.java
@@ -29,6 +29,7 @@ import us.kbase.auth2.cryptutils.RandomDataGenerator;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.PasswordHashAndSalt;
 import us.kbase.auth2.lib.Role;
@@ -134,7 +135,7 @@ public class AuthenticationCreateLocalUserTest {
 		when(clock.instant()).thenReturn(create);
 		
 		final LocalUser expected = LocalUser.getLocalUserBuilder(
-				new UserName("foo"), uid, new DisplayName("bar"), create)
+				new NewUserName("foo"), uid, new DisplayName("bar"), create)
 				.withEmailAddress(new EmailAddress("f@h.com"))
 				.withForceReset(true).build();
 		
@@ -145,7 +146,8 @@ public class AuthenticationCreateLocalUserTest {
 				any(LocalUser.class), any(PasswordHashAndSalt.class));
 		
 		final Password pwd = auth.createLocalUser(
-				token, new UserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"));
+				token, new NewUserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com")
+		);
 		assertThat("incorrect pwd", pwd.getPassword(), is(pwdChar));
 		assertClear(matcher.savedSalt);
 		assertClear(matcher.savedHash);
@@ -198,7 +200,7 @@ public class AuthenticationCreateLocalUserTest {
 		doThrow(new UserExistsException("foo")).when(storage)
 				.createLocalUser(any(LocalUser.class), any(PasswordHashAndSalt.class));
 		
-		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+		failCreateLocalUser(auth, token, new NewUserName("foo"), new DisplayName("bar"),
 				new EmailAddress("f@h.com"), new UserExistsException("foo"));
 	}
 	
@@ -238,7 +240,7 @@ public class AuthenticationCreateLocalUserTest {
 		doThrow(new NoSuchRoleException("foo")).when(storage)
 				.createLocalUser(any(LocalUser.class), any(PasswordHashAndSalt.class));
 		
-		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+		failCreateLocalUser(auth, token, new NewUserName("foo"), new DisplayName("bar"),
 				new EmailAddress("f@h.com"), new RuntimeException("didn't supply any roles"));
 	}
 	
@@ -266,7 +268,7 @@ public class AuthenticationCreateLocalUserTest {
 		
 		when(rand.getTemporaryPassword(10)).thenThrow(new RuntimeException("booga"));
 		
-		failCreateLocalUser(auth, token, new UserName("foo"), new DisplayName("bar"),
+		failCreateLocalUser(auth, token, new NewUserName("foo"), new DisplayName("bar"),
 				new EmailAddress("f@h.com"), new RuntimeException("booga"));
 	}
 	
@@ -282,7 +284,7 @@ public class AuthenticationCreateLocalUserTest {
 			
 			@Override
 			public void execute(final Authentication auth) throws Exception {
-				auth.createLocalUser(token, new UserName("whee"), new DisplayName("bar"),
+				auth.createLocalUser(token, new NewUserName("whee"), new DisplayName("bar"),
 						new EmailAddress("f@h.com"));
 			}
 
@@ -303,18 +305,18 @@ public class AuthenticationCreateLocalUserTest {
 		final TestMocks testauth = initTestMocks();
 		final Authentication auth = testauth.auth;
 		
-		failCreateLocalUser(auth, null, new UserName("foo"), new DisplayName("bar"),
+		failCreateLocalUser(auth, null, new NewUserName("foo"), new DisplayName("bar"),
 				new EmailAddress("f@h.com"), new NullPointerException("token"));
 		
 		failCreateLocalUser(auth, new IncomingToken("whee"), null,
 				new DisplayName("bar"), new EmailAddress("f@h.com"),
 				new NullPointerException("userName"));
 		
-		failCreateLocalUser(auth, new IncomingToken("whee"), new UserName("foo"),
+		failCreateLocalUser(auth, new IncomingToken("whee"), new NewUserName("foo"),
 				null, new EmailAddress("f@h.com"),
 				new NullPointerException("displayName"));
 		
-		failCreateLocalUser(auth, new IncomingToken("whee"), new UserName("foo"),
+		failCreateLocalUser(auth, new IncomingToken("whee"), new NewUserName("foo"),
 				new DisplayName("bar"), null,
 				new NullPointerException("email"));
 	}
@@ -340,7 +342,7 @@ public class AuthenticationCreateLocalUserTest {
 		
 		when(storage.getUser(new UserName("admin"))).thenReturn(admin);
 		
-		failCreateLocalUser(auth, token, UserName.ROOT, new DisplayName("bar"),
+		failCreateLocalUser(auth, token, NewUserName.ROOT, new DisplayName("bar"),
 				new EmailAddress("f@h.com"), new UnauthorizedException(ErrorType.UNAUTHORIZED,
 						"Cannot create ROOT user"));
 		
@@ -353,7 +355,7 @@ public class AuthenticationCreateLocalUserTest {
 	public void failCreateLocalUser(
 			final Authentication auth,
 			final IncomingToken token,
-			final UserName userName,
+			final NewUserName userName,
 			final DisplayName display,
 			final EmailAddress email,
 			final Exception e) {

--- a/src/test/java/us/kbase/test/auth2/lib/AuthenticationImportUserTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/AuthenticationImportUserTest.java
@@ -22,7 +22,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
-import us.kbase.auth2.lib.UserName;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.exceptions.IdentityLinkedException;
 import us.kbase.auth2.lib.exceptions.NoSuchRoleException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
@@ -66,11 +66,14 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
-				new RemoteIdentityDetails("user", "full", "f@h.com")));
+		auth.importUser(
+				new NewUserName("foo"),
+				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
+				new RemoteIdentityDetails("user", "full", "f@h.com"))
+		);
 		
 		verify(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
+				NewUser.getBuilder(new NewUserName("foo"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 								new RemoteIdentityDetails("user", "full", "f@h.com")))
@@ -97,10 +100,13 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
-				new RemoteIdentityDetails("user", fullname, "f@h.com")));
+		auth.importUser(
+				new NewUserName("foo"),
+				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
+				new RemoteIdentityDetails("user", fullname, "f@h.com"))
+		);
 		
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), UID,
+		verify(storage).createUser(NewUser.getBuilder(new NewUserName("foo"), UID,
 				new DisplayName("unknown"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user", fullname, "f@h.com")))
@@ -124,10 +130,13 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id"),
-				new RemoteIdentityDetails("user", "full", email)));
+		auth.importUser(
+				new NewUserName("foo"),
+				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
+				new RemoteIdentityDetails("user", "full", email))
+		);
 		
-		verify(storage).createUser(NewUser.getBuilder(new UserName("foo"), UID,
+		verify(storage).createUser(NewUser.getBuilder(new NewUserName("foo"), UID,
 				new DisplayName("full"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id"),
 						new RemoteIdentityDetails("user", "full", email)))
@@ -143,7 +152,7 @@ public class AuthenticationImportUserTest {
 				new RemoteIdentityID("prov", "id"),
 				new RemoteIdentityDetails("user", "full", "email")),
 				new NullPointerException("userName"));
-		failImportUser(auth, new UserName("foo"), null,
+		failImportUser(auth, new NewUserName("foo"), null,
 				new NullPointerException("remoteIdentity"));
 	}
 	
@@ -158,15 +167,15 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), REMOTE_ID);
+		auth.importUser(new NewUserName("foo"), REMOTE_ID);
 		
 		doThrow(new UserExistsException("foo")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
+				NewUser.getBuilder(new NewUserName("foo"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());
 		
-		failImportUser(auth, new UserName("foo"), REMOTE_ID, new UserExistsException("foo"));
+		failImportUser(auth, new NewUserName("foo"), REMOTE_ID, new UserExistsException("foo"));
 	}
 	
 	@Test
@@ -180,15 +189,15 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo"), REMOTE_ID);
+		auth.importUser(new NewUserName("foo"), REMOTE_ID);
 		
 		doThrow(new IdentityLinkedException("linked")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo2"), UID, new DisplayName("full"),
+				NewUser.getBuilder(new NewUserName("foo2"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());
 		
-		failImportUser(auth, new UserName("foo2"), REMOTE_ID,
+		failImportUser(auth, new NewUserName("foo2"), REMOTE_ID,
 				new IdentityLinkedException("linked"));
 	}
 	
@@ -203,21 +212,21 @@ public class AuthenticationImportUserTest {
 		
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.importUser(new UserName("foo2"), REMOTE_ID);
+		auth.importUser(new NewUserName("foo2"), REMOTE_ID);
 		
 		doThrow(new NoSuchRoleException("foo")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("foo"), UID, new DisplayName("full"),
+				NewUser.getBuilder(new NewUserName("foo"), UID, new DisplayName("full"),
 						Instant.ofEpochMilli(10000), REMOTE_ID)
 						.withEmailAddress(new EmailAddress("e@g.com"))
 						.build());
 		
-		failImportUser(auth, new UserName("foo"), REMOTE_ID,
+		failImportUser(auth, new NewUserName("foo"), REMOTE_ID,
 				new RuntimeException("didn't supply any roles"));
 	}
 
 	private void failImportUser(
 			final Authentication auth,
-			final UserName userName,
+			final NewUserName userName,
 			final RemoteIdentity remoteIdentity,
 			final Exception e) {
 		try {

--- a/src/test/java/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/AuthenticationLoginTest.java
@@ -43,6 +43,7 @@ import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
 import us.kbase.auth2.lib.LoginState;
 import us.kbase.auth2.lib.LoginToken;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.OAuth2StartData;
 import us.kbase.auth2.lib.PolicyID;
 import us.kbase.auth2.lib.Role;
@@ -1408,12 +1409,12 @@ public class AuthenticationLoginTest {
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
-				new UserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
+				new NewUserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
 				set(new PolicyID("pid1"), new PolicyID("pid2")),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), false);
 
 		verify(storage).createUser(NewUser.getBuilder(
-				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
+				new NewUserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com"))
@@ -1423,17 +1424,17 @@ public class AuthenticationLoginTest {
 		verify(storage, never()).link(any(), any());
 		
 		verify(storage).storeToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 14 * 24 * 3600 * 1000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
 				"hQ9Z3p0WaYunsmIBRUcJgBn5Pd4BCYhOEQCE3enFOzA=");
 		
-		verify(storage).setLastLogin(new UserName("foo"), Instant.ofEpochMilli(30000));
+		verify(storage).setLastLogin(new NewUserName("foo"), Instant.ofEpochMilli(30000));
 		verify(storage).deleteTemporarySessionData(token.getHashedToken());
 		
 		assertThat("incorrect new token", nt, is(new NewToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 14 * 24 * 3600 * 1000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
@@ -1478,12 +1479,12 @@ public class AuthenticationLoginTest {
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
-				new UserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
+				new NewUserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
 				set(new PolicyID("pid1"), new PolicyID("pid2")),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), true);
 
 		verify(storage).createUser(NewUser.getBuilder(
-				new UserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
+				new NewUserName("foo"), UID, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com"))
@@ -1493,17 +1494,17 @@ public class AuthenticationLoginTest {
 		verify(storage, never()).link(any(), any());
 		
 		verify(storage).storeToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 100000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
 				"hQ9Z3p0WaYunsmIBRUcJgBn5Pd4BCYhOEQCE3enFOzA=");
 		
-		verify(storage).setLastLogin(new UserName("foo"), Instant.ofEpochMilli(30000));
+		verify(storage).setLastLogin(new NewUserName("foo"), Instant.ofEpochMilli(30000));
 		verify(storage).deleteTemporarySessionData(token.getHashedToken());
 		
 		assertThat("incorrect new token", nt, is(new NewToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 100000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
@@ -1575,16 +1576,16 @@ public class AuthenticationLoginTest {
 		
 		//the identity was linked after identity filtering. Code should just ignore this.
 		when(storage.link(
-				new UserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id3"),
+				new NewUserName("foo"), new RemoteIdentity(new RemoteIdentityID("prov", "id3"),
 				new RemoteIdentityDetails("user3", "full3", "d@g.com"))))
 				.thenThrow(new IdentityLinkedException("foo"));
 		
-		when(storage.link(new UserName("foo"), new RemoteIdentity(
+		when(storage.link(new NewUserName("foo"), new RemoteIdentity(
 				new RemoteIdentityID("prov", "id2"),
 				new RemoteIdentityDetails("user2", "full2", "e@g.com"))))
 		.thenReturn(true);
 		
-		when(storage.link(new UserName("foo"), new RemoteIdentity(
+		when(storage.link(new NewUserName("foo"), new RemoteIdentity(
 				new RemoteIdentityID("prov", "id4"),
 				new RemoteIdentityDetails("user4", "full4", "c@g.com"))))
 		.thenReturn(true);
@@ -1595,36 +1596,36 @@ public class AuthenticationLoginTest {
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		final NewToken nt = auth.createUser(token, "ef0518c79af70ed979907969c6d0a0f7",
-				new UserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
+				new NewUserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
 				Collections.emptySet(),
 				TokenCreationContext.getBuilder().withNullableDevice("d").build(), true);
 
 		verify(storage).createUser(NewUser.getBuilder(
-				new UserName("foo"), UID2, new DisplayName("bar"), Instant.ofEpochMilli(10000),
+				new NewUserName("foo"), UID2, new DisplayName("bar"), Instant.ofEpochMilli(10000),
 				new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 						new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 				.withEmailAddress(new EmailAddress("f@h.com")).build());
 		
-		verify(storage, never()).link(new UserName("foo"), new RemoteIdentity(
+		verify(storage, never()).link(new NewUserName("foo"), new RemoteIdentity(
 				new RemoteIdentityID("prov", "id1"),
 				new RemoteIdentityDetails("user1", "full1", "f@h.com")));
 		
-		verify(storage, never()).link(new UserName("foo"), new RemoteIdentity(
+		verify(storage, never()).link(new NewUserName("foo"), new RemoteIdentity(
 				new RemoteIdentityID("prov", "id5"),
 				new RemoteIdentityDetails("user5", "full5", "b@g.com")));
 
 		verify(storage).storeToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 14 * 24 * 3600 * 1000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
 				"hQ9Z3p0WaYunsmIBRUcJgBn5Pd4BCYhOEQCE3enFOzA=");
 		
-		verify(storage).setLastLogin(new UserName("foo"), Instant.ofEpochMilli(30000));
+		verify(storage).setLastLogin(new NewUserName("foo"), Instant.ofEpochMilli(30000));
 		verify(storage).deleteTemporarySessionData(token.getHashedToken());
 		
 		assertThat("incorrect new token", nt, is(new NewToken(StoredToken.getBuilder(
-				TokenType.LOGIN, tokenID, new UserName("foo"))
+				TokenType.LOGIN, tokenID, new NewUserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(20000), 14 * 24 * 3600 * 1000)
 				.withContext(TokenCreationContext.getBuilder().withNullableDevice("d").build())
 				.build(),
@@ -1659,7 +1660,7 @@ public class AuthenticationLoginTest {
 						.login(set(REMOTE)));
 		
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1687,7 +1688,7 @@ public class AuthenticationLoginTest {
 		
 		final IncomingToken t = new IncomingToken("foo");
 		final String id = "bar";
-		final UserName u = UserName.ROOT;
+		final NewUserName u = NewUserName.ROOT;
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1712,7 +1713,7 @@ public class AuthenticationLoginTest {
 		
 		final IncomingToken t = new IncomingToken("foo");
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1741,7 +1742,7 @@ public class AuthenticationLoginTest {
 				.thenThrow(new NoSuchTokenException("foo"));
 		
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1772,7 +1773,7 @@ public class AuthenticationLoginTest {
 				.thenReturn(null);
 		
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1803,7 +1804,7 @@ public class AuthenticationLoginTest {
 				.thenReturn(null);
 		
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1835,7 +1836,7 @@ public class AuthenticationLoginTest {
 				.thenReturn(null);
 		
 		final String id = "bar";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1872,7 +1873,7 @@ public class AuthenticationLoginTest {
 				.thenReturn(null);
 		
 		final String id = "bar"; //yep, that won't match
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1909,14 +1910,14 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new UserExistsException("baz")).when(storage).createUser(
-				NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
+				NewUser.getBuilder(new NewUserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 						.withEmailAddress(new EmailAddress("e@g.com")).build());
 		
 		final String id = "ef0518c79af70ed979907969c6d0a0f7";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1952,14 +1953,14 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new IdentityLinkedException("ef0518c79af70ed979907969c6d0a0f7")).when(storage)
-				.createUser(NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
+				.createUser(NewUser.getBuilder(new NewUserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 						.withEmailAddress(new EmailAddress("e@g.com")).build());
 		
 		final String id = "ef0518c79af70ed979907969c6d0a0f7";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -1995,14 +1996,14 @@ public class AuthenticationLoginTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000L)).thenReturn(null);
 		
 		doThrow(new NoSuchRoleException("foobar")).when(storage)
-				.createUser(NewUser.getBuilder(new UserName("baz"), UID, new DisplayName("bat"),
+				.createUser(NewUser.getBuilder(new NewUserName("baz"), UID, new DisplayName("bat"),
 						Instant.ofEpochMilli(10000),
 						new RemoteIdentity(new RemoteIdentityID("prov", "id1"),
 								new RemoteIdentityDetails("user1", "full1", "f@h.com")))
 						.withEmailAddress(new EmailAddress("e@g.com")).build());
 		
 		final String id = "ef0518c79af70ed979907969c6d0a0f7";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -2048,11 +2049,11 @@ public class AuthenticationLoginTest {
 				.thenReturn(Optional.empty());
 		
 		doThrow(new NoSuchUserException("baz")).when(storage).link(
-				new UserName("baz"), new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
+				new NewUserName("baz"), new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 						new RemoteIdentityDetails("user2", "full2", "e@g.com")));
 		
 		final String id = "ef0518c79af70ed979907969c6d0a0f7";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -2099,11 +2100,11 @@ public class AuthenticationLoginTest {
 				.thenReturn(Optional.empty());
 		
 		doThrow(new LinkFailedException("local")).when(storage).link(
-				new UserName("baz"), new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
+				new NewUserName("baz"), new RemoteIdentity(new RemoteIdentityID("prov", "id2"),
 						new RemoteIdentityDetails("user2", "full2", "e@g.com")));
 		
 		final String id = "ef0518c79af70ed979907969c6d0a0f7";
-		final UserName u = new UserName("baz");
+		final NewUserName u = new NewUserName("baz");
 		final DisplayName d = new DisplayName("bat");
 		final EmailAddress e = new EmailAddress("e@g.com");
 		final Set<PolicyID> pids = Collections.emptySet();
@@ -2145,10 +2146,10 @@ public class AuthenticationLoginTest {
 		when(rand.getToken()).thenReturn("mfingtoken");
 		
 		doThrow(new NoSuchUserException("foo")).when(storage).setLastLogin(
-				new UserName("foo"), Instant.ofEpochMilli(30000));
+				new NewUserName("foo"), Instant.ofEpochMilli(30000));
 		
 		failCreateUser(auth, token, "ef0518c79af70ed979907969c6d0a0f7",
-				new UserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
+				new NewUserName("foo"), new DisplayName("bar"), new EmailAddress("f@h.com"),
 				Collections.emptySet(), CTX, false, new AuthStorageException(
 						"Something is very broken. User should exist but doesn't: " +
 						"50000 No such user: foo"));
@@ -2158,7 +2159,7 @@ public class AuthenticationLoginTest {
 			final Authentication auth,
 			final IncomingToken token,
 			final String identityID,
-			final UserName userName,
+			final NewUserName userName,
 			final DisplayName displayName,
 			final EmailAddress email,
 			final Set<PolicyID> pids,

--- a/src/test/java/us/kbase/test/auth2/lib/AuthenticationTestModeUserTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/AuthenticationTestModeUserTest.java
@@ -24,6 +24,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.ViewableUser;
 import us.kbase.auth2.lib.exceptions.ErrorType;
@@ -82,9 +83,9 @@ public class AuthenticationTestModeUserTest {
 		when(testauth.randGenMock.randomUUID()).thenReturn(UID, (UUID) null);
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		
-		auth.testModeCreateUser(new UserName("foo"), new DisplayName("whee"));
+		auth.testModeCreateUser(new NewUserName("foo"), new DisplayName("whee"));
 		
-		verify(storage).testModeCreateUser(new UserName("foo"), UID, new DisplayName("whee"),
+		verify(storage).testModeCreateUser(new NewUserName("foo"), UID, new DisplayName("whee"),
 				Instant.ofEpochMilli(10000), Instant.ofEpochMilli(3610000));
 		
 		assertLogEventsCorrect(logEvents, new LogEvent(Level.INFO, "Created test mode user foo",
@@ -96,12 +97,12 @@ public class AuthenticationTestModeUserTest {
 		final TestMocks testauth = initTestMocks(true);
 		final Authentication auth = testauth.auth;
 		
-		final UserName u = new UserName("foo");
+		final NewUserName u = new NewUserName("foo");
 		final DisplayName d = new DisplayName("bar");
 		
 		failCreateUser(auth, null, d, new NullPointerException("userName"));
 		failCreateUser(auth, u, null, new NullPointerException("displayName"));
-		failCreateUser(auth, UserName.ROOT, d,
+		failCreateUser(auth, NewUserName.ROOT, d,
 				new UnauthorizedException("Cannot create root user"));
 	}
 	
@@ -112,7 +113,7 @@ public class AuthenticationTestModeUserTest {
 		final AuthStorage storage = testauth.storageMock;
 		final Clock clock = testauth.clockMock;
 		
-		final UserName u = new UserName("foo");
+		final NewUserName u = new NewUserName("foo");
 		final DisplayName d = new DisplayName("bar");
 		
 		when(testauth.randGenMock.randomUUID()).thenReturn(UID, (UUID) null);
@@ -126,13 +127,13 @@ public class AuthenticationTestModeUserTest {
 	
 	@Test
 	public void createUserFailNoTestMode() throws Exception {
-		failCreateUser(initTestMocks(false).auth, new UserName("u"), new DisplayName("d"),
+		failCreateUser(initTestMocks(false).auth, new NewUserName("u"), new DisplayName("d"),
 				new TestModeException(ErrorType.UNSUPPORTED_OP, "Test mode is not enabled"));
 	}
 	
 	private void failCreateUser(
 			final Authentication auth,
-			final UserName userName,
+			final NewUserName userName,
 			final DisplayName displayName,
 			final Exception expected) {
 		try {

--- a/src/test/java/us/kbase/test/auth2/lib/UserNameTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/UserNameTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.util.Optional;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
@@ -24,22 +25,32 @@ public class UserNameTest {
 		assertThat("incorrect username", un.getName(), is("***ROOT***"));
 		assertThat("incorrect is root", un.isRoot(), is(true));
 		assertThat("incorrect toString", un.toString(), is("UserName [getName()=***ROOT***]"));
-		assertThat("incorrect hashCode" , un.hashCode(), is(-280622915));
 		
 		final UserName un2 = UserName.ROOT;
 		assertThat("incorrect username", un2.getName(), is("***ROOT***"));
 		assertThat("incorrect is root", un2.isRoot(), is(true));
 		assertThat("incorrect toString", un2.toString(), is("UserName [getName()=***ROOT***]"));
-		assertThat("incorrect hashCode" , un2.hashCode(), is(-280622915));
+		
+		final NewUserName nun = NewUserName.ROOT;
+		assertThat("incorrect username", nun.getName(), is("***ROOT***"));
+		assertThat("incorrect is root", nun.isRoot(), is(true));
+		assertThat("incorrect toString", nun.toString(), is("NewUserName [getName()=***ROOT***]"));
 	}
 	
 	@Test
 	public void construct() throws Exception {
-		final UserName un = new UserName("a8nba9");
-		assertThat("incorrect username", un.getName(), is("a8nba9"));
+		final UserName un = new UserName("a8___nba9__");
+		assertThat("incorrect username", un.getName(), is("a8___nba9__"));
 		assertThat("incorrect is root", un.isRoot(), is(false));
-		assertThat("incorrect toString", un.toString(), is("UserName [getName()=a8nba9]"));
-		assertThat("incorrect hashCode" , un.hashCode(), is(-1462848190));
+		assertThat("incorrect toString", un.toString(), is("UserName [getName()=a8___nba9__]"));
+	}
+	
+	@Test
+	public void constructNewUser() throws Exception {
+		final NewUserName un = new NewUserName("a8_nba9");
+		assertThat("incorrect username", un.getName(), is("a8_nba9"));
+		assertThat("incorrect is root", un.isRoot(), is(false));
+		assertThat("incorrect toString", un.toString(), is("NewUserName [getName()=a8_nba9]"));
 	}
 	
 	@Test
@@ -58,12 +69,35 @@ public class UserNameTest {
 				ErrorType.ILLEGAL_PARAMETER,
 				"user name size greater than limit 100"));
 	}
+	
+	@Test
+	public void constructFailNewUser() throws Exception {
+		failConstructNewUser(null, new MissingParameterException("user name"));
+		failConstructNewUser("   \t \n    ", new MissingParameterException("user name"));
+		failConstructNewUser(
+				"xaa__baea", new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME,
+				"New usernames cannot contain repeating underscores or trailing underscores")
+		);
+		failConstructNewUser("xaabaea_", new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME,
+				"New usernames cannot contain repeating underscores or trailing underscores"));
+	}
 
 	private void failConstruct(
 			final String name,
 			final Exception exception) {
 		try {
 			new UserName(name);
+			fail("constructed bad name");
+		} catch (Exception e) {
+			TestCommon.assertExceptionCorrect(e, exception);
+		}
+	}
+	
+	private void failConstructNewUser(
+			final String name,
+			final Exception exception) {
+		try {
+			new NewUserName(name);
 			fail("constructed bad name");
 		} catch (Exception e) {
 			TestCommon.assertExceptionCorrect(e, exception);
@@ -101,6 +135,7 @@ public class UserNameTest {
 	@Test
 	public void equals() throws Exception {
 		EqualsVerifier.forClass(UserName.class).usingGetClass().verify();
+		EqualsVerifier.forClass(NewUserName.class).usingGetClass().verify();
 	}
 	
 	@Test

--- a/src/test/java/us/kbase/test/auth2/service/ServiceTestUtils.java
+++ b/src/test/java/us/kbase/test/auth2/service/ServiceTestUtils.java
@@ -46,6 +46,7 @@ import de.danielbechler.diff.path.NodePath;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.DisplayName;
 import us.kbase.auth2.lib.EmailAddress;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.Password;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.TokenCreationContext;
@@ -83,7 +84,7 @@ public class ServiceTestUtils {
 				new Password(rootpwd.toCharArray()),
 				TokenCreationContext.getBuilder().build()).getToken().get().getToken();
 		final Password admintemppwd = auth.createLocalUser(
-				new IncomingToken(roottoken), new UserName("admin"), new DisplayName("a"),
+				new IncomingToken(roottoken), new NewUserName("admin"), new DisplayName("a"),
 				new EmailAddress("f@h.com"));
 		auth.updateRoles(new IncomingToken(roottoken), new UserName("admin"),
 				set(Role.CREATE_ADMIN), set());

--- a/src/test/java/us/kbase/test/auth2/service/api/TestModeTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/api/TestModeTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import us.kbase.auth2.lib.Authentication;
 import us.kbase.auth2.lib.CustomRole;
 import us.kbase.auth2.lib.DisplayName;
+import us.kbase.auth2.lib.NewUserName;
 import us.kbase.auth2.lib.Role;
 import us.kbase.auth2.lib.UserName;
 import us.kbase.auth2.lib.ViewableUser;
@@ -85,7 +86,7 @@ public class TestModeTest {
 		final Authentication auth = mock(Authentication.class);
 		final TestMode tm = new TestMode(auth);
 		
-		when(auth.testModeGetUser(new UserName("foobar"))).thenReturn(AuthUser.getBuilder(
+		when(auth.testModeGetUser(new NewUserName("foobar"))).thenReturn(AuthUser.getBuilder(
 				new UserName("foobar"), UID, new DisplayName("foo bar"), inst(10000))
 				.build());
 		
@@ -107,7 +108,7 @@ public class TestModeTest {
 		
 		assertThat("incorrect user", au, is(expected));
 		
-		verify(auth).testModeCreateUser(new UserName("foobar"), new DisplayName("foo bar"));
+		verify(auth).testModeCreateUser(new NewUserName("foobar"), new DisplayName("foo bar"));
 	}
 	
 	@Test
@@ -132,7 +133,7 @@ public class TestModeTest {
 		
 		doThrow(new UnauthorizedException("Cannot create root user"))
 				.when(auth).testModeCreateUser(
-						new UserName("***ROOT***"), new DisplayName("root baby"));
+						new NewUserName("***ROOT***"), new DisplayName("root baby"));
 		
 		final TestMode tm = new TestMode(auth);
 		final CreateTestUser ctu = new CreateTestUser("***ROOT***", "root baby");
@@ -146,12 +147,26 @@ public class TestModeTest {
 		
 		final TestMode tm = new TestMode(auth);
 		
-		when(auth.testModeGetUser(new UserName("foobar")))
+		when(auth.testModeGetUser(new NewUserName("foobar")))
 				.thenThrow(new NoSuchUserException("foobar"));
 		
 		final CreateTestUser ctu = new CreateTestUser("foobar", "foo bar");
 		failCreateUser(tm, ctu, new RuntimeException(
 				"Neat, user creation is totally busted: 50000 No such user: foobar"));
+	}
+	
+	@Test
+	public void createUserFailUnderscores() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		
+		final TestMode tm = new TestMode(auth);
+		final String err = "New usernames cannot contain repeating underscores or trailing "
+				+ "underscores";
+		
+		final CreateTestUser ctu = new CreateTestUser("foo__bar", "foo bar");
+		failCreateUser(tm, ctu, new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err));
+		final CreateTestUser ctu2 = new CreateTestUser("foobar__", "foo bar");
+		failCreateUser(tm, ctu2, new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err));
 	}
 	
 	private void failCreateUser(

--- a/src/test/java/us/kbase/test/auth2/service/ui/AdminTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/ui/AdminTest.java
@@ -41,6 +41,7 @@ import us.kbase.auth2.lib.config.AuthConfig.TokenLifetimeType;
 import us.kbase.auth2.lib.config.AuthConfigSetWithUpdateTime;
 import us.kbase.auth2.lib.config.AuthConfigUpdate;
 import us.kbase.auth2.lib.config.ConfigAction.State;
+import us.kbase.auth2.lib.exceptions.ErrorType;
 import us.kbase.auth2.lib.exceptions.ExternalConfigMappingException;
 import us.kbase.auth2.lib.exceptions.IllegalParameterException;
 import us.kbase.auth2.lib.exceptions.InvalidTokenException;
@@ -72,7 +73,55 @@ public class AdminTest {
 	 *  - but keep the integration tests as simple as possible. On the order of 1 happy path,
 	 *  1 unhappy path per method. Also need to test mustache templates
 	 */
+	
+	// TODO TEST need to add unit tests for happy path createLocalUser (and a lot of other stuff)
+	@Test
+	public void createLocalUserFailUnderscores() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
+		final HttpHeaders headers = mock(HttpHeaders.class);
+		
+		final Admin admin = new Admin(auth, cfg);
+		
+		when(headers.getCookies()).thenReturn(
+				ImmutableMap.of("kbcookie", new Cookie("kbcookie", "token")));
+		
+		final String err = "New usernames cannot contain repeating underscores or trailing "
+				+ "underscores";
+		failCreateLocalUser(
+				admin,
+				headers,
+				"under__score",
+				"foo",
+				"foo@example.com",
+				new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err)
+		);
+		failCreateLocalUser(
+				admin,
+				headers,
+				"underscore_",
+				"foo",
+				"foo@example.com",
+				new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err)
+		);
+	}
 
+	private void failCreateLocalUser(
+			final Admin admin,
+			final HttpHeaders headers,
+			final String userName,
+			final String displayName,
+			final String email,
+			final Exception expected
+			) throws Exception {
+		try {
+			admin.createLocalAccountComplete(headers, userName, displayName, email);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+		
 	@Test
 	public void getConfigMinimal() throws Exception {
 		final Authentication auth = mock(Authentication.class);

--- a/src/test/java/us/kbase/test/auth2/service/ui/LoginTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/ui/LoginTest.java
@@ -1,0 +1,140 @@
+package us.kbase.test.auth2.service.ui;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.junit.Assert.fail;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+
+import us.kbase.auth2.lib.Authentication;
+import us.kbase.auth2.lib.TokenCreationContext;
+import us.kbase.auth2.lib.config.ConfigItem;
+import us.kbase.auth2.lib.exceptions.ErrorType;
+import us.kbase.auth2.lib.exceptions.IllegalParameterException;
+import us.kbase.auth2.service.AuthAPIStaticConfig;
+import us.kbase.auth2.service.AuthExternalConfig;
+import us.kbase.auth2.service.UserAgentParser;
+import us.kbase.auth2.service.AuthExternalConfig.URLSet;
+import us.kbase.auth2.service.ui.Login;
+import us.kbase.testutils.TestCommon;
+
+public class LoginTest {
+
+	// these are unit tests, not integration tests.
+	
+	// TODO TEST finish unit tests
+	
+	// TODO TEST need to add unit tests for happy path createUser (and a lot of other stuff)
+	@Test
+	public void createUserFailUnderscores() throws Exception {
+		final Authentication auth = mock(Authentication.class);
+		final AuthAPIStaticConfig cfg = new AuthAPIStaticConfig("kbcookie", "fake");
+		final HttpServletRequest hsr = mock(HttpServletRequest.class);
+		final UserAgentParser uap = mock(UserAgentParser.class);  // looong startup
+		
+		when(hsr.getHeader("user-agent")).thenReturn("foo");
+		when(uap.getTokenContextFromUserAgent("foo")).thenReturn(
+				TokenCreationContext.getBuilder()
+		);
+		when(auth.getExternalConfig(isA(AuthExternalConfig.AuthExternalConfigMapper.class)))
+			.thenReturn(AuthExternalConfig.getBuilder(
+					new URLSet<>(
+							ConfigItem.emptyState(),
+							ConfigItem.emptyState(),
+							ConfigItem.emptyState(),
+							ConfigItem.emptyState()),
+					ConfigItem.state(true),  // ignore ip headers
+					ConfigItem.state(false))
+					.build());
+		when(hsr.getRemoteAddr()).thenReturn("");  // causes system to ignore IP
+		
+		final Login login = new Login(auth, cfg, uap);
+		
+		final String err = "New usernames cannot contain repeating underscores or trailing "
+				+ "underscores";
+		
+		createLocalUserFail(
+				login,
+				hsr,
+				"tok",
+				null,
+				null,
+				null,
+				"ident",
+				"foo__bar",
+				"display",
+				"foo@example.com",
+				new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err)
+		);
+		createLocalUserFail(
+				login,
+				hsr,
+				"tok",
+				null,
+				null,
+				null,
+				"ident",
+				"foobar_",
+				"display",
+				"foo@example.com",
+				new IllegalParameterException(ErrorType.ILLEGAL_USER_NAME, err)
+		);
+	}
+	
+	private void createLocalUserFail(
+			final Login login,
+			final HttpServletRequest req,
+			final String token,
+			final String redirect,
+			final String session,
+			final String environment,
+			final String identityID,
+			final String userName,
+			final String displayName,
+			final String email,
+			final Exception expected
+			) throws Exception {
+		try {
+			login.createUser(  // form based
+					req,
+					token,
+					redirect,
+					session,
+					environment,
+					identityID,
+					userName,
+					displayName,
+					email,
+					null,
+					null,
+					null
+			);
+			fail("expected exception");
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+		try {
+			login.createUser(  // json based
+					req,
+					token,
+					redirect,
+					environment,
+					new Login.CreateChoice(
+							identityID,
+							userName,
+							displayName,
+							email,
+							null,
+							null,
+							false
+					)
+			);
+		} catch (Exception got) {
+			TestCommon.assertExceptionCorrect(got, expected);
+		}
+	}
+
+}


### PR DESCRIPTION
Current users should be unaffected.

< 1% of KBase users have these features in their usernames.

Makes it easier to integrate with other systems that have stringent character requirements where we want to insert a username into a field, as now a double underscore can be used to separate the username from the rest of the field.