### PR TITLE
CDM-243: Allow specifying the MFA status for test mode tokens

### DIFF
--- a/src/main/java/us/kbase/auth2/lib/Authentication.java
+++ b/src/main/java/us/kbase/auth2/lib/Authentication.java
@@ -2043,16 +2043,19 @@ public class Authentication {
 	public NewToken testModeCreateToken(
 			final UserName userName,
 			final TokenName tokenName,
-			final TokenType tokenType)
+			final TokenType tokenType,
+			final MFAStatus mfa)
 			throws TestModeException, AuthStorageException, NoSuchUserException {
 		ensureTestMode();
 		requireNonNull(userName, "userName");
 		requireNonNull(tokenType, "tokenType");
+		requireNonNull(mfa, "mfa");
 		storage.testModeGetUser(userName); // ensure user exists
 		final UUID id = randGen.randomUUID();
 		final NewToken nt = new NewToken(StoredToken.getBuilder(tokenType, id, userName)
 				.withLifeTime(clock.instant(), TEST_MODE_DATA_LIFETIME_MS)
 				.withNullableTokenName(tokenName)
+				.withMFA(mfa)
 				.build(),
 				randGen.getToken());
 		storage.testModeStoreToken(nt.getStoredToken(), nt.getTokenHash());

--- a/src/main/java/us/kbase/auth2/service/api/TestMode.java
+++ b/src/main/java/us/kbase/auth2/service/api/TestMode.java
@@ -50,6 +50,7 @@ import us.kbase.auth2.lib.exceptions.TestModeException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.exceptions.UserExistsException;
 import us.kbase.auth2.lib.storage.exceptions.AuthStorageException;
+import us.kbase.auth2.lib.token.MFAStatus;
 import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.lib.token.TokenName;
 import us.kbase.auth2.lib.token.TokenType;
@@ -119,22 +120,6 @@ public class TestMode {
 		return Me.toUserMap(auth.testModeGetUser(new UserName(userName)));
 	}
 	
-	public static class CreateTestToken extends IncomingJSON {
-		public final String userName;
-		public final String tokenName;
-		public final String tokenType;
-
-		@JsonCreator
-		public CreateTestToken(
-				@JsonProperty(Fields.USER) final String userName,
-				@JsonProperty(Fields.TOKEN_NAME) final String tokenName,
-				@JsonProperty(Fields.TOKEN_TYPE) final String tokenType) {
-			this.userName = userName;
-			this.tokenName = tokenName;
-			this.tokenType = tokenType;
-		}
-	}
-	
 	@GET
 	@Path(APIPaths.TESTMODE_USER_DISPLAY)
 	@Produces(MediaType.APPLICATION_JSON)
@@ -150,6 +135,26 @@ public class TestMode {
 				Collectors.toMap(e -> e.getKey().getName(), e -> e.getValue().getName()));
 	}
 	
+	public static class CreateTestToken extends IncomingJSON {
+		public final String userName;
+		public final String tokenName;
+		public final String tokenType;
+		public final String mfa;
+
+		@JsonCreator
+		public CreateTestToken(
+				@JsonProperty(Fields.USER) final String userName,
+				@JsonProperty(Fields.TOKEN_NAME) final String tokenName,
+				@JsonProperty(Fields.TOKEN_TYPE) final String tokenType,
+				@JsonProperty(Fields.TOKEN_MFA) final String mfa
+		) {
+			this.userName = userName;
+			this.tokenName = tokenName;
+			this.tokenType = tokenType;
+			this.mfa = mfa;
+		}
+	}
+	
 	@POST
 	@Path(APIPaths.TESTMODE_TOKEN_CREATE)
 	@Consumes(MediaType.APPLICATION_JSON)
@@ -161,10 +166,24 @@ public class TestMode {
 			throw new MissingParameterException("JSON body missing");
 		}
 		create.exceptOnAdditionalProperties();
+		final MFAStatus mfa;
+		if (create.mfa == null || create.mfa.trim().isEmpty()) {
+			mfa = MFAStatus.UNKNOWN;
+		} else {
+			try {
+				// TODO CODE this should really be from description, but they're identical
+				//           currently so we just use fromID
+				mfa = MFAStatus.fromID(create.mfa.trim());
+			} catch (IllegalArgumentException e) {
+				throw new IllegalParameterException("Unknown MFA state: " + create.mfa);
+			}
+		}
 		return new NewAPIToken(auth.testModeCreateToken(
-				new UserName(create.userName),
-				create.tokenName == null ? null : new TokenName(create.tokenName),
-				getTokenType(create.tokenType)),
+					new UserName(create.userName),
+					create.tokenName == null ? null : new TokenName(create.tokenName),
+					getTokenType(create.tokenType),
+					mfa
+				),
 				auth.getSuggestedTokenCacheTime());
 	}
 

