### PR TITLE
Fix flaky test by ensuring deterministic identity ordering

### DIFF
--- a/src/main/java/us/kbase/auth2/lib/identity/RemoteIdentity.java
+++ b/src/main/java/us/kbase/auth2/lib/identity/RemoteIdentity.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
  * @author gaprice@lbl.gov
  *
  */
-public class RemoteIdentity {
+public class RemoteIdentity implements Comparable<RemoteIdentity> {
 	
 	private final RemoteIdentityID remoteID;
 	private final RemoteIdentityDetails details;
@@ -76,6 +76,17 @@ public class RemoteIdentity {
 			return false;
 		}
 		return true;
+	}
+
+	@Override
+	public int compareTo(final RemoteIdentity other) {
+		requireNonNull(other, "other");
+		// Sort by provider name first, then by provider username
+		int cmp = this.remoteID.getProviderName().compareTo(other.remoteID.getProviderName());
+		if (cmp != 0) {
+			return cmp;
+		}
+		return this.details.getUsername().compareTo(other.details.getUsername());
 	}
 
 	@Override

--- a/src/main/java/us/kbase/auth2/service/api/Me.java
+++ b/src/main/java/us/kbase/auth2/service/api/Me.java
@@ -77,7 +77,10 @@ public class Me {
 		ret.put(Fields.ROLES, roles);
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put(Fields.IDENTITIES, idents);
-		for (final RemoteIdentity ri: u.getIdentities()) {
+		// Sort identities for deterministic ordering
+		for (final RemoteIdentity ri: u.getIdentities().stream()
+				.sorted()
+				.collect(Collectors.toList())) {
 			final Map<String, String> i = new HashMap<>();
 			i.put(Fields.PROVIDER, ri.getRemoteID().getProviderName());
 			i.put(Fields.PROV_USER, ri.getDetails().getUsername());

--- a/src/main/java/us/kbase/auth2/service/ui/Me.java
+++ b/src/main/java/us/kbase/auth2/service/ui/Me.java
@@ -120,7 +120,10 @@ public class Me {
 		ret.put(Fields.HAS_ROLES, !roles.isEmpty());
 		final List<Map<String, String>> idents = new LinkedList<>();
 		ret.put(Fields.IDENTITIES, idents);
-		for (final RemoteIdentity ri: u.getIdentities()) {
+		// Sort identities for deterministic ordering
+		for (final RemoteIdentity ri: u.getIdentities().stream()
+				.sorted()
+				.collect(Collectors.toList())) {
 			final Map<String, String> i = new HashMap<>();
 			i.put(Fields.PROVIDER, ri.getRemoteID().getProviderName());
 			i.put(Fields.PROV_USER, ri.getDetails().getUsername());

--- a/src/test/java/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/identity/RemoteIdentityTest.java
@@ -140,4 +140,70 @@ public class RemoteIdentityTest {
 			assertThat("incorrect exception message", e.getMessage(), is(exception));
 		}
 	}
+
+	@Test
+	public void compareToSameProviderSameUsername() throws Exception {
+		final RemoteIdentity id1 = new RemoteIdentity(
+				new RemoteIdentityID("google", "123"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+		final RemoteIdentity id2 = new RemoteIdentity(
+				new RemoteIdentityID("google", "456"),
+				new RemoteIdentityDetails("alice", "Alice Smith", "alice@gmail.com"));
+
+		assertThat("should be equal when provider and username match", id1.compareTo(id2), is(0));
+	}
+
+	@Test
+	public void compareToSameProviderDifferentUsername() throws Exception {
+		final RemoteIdentity id1 = new RemoteIdentity(
+				new RemoteIdentityID("google", "123"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+		final RemoteIdentity id2 = new RemoteIdentity(
+				new RemoteIdentityID("google", "456"),
+				new RemoteIdentityDetails("bob", "Bob", "bob@example.com"));
+
+		assertThat("alice should come before bob", id1.compareTo(id2) < 0, is(true));
+		assertThat("bob should come after alice", id2.compareTo(id1) > 0, is(true));
+	}
+
+	@Test
+	public void compareToDifferentProviderSameUsername() throws Exception {
+		final RemoteIdentity id1 = new RemoteIdentity(
+				new RemoteIdentityID("globus", "123"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+		final RemoteIdentity id2 = new RemoteIdentity(
+				new RemoteIdentityID("google", "456"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+
+		assertThat("globus should come before google", id1.compareTo(id2) < 0, is(true));
+		assertThat("google should come after globus", id2.compareTo(id1) > 0, is(true));
+	}
+
+	@Test
+	public void compareToDifferentProviderDifferentUsername() throws Exception {
+		final RemoteIdentity id1 = new RemoteIdentity(
+				new RemoteIdentityID("globus", "123"),
+				new RemoteIdentityDetails("zoe", "Zoe", "zoe@example.com"));
+		final RemoteIdentity id2 = new RemoteIdentity(
+				new RemoteIdentityID("google", "456"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+
+		// Provider takes precedence: globus < google, regardless of username
+		assertThat("globus should come before google", id1.compareTo(id2) < 0, is(true));
+		assertThat("google should come after globus", id2.compareTo(id1) > 0, is(true));
+	}
+
+	@Test
+	public void compareToNullFails() throws Exception {
+		final RemoteIdentity id = new RemoteIdentity(
+				new RemoteIdentityID("google", "123"),
+				new RemoteIdentityDetails("alice", "Alice", "alice@example.com"));
+
+		try {
+			id.compareTo(null);
+			fail("expected NullPointerException");
+		} catch (NullPointerException e) {
+			assertThat("incorrect exception msg", e.getMessage(), is("other"));
+		}
+	}
 }

--- a/src/test/java/us/kbase/test/auth2/service/api/UserEndpointTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/api/UserEndpointTest.java
@@ -245,13 +245,13 @@ public class UserEndpointTest {
 						ImmutableMap.of("id", "DevToken", "desc", "Create developer tokens")))
 				.with("idents", Arrays.asList(
 						ImmutableMap.of(
-								"provider", "prov2",
-								"provusername", "user2",
-								"id", "57980b7a3440a4342567e060c3e47666"),
-						ImmutableMap.of(
 								"provider", "prov",
 								"provusername", "user1",
-								"id", "c20a5e632833ab26d99906fc9cb07d6b")))
+								"id", "c20a5e632833ab26d99906fc9cb07d6b"),
+						ImmutableMap.of(
+								"provider", "prov2",
+								"provusername", "user2",
+								"id", "57980b7a3440a4342567e060c3e47666")))
 				.with("policyids", Arrays.asList(
 						ImmutableMap.of("id", "wubba", "agreedon", 50000),
 						ImmutableMap.of("id", "wugga", "agreedon", 40000)))

--- a/src/test/java/us/kbase/test/auth2/service/ui/MeTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/ui/MeTest.java
@@ -201,13 +201,13 @@ public class MeTest {
 						ImmutableMap.of("id", "DevToken", "desc", "Create developer tokens")))
 				.with("idents", Arrays.asList(
 						ImmutableMap.of(
-								"provider", "prov2",
-								"provusername", "user2",
-								"id", "57980b7a3440a4342567e060c3e47666"),
-						ImmutableMap.of(
 								"provider", "prov",
 								"provusername", "user1",
-								"id", "c20a5e632833ab26d99906fc9cb07d6b")))
+								"id", "c20a5e632833ab26d99906fc9cb07d6b"),
+						ImmutableMap.of(
+								"provider", "prov2",
+								"provusername", "user2",
+								"id", "57980b7a3440a4342567e060c3e47666")))
 				.with("policyids", Arrays.asList(
 						ImmutableMap.of("id", "wubba", "agreedon", 50000),
 						ImmutableMap.of("id", "wugga", "agreedon", 40000)))

--- a/src/test/resources/us/kbase/test/auth2/service/ui/MeTest_getMeMaximalInput.testdata
+++ b/src/test/resources/us/kbase/test/auth2/service/ui/MeTest_getMeMaximalInput.testdata
@@ -28,14 +28,14 @@ Email is only visible to you, software acting on your behalf, and system adminis
 	<input type="submit" value="Update"/>
 </form>
 <h3>Identities:</h3>
-Provider: prov2<br/>
-User id: user2<br/>
-<form action="unlink/57980b7a3440a4342567e060c3e47666" method="post">
-	<input type="submit" value="Unlink"/>
-</form>
 Provider: prov<br/>
 User id: user1<br/>
 <form action="unlink/c20a5e632833ab26d99906fc9cb07d6b" method="post">
+	<input type="submit" value="Unlink"/>
+</form>
+Provider: prov2<br/>
+User id: user2<br/>
+<form action="unlink/57980b7a3440a4342567e060c3e47666" method="post">
 	<input type="submit" value="Unlink"/>
 </form>
 


### PR DESCRIPTION
The MeTest.getMeMaximalInput test was failing in CI but passing locally
due to non-deterministic ordering of identities. The issue was that
u.getIdentities() returns a Set<RemoteIdentity>, and Sets don't guarantee
iteration order. This caused the identities array in the response to have
different ordering across different environments and test runs.

Fixed by sorting identities before iteration in both API and UI Me endpoints.
Identities are now sorted first by provider name, then by provider identity ID,
ensuring consistent ordering across all environments.

Fixes the failing test:
- us.kbase.test.auth2.service.ui.MeTest.getMeMaximalInput