--- a/src/main/java/us/kbase/auth2/service/common/Fields.java
+++ b/src/main/java/us/kbase/auth2/service/common/Fields.java
@@ -174,6 +174,8 @@ public class Fields {
 	public static final String TOKEN_NAME = "name";
 	/** The type of a token. */
 	public static final String TOKEN_TYPE = "type";
+	/** The mfa status of a token. */
+	public static final String TOKEN_MFA = "mfa";
 	/** Whether the user can create developer tokens. */
 	public static final String TOKEN_DEV = "dev";
 	/** Whether the user can create service tokens. */

--- a/src/test/java/us/kbase/test/auth2/lib/AuthenticationTestModeTokenTest.java
+++ b/src/test/java/us/kbase/test/auth2/lib/AuthenticationTestModeTokenTest.java
@@ -30,6 +30,7 @@ import us.kbase.auth2.lib.exceptions.NoSuchUserException;
 import us.kbase.auth2.lib.exceptions.TestModeException;
 import us.kbase.auth2.lib.storage.AuthStorage;
 import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.MFAStatus;
 import us.kbase.auth2.lib.token.NewToken;
 import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.lib.token.TokenName;
@@ -71,17 +72,21 @@ public class AuthenticationTestModeTokenTest {
 		when(clock.instant()).thenReturn(Instant.ofEpochMilli(10000));
 		when(rand.getToken()).thenReturn("whee");
 		
-		final NewToken nt = auth.testModeCreateToken(new UserName("foo"), null, TokenType.AGENT);
+		final NewToken nt = auth.testModeCreateToken(
+				new UserName("foo"), null, TokenType.AGENT, MFAStatus.USED
+		);
 		
 		assertThat("incorrect token", nt, is(new NewToken(StoredToken.getBuilder(
 				TokenType.AGENT, id, new UserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(3610000))
+				.withMFA(MFAStatus.USED)
 				.build(),
 				"whee")));
 		
 		verify(storage).testModeStoreToken(StoredToken.getBuilder(
 				TokenType.AGENT, id, new UserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(3610000))
+				.withMFA(MFAStatus.USED)
 				.build(),
 				IncomingToken.hash("whee"));
 		
@@ -107,12 +112,13 @@ public class AuthenticationTestModeTokenTest {
 		when(rand.getToken()).thenReturn("whee");
 		
 		final NewToken nt = auth.testModeCreateToken(
-				new UserName("foo"), new TokenName("tok"), TokenType.SERV);
+				new UserName("foo"), new TokenName("tok"), TokenType.SERV, MFAStatus.NOT_USED);
 		
 		assertThat("incorrect token", nt, is(new NewToken(StoredToken.getBuilder(
 				TokenType.SERV, id, new UserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(3610000))
 				.withTokenName(new TokenName("tok"))
+				.withMFA(MFAStatus.NOT_USED)
 				.build(),
 				"whee")));
 		
@@ -120,6 +126,7 @@ public class AuthenticationTestModeTokenTest {
 				TokenType.SERV, id, new UserName("foo"))
 				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(3610000))
 				.withTokenName(new TokenName("tok"))
+				.withMFA(MFAStatus.NOT_USED)
 				.build(),
 				IncomingToken.hash("whee"));
 		
@@ -131,14 +138,19 @@ public class AuthenticationTestModeTokenTest {
 	@Test
 	public void createTokenFailNulls() throws Exception {
 		final Authentication auth = initTestMocks(true).auth;
-		failCreateToken(auth, null, TokenType.DEV, new NullPointerException("userName"));
-		failCreateToken(auth, new UserName("u"), null, new NullPointerException("tokenType"));
+		final TokenType tt = TokenType.DEV;
+		final MFAStatus m = MFAStatus.NOT_USED;
+		failCreateToken(auth, null, tt, m, new NullPointerException("userName"));
+		failCreateToken(auth, new UserName("u"), null, m, new NullPointerException("tokenType"));
+		failCreateToken(auth, new UserName("u"), tt, null, new NullPointerException("mfa"));
 	}
 	
 	@Test
 	public void createTokenFailNoTestMode() throws Exception {
-		failCreateToken(initTestMocks(false).auth, new UserName("u"), TokenType.DEV,
-				new TestModeException(ErrorType.UNSUPPORTED_OP, "Test mode is not enabled"));
+		failCreateToken(
+				initTestMocks(false).auth, new UserName("u"), TokenType.DEV, MFAStatus.UNKNOWN,
+				new TestModeException(ErrorType.UNSUPPORTED_OP, "Test mode is not enabled")
+		);
 	}
 	
 	@Test
@@ -150,7 +162,7 @@ public class AuthenticationTestModeTokenTest {
 		when(storage.testModeGetUser(new UserName("foo")))
 				.thenThrow(new NoSuchUserException("foo"));
 		
-		failCreateToken(auth, new UserName("foo"), TokenType.AGENT,
+		failCreateToken(auth, new UserName("foo"), TokenType.AGENT, MFAStatus.UNKNOWN,
 				new NoSuchUserException("foo"));
 	}
 	
@@ -158,9 +170,10 @@ public class AuthenticationTestModeTokenTest {
 			final Authentication auth,
 			final UserName userName,
 			final TokenType tokenType,
+			final MFAStatus mfa,
 			final Exception expected) {
 		try {
-			auth.testModeCreateToken(userName, null, tokenType);
+			auth.testModeCreateToken(userName, null, tokenType, mfa);
 			fail("expected exception");
 		} catch (Exception got) {
 			TestCommon.assertExceptionCorrect(got, expected);

--- a/src/test/java/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/api/TestModeIntegrationTest.java
@@ -190,7 +190,7 @@ public class TestModeIntegrationTest {
 				ImmutableMap.of("user", "whee", "display", "whoo")));
 		assertThat("user create failed", ures.getStatus(), is(200));
 		
-		final Map<String, Object> response = createToken("whee", "Login", "foo");
+		final Map<String, Object> response = createToken("whee", "Login", "foo", "Used");
 		
 		final long created = (long) response.get("created");
 		response.remove("created");
@@ -240,19 +240,30 @@ public class TestModeIntegrationTest {
 		final Map<String, Object> response2 = res2.readEntity(Map.class);
 		return response2;
 	}
-	
 
 	private Map<String, Object> createToken(
 			final String user,
 			final String type,
 			final String name) {
+		return createToken(user, type, name, null);
+	}
+	
+	private Map<String, Object> createToken(
+			final String user,
+			final String type,
+			final String name,
+			final String mfa) {
 		final URI target = UriBuilder.fromUri(host).path("/testmode/api/V2/testmodeonly/token/")
 				.build();
 		final WebTarget wt = CLI.target(target);
 		final Builder req = wt.request();
+		final Map<String, String> json = new HashMap<>();
+		json.put("user", user);
+		json.put("type", type);
+		json.put("name", name);
+		json.put("mfa", mfa);
 		
-		final Response res = req.post(Entity.json(
-				ImmutableMap.of("user", user, "type", type, "name", name)));
+		final Response res = req.post(Entity.json(json));
 		
 		assertThat("incorrect response code", res.getStatus(), is(200));
 		

--- a/src/test/java/us/kbase/test/auth2/service/api/TestModeTest.java
+++ b/src/test/java/us/kbase/test/auth2/service/api/TestModeTest.java
@@ -46,6 +46,7 @@ import us.kbase.auth2.lib.exceptions.NoTokenProvidedException;
 import us.kbase.auth2.lib.exceptions.TestModeException;
 import us.kbase.auth2.lib.exceptions.UnauthorizedException;
 import us.kbase.auth2.lib.token.IncomingToken;
+import us.kbase.auth2.lib.token.MFAStatus;
 import us.kbase.auth2.lib.token.NewToken;
 import us.kbase.auth2.lib.token.StoredToken;
 import us.kbase.auth2.lib.token.TokenName;
@@ -314,24 +315,30 @@ public class TestModeTest {
 		
 		final UUID uuid = UUID.randomUUID();
 		
-		when(auth.testModeCreateToken(new UserName("foo"), null, TokenType.DEV))
+		when(auth.testModeCreateToken(new UserName("foo"), null, TokenType.DEV, MFAStatus.UNKNOWN))
 				.thenReturn(new NewToken(StoredToken.getBuilder(
 						TokenType.DEV, uuid, new UserName("foo"))
 						.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+						.withMFA(MFAStatus.UNKNOWN)
 						.build(),
 						"a token"));
 		
 		when(auth.getSuggestedTokenCacheTime()).thenReturn(30000L);
 		
-		final NewAPIToken token = tm.createTestToken(new CreateTestToken("foo", null, "Dev"));
-		
-		final NewAPIToken expected = new NewAPIToken(new NewToken(StoredToken.getBuilder(
-				TokenType.DEV, uuid, new UserName("foo"))
-				.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
-				.build(),
-				"a token"), 30000L);
-		
-		assertThat("incorrect token", token, is(expected));
+		for (final String mfa: Arrays.asList(null, "", "   \t   ")) {
+			final NewAPIToken token = tm.createTestToken(
+					new CreateTestToken("foo", null, "Dev", mfa
+			));
+			
+			final NewAPIToken expected = new NewAPIToken(new NewToken(StoredToken.getBuilder(
+					TokenType.DEV, uuid, new UserName("foo"))
+					.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
+					.withMFA(MFAStatus.USED)
+					.build(),
+					"a token"), 30000L);
+			
+			assertThat("incorrect token", token, is(expected));
+		}
 	}
 	
 	@Test
@@ -341,17 +348,20 @@ public class TestModeTest {
 		
 		final UUID uuid = UUID.randomUUID();
 		
-		when(auth.testModeCreateToken(new UserName("foo"), new TokenName("whee"), TokenType.AGENT))
+		when(auth.testModeCreateToken(
+				new UserName("foo"), new TokenName("whee"), TokenType.AGENT, MFAStatus.USED))
 				.thenReturn(new NewToken(StoredToken.getBuilder(
 						TokenType.AGENT, uuid, new UserName("foo"))
 						.withLifeTime(Instant.ofEpochMilli(10000), Instant.ofEpochMilli(20000))
 						.withTokenName(new TokenName("whee"))
+						.withMFA(MFAStatus.USED)
 						.build(),
 						"a token"));
 		
 		when(auth.getSuggestedTokenCacheTime()).thenReturn(30000L);
 		
-		final NewAPIToken token = tm.createTestToken(new CreateTestToken("foo", "whee", "Agent"));
+		final NewAPIToken token = tm.createTestToken(
+				new CreateTestToken("foo", "whee", "Agent", "  Used  \t  "));
 		
 		final NewAPIToken expected = new NewAPIToken(new NewToken(StoredToken.getBuilder(
 				TokenType.AGENT, uuid, new UserName("foo"))
@@ -373,11 +383,11 @@ public class TestModeTest {
 	public void createTokenFailNulls() {
 		final TestMode tm = new TestMode(mock(Authentication.class));
 		
-		failCreateToken(tm, new CreateTestToken(null, "foo", "Dev"),
+		failCreateToken(tm, new CreateTestToken(null, "foo", "Dev", null),
 				new MissingParameterException("user name"));
-		failCreateToken(tm, new CreateTestToken("foo", "  \t  \n ", "Dev"),
+		failCreateToken(tm, new CreateTestToken("foo", "  \t  \n ", "Dev", null),
 				new MissingParameterException("token name"));
-		failCreateToken(tm, new CreateTestToken("whee", "foo", null),
+		failCreateToken(tm, new CreateTestToken("whee", "foo", null, null),
 				new IllegalParameterException("Invalid token type: null"));
 	}
 	
@@ -385,14 +395,22 @@ public class TestModeTest {
 	public void createTokenFailBadTokenType() {
 		final TestMode tm = new TestMode(mock(Authentication.class));
 		
-		failCreateToken(tm, new CreateTestToken("whee", "foo", "Devv"),
+		failCreateToken(tm, new CreateTestToken("whee", "foo", "Devv", null),
 				new IllegalParameterException("Invalid token type: Devv"));
+	}
+	
+	@Test
+	public void createTokenFailBadMFAType() {
+		final TestMode tm = new TestMode(mock(Authentication.class));
+		
+		failCreateToken(tm, new CreateTestToken("whee", "foo", "Dev", "SlightlyUsed"),
+				new IllegalParameterException("Unknown MFA state: SlightlyUsed"));
 	}
 	
 	@Test
 	public void createTokenFailAddlProps() {
 		final TestMode tm = new TestMode(mock(Authentication.class));
-		final CreateTestToken create = new CreateTestToken("foo", "bar", "baz");
+		final CreateTestToken create = new CreateTestToken("foo", "bar", "baz", null);
 		create.setAdditionalProperties("whee", "whoo");
 		failCreateToken(tm, create, new IllegalParameterException(
 				"Unexpected parameters in request: whee"));


### PR DESCRIPTION
Currently the tests other than the Authentication unit tests can't see the MFA status because it's not yet in the ExternalToken. Once that happends there will be changes all over so I'll do that later